### PR TITLE
Add verbose flag to CLI and functions

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -17,6 +17,11 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     parser.add_argument(
         "--window", required=True, help="Candle window, e.g. 1m or 1h"
     )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Enable debug output",
+    )
     return parser.parse_args(argv)
 
 
@@ -26,11 +31,12 @@ def main(argv: list[str] | None = None) -> None:
     mode = args.mode.lower()
     tag = args.tag
     window = args.window
+    verbose = args.verbose
 
     if mode == "sim":
-        run_simulation(tag=tag, window=window)
+        run_simulation(tag=tag, window=window, verbose=verbose)
     elif mode == "live":
-        run_live(tag=tag, window=window)
+        run_live(tag=tag, window=window, verbose=verbose)
     else:
         print("Error: --mode must be either 'sim' or 'live'", file=sys.stderr)
         sys.exit(1)

--- a/systems/live_engine.py
+++ b/systems/live_engine.py
@@ -21,8 +21,9 @@ def esc_listener(should_exit_flag):
                 break
 
 
-def run_live(tag: str, window: str) -> None:
-    tqdm.write(f"[LIVE] Running live mode for {tag} on window {window}")
+def run_live(tag: str, window: str, verbose: bool = False) -> None:
+    if verbose:
+        tqdm.write(f"[LIVE] Running live mode for {tag} on window {window}")
     should_exit = []
 
     if msvcrt:
@@ -45,9 +46,11 @@ def run_live(tag: str, window: str) -> None:
         ) as pbar:
             for _ in range(remaining_secs):
                 if should_exit:
-                    tqdm.write("\n🚪 ESC detected — exiting live mode.")
+                    if verbose:
+                        tqdm.write("\n🚪 ESC detected — exiting live mode.")
                     return
                 time.sleep(1)
                 pbar.update(1)
 
-        tqdm.write("\n🕐 Top of hour reached! Restarting countdown...\n")
+        if verbose:
+            tqdm.write("\n🕐 Top of hour reached! Restarting countdown...\n")

--- a/systems/scripts/evaluate_buy.py
+++ b/systems/scripts/evaluate_buy.py
@@ -1,4 +1,4 @@
-def evaluate_buy(candle: dict, window_data: dict) -> bool:
+def evaluate_buy(candle: dict, window_data: dict, verbose: bool = False) -> bool:
     """
     Debug stub for buy logic.
     Prints tunnel and window position.
@@ -7,7 +7,10 @@ def evaluate_buy(candle: dict, window_data: dict) -> bool:
     tunnel_pos = window_data.get("tunnel_position")
     window_pos = window_data.get("window_position")
     
-    print(f"[EVAL BUY] tunnel_position={tunnel_pos:.4f} | window_position={window_pos:.4f}")
+    if verbose:
+        print(
+            f"[EVAL BUY] tunnel_position={tunnel_pos:.4f} | window_position={window_pos:.4f}"
+        )
     
     # TODO: plug in actual knife/whale/fish logic
     return False

--- a/systems/scripts/get_candle_data.py
+++ b/systems/scripts/get_candle_data.py
@@ -8,7 +8,7 @@ from typing import Dict, Any
 from systems.utils.path import find_project_root
 
 
-def get_candle_data(tag: str, row_offset: int = 0) -> Dict[str, Any]:
+def get_candle_data(tag: str, row_offset: int = 0, verbose: bool = False) -> Dict[str, Any]:
     """Return the most recent candle for ``tag`` from the raw CSV data.
 
     Parameters
