### PR TITLE
Support DataFrame and CSV modes

### DIFF
--- a/systems/live_engine.py
+++ b/systems/live_engine.py
@@ -4,6 +4,9 @@ import threading
 from datetime import datetime, timedelta, timezone
 from tqdm import tqdm
 
+from systems.scripts.get_candle_data import get_candle_data_json
+from systems.scripts.get_window_data import get_window_data_json
+
 try:
     import msvcrt  # Windows-only
 except ImportError:
@@ -54,3 +57,8 @@ def run_live(tag: str, window: str, verbose: bool = False) -> None:
 
         if verbose:
             tqdm.write("\n🕐 Top of hour reached! Restarting countdown...\n")
+
+        candle = get_candle_data_json(tag, row_offset=0)
+        window_data = get_window_data_json(tag, window, candle_offset=0)
+        if candle and window_data:
+            pass

--- a/systems/scripts/get_window_data.py
+++ b/systems/scripts/get_window_data.py
@@ -5,6 +5,56 @@ from systems.utils.path import find_project_root
 from systems.utils.time import parse_cutoff
 
 
+def _extract_window_data(df: pd.DataFrame, window: str, candle_offset: int = 0) -> dict | None:
+    if df.empty:
+        return None
+
+    duration = parse_cutoff(window)
+    num_candles = int(duration.total_seconds() // 3600)
+
+    start_idx = max(0, len(df) - candle_offset - num_candles)
+    end_idx = len(df) - candle_offset if candle_offset != 0 else None
+    window_df = df.iloc[start_idx:end_idx]
+
+    if window_df.empty:
+        return None
+
+    ceiling = window_df["high"].max()
+    floor = window_df["low"].min()
+
+    try:
+        last_candle = df.iloc[-1 - candle_offset]
+        close = last_candle["close"]
+    except IndexError:
+        return None
+
+    range_val = ceiling - floor
+    tunnel_position = (close - floor) / range_val if range_val != 0 else 0.5
+    window_position = floor if range_val != 0 else 0.0
+
+    return {
+        "window_ceiling": round(ceiling, 8),
+        "window_floor": round(floor, 8),
+        "tunnel_position": round(tunnel_position, 4),
+        "window_position": round(window_position, 4),
+    }
+
+
+def get_window_data_df(df: pd.DataFrame, window: str, candle_offset: int = 0) -> dict | None:
+    return _extract_window_data(df, window, candle_offset)
+
+
+def get_window_data_json(tag: str, window: str, candle_offset: int = 0) -> dict | None:
+    root = find_project_root()
+    path = root / "data" / "raw" / f"{tag.upper()}.csv"
+    try:
+        df = pd.read_csv(path)
+    except FileNotFoundError:
+        return None
+
+    return _extract_window_data(df, window, candle_offset)
+
+
 def get_window_data(tag: str, window: str, candle_offset: int = 0, verbose: bool = False) -> dict | None:
     if verbose:
         print(

--- a/systems/sim_engine.py
+++ b/systems/sim_engine.py
@@ -7,8 +7,8 @@ import sys
 from systems.utils.path import find_project_root
 sys.path.append(str(find_project_root()))
 
-from systems.scripts.get_candle_data import get_candle_data
-from systems.scripts.get_window_data import get_window_data
+from systems.scripts.get_candle_data import get_candle_data_df
+from systems.scripts.get_window_data import get_window_data_df
 from systems.scripts.evaluate_buy import evaluate_buy
 
 try:
@@ -70,8 +70,8 @@ def run_simulation(tag: str, window: str, verbose: bool = False) -> None:
                     tqdm.write("\n🚪 ESC detected — exiting simulation early.")
                 break
 
-            candle = get_candle_data(tag, row_offset=step, verbose=verbose)
-            window_data = get_window_data(tag, window, candle_offset=step, verbose=verbose)
+            candle = get_candle_data_df(df, row_offset=step)
+            window_data = get_window_data_df(df, window, candle_offset=step)
             if candle and window_data:
                 evaluate_buy(candle, window_data, verbose=verbose)
             else:


### PR DESCRIPTION
## Summary
- add `_extract_candle_row` helper and JSON/DF functions in `get_candle_data`
- add `_extract_window_data` helper and JSON/DF functions in `get_window_data`
- update `sim_engine` to call DataFrame versions
- update `live_engine` to load fresh data each loop

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6886293f485c83269fe1bdcc944f23c1