@@ -32,6 +32,9 @@ def get_candle_data(tag: str, row_offset: int = 0) -> Dict[str, Any]:
     IndexError
         If the requested row does not exist in the file.
     """
+
+    if verbose:
+        print(f"[get_candle_data] tag={tag} row_offset={row_offset}")
 
     root = find_project_root()
     path: Path = root / "data" / "raw" / f"{tag.upper()}.csv"
@@ -63,7 +66,7 @@ def get_candle_data(tag: str, row_offset: int = 0) -> Dict[str, Any]:
                 )
             row = last_rows[-(1 + row_offset)]
 
-    return {
+    result = {
         "timestamp": int(row["timestamp"]),
         "open": float(row["open"]),
         "high": float(row["high"]),
@@ -71,3 +74,8 @@ def get_candle_data(tag: str, row_offset: int = 0) -> Dict[str, Any]:
         "close": float(row["close"]),
         "volume": float(row["volume"]),
     }
+
+    if verbose:
+        print(f"[get_candle_data] result={result}")
+
+    return result

--- a/systems/scripts/get_window_data.py
+++ b/systems/scripts/get_window_data.py
@@ -5,18 +5,25 @@ from systems.utils.path import find_project_root
 from systems.utils.time import parse_cutoff
 
 
-def get_window_data(tag: str, window: str, candle_offset: int = 0) -> dict | None:
+def get_window_data(tag: str, window: str, candle_offset: int = 0, verbose: bool = False) -> dict | None:
+    if verbose:
+        print(
+            f"[get_window_data] tag={tag} window={window} candle_offset={candle_offset}"
+        )
+
     root = find_project_root()
     path = root / "data" / "raw" / f"{tag.upper()}.csv"
 
     try:
         df = pd.read_csv(path)
     except FileNotFoundError:
-        print(f"[ERROR] Data file not found: {path}")
+        if verbose:
+            print(f"[ERROR] Data file not found: {path}")
         return None
 
     if df.empty:
-        print("[WARN] CSV is empty")
+        if verbose:
+            print("[WARN] CSV is empty")
         return None
 
     # Convert window to duration in candles (assume hourly)
@@ -29,7 +36,8 @@ def get_window_data(tag: str, window: str, candle_offset: int = 0) -> dict | Non
     window_df = df.iloc[start_idx:end_idx]
 
     if window_df.empty:
-        print("[WARN] No candle data in computed window slice")
+        if verbose:
+            print("[WARN] No candle data in computed window slice")
         return None
 
     ceiling = window_df["high"].max()
@@ -39,16 +47,22 @@ def get_window_data(tag: str, window: str, candle_offset: int = 0) -> dict | Non
         last_candle = df.iloc[-1 - candle_offset]
         close = last_candle["close"]
     except IndexError:
-        print(f"[ERROR] Not enough candles to read offset {candle_offset}")
+        if verbose:
+            print(f"[ERROR] Not enough candles to read offset {candle_offset}")
         return None
 
     range_val = ceiling - floor
     tunnel_position = (close - floor) / range_val if range_val != 0 else 0.5
     window_position = floor / range_val if range_val != 0 else 0.0
 
-    return {
+    result = {
         "window_ceiling": round(ceiling, 8),
         "window_floor": round(floor, 8),
         "tunnel_position": round(tunnel_position, 4),
         "window_position": round(window_position, 4)
     }
+
+    if verbose:
+        print(f"[get_window_data] result={result}")
+
+    return result

--- a/systems/sim_engine.py
+++ b/systems/sim_engine.py
@@ -37,8 +37,9 @@ def listen_for_keys(tick_delay, should_exit_flag):
                     should_exit_flag.append(True)
 
 
-def run_simulation(tag: str, window: str) -> None:
-    tqdm.write(f"[SIM] Starting simulation for {tag} on window {window}")
+def run_simulation(tag: str, window: str, verbose: bool = False) -> None:
+    if verbose:
+        tqdm.write(f"[SIM] Starting simulation for {tag} on window {window}")
 
     root = find_project_root()
     path = root / "data" / "raw" / f"{tag.upper()}.csv"
@@ -46,7 +47,8 @@ def run_simulation(tag: str, window: str) -> None:
     total_rows = len(df)
 
     if total_rows == 0:
-        tqdm.write("❌ No data in CSV.")
+        if verbose:
+            tqdm.write("❌ No data in CSV.")
         return
 
     tick_delay = [0.15]
@@ -64,17 +66,20 @@ def run_simulation(tag: str, window: str) -> None:
     ) as pbar:
         for step in range(total_rows):
             if should_exit:
-                tqdm.write("\n🚪 ESC detected — exiting simulation early.")
+                if verbose:
+                    tqdm.write("\n🚪 ESC detected — exiting simulation early.")
                 break
 
-            candle = get_candle_data(tag, row_offset=step)
-            window_data = get_window_data(tag, window, candle_offset=step)
+            candle = get_candle_data(tag, row_offset=step, verbose=verbose)
+            window_data = get_window_data(tag, window, candle_offset=step, verbose=verbose)
             if candle and window_data:
-                evaluate_buy(candle, window_data)
+                evaluate_buy(candle, window_data, verbose=verbose)
             else:
-                 tqdm.write(f"[STEP {step+1}] ❌ Incomplete data (candle or window)")
+                if verbose:
+                    tqdm.write(f"[STEP {step+1}] ❌ Incomplete data (candle or window)")
 
             time.sleep(tick_delay[0])
             pbar.update(1)
 
-    tqdm.write("\n✅ Simulation complete.")
+    if verbose:
+        tqdm.write("\n✅ Simulation complete.")


### PR DESCRIPTION
## Summary
- add `--verbose` option for the command line
- pipe verbose option into simulation and live engines
- propagate verbose option into candle/window data utilities and evaluate_buy
- gate debug output behind the verbose flag

## Testing
- `python -m py_compile bot.py systems/sim_engine.py systems/live_engine.py systems/scripts/get_candle_data.py systems/scripts/get_window_data.py systems/scripts/evaluate_buy.py`
- `pip install tqdm` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_688624df830c8326ac8da12a0128b478