### PR TITLE
Add strategy logic modules

### DIFF
--- a/systems/scripts/logic/fish_catch.py
+++ b/systems/scripts/logic/fish_catch.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from typing import Optional, List, Dict
+
+
+def should_buy(candle: Dict, window_data: Dict, active_notes: List[Dict], verbose: bool = False) -> Optional[Dict]:
+    """Return buy note if ``tunnel_position`` < 0.6 and no active note."""
+    if not window_data:
+        return None
+    position = window_data.get("tunnel_position", 0)
+    has_note = any(n.get("strategy") == "fish_catch" for n in active_notes)
+
+    if verbose:
+        print(f"[fish_catch] evaluate buy position={position} has_note={has_note}")
+
+    if position < 0.6 and not has_note:
+        note = {
+            "strategy": "fish_catch",
+            "price": candle["close"],
+            "window": window_data.get("window_label"),
+            "entry_tunnel_position": position,
+            "entry_window_position": window_data.get("window_position"),
+            "timestamp": candle["timestamp"],
+        }
+        return note
+    return None
+
+
+def should_sell(note: Dict, candle: Dict, window_data: Dict, verbose: bool = False) -> bool:
+    """Return True if ``tunnel_position`` > 0.9."""
+    if not window_data:
+        return False
+    position = window_data.get("tunnel_position", 0)
+
+    if verbose:
+        print(f"[fish_catch] evaluate sell position={position}")
+
+    return position > 0.9

--- a/systems/scripts/logic/knife_catch.py
+++ b/systems/scripts/logic/knife_catch.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from typing import Optional, List, Dict
+
+
+def should_buy(candle: Dict, window_data: Dict, active_notes: List[Dict], verbose: bool = False) -> Optional[Dict]:
+    """Buy based on falling tunnel position logic."""
+    if not window_data:
+        return None
+    position = window_data.get("tunnel_position", 0)
+    existing = next((n for n in active_notes if n.get("strategy") == "knife_catch"), None)
+
+    if verbose:
+        print(f"[knife_catch] evaluate buy position={position} has_note={existing is not None}")
+
+    if existing is None:
+        if position == 0:
+            return {
+                "strategy": "knife_catch",
+                "price": candle["close"],
+                "window": window_data.get("window_label"),
+                "entry_tunnel_position": position,
+                "entry_window_position": window_data.get("window_position"),
+                "timestamp": candle["timestamp"],
+            }
+        return None
+
+    entry_pos = existing.get("entry_tunnel_position", 0)
+    if position < entry_pos:
+        return {
+            "strategy": "knife_catch",
+            "price": candle["close"],
+            "window": window_data.get("window_label"),
+            "entry_tunnel_position": position,
+            "entry_window_position": window_data.get("window_position"),
+            "timestamp": candle["timestamp"],
+        }
+
+    return None
+
+
+def should_sell(note: Dict, candle: Dict, window_data: Dict, verbose: bool = False) -> bool:
+    """Sell when tunnel and window positions recover."""
+    if not window_data:
+        return False
+    position = window_data.get("tunnel_position", 0)
+    window_pos = window_data.get("window_position", 0)
+
+    if verbose:
+        print(
+            f"[knife_catch] evaluate sell position={position} window_pos={window_pos} entry_window={note.get('entry_window_position')}"
+        )
+
+    return position > 0.9 and window_pos >= note.get("entry_window_position", 0)
+

--- a/systems/scripts/logic/whale_catch.py
+++ b/systems/scripts/logic/whale_catch.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from typing import Optional, List, Dict
+
+
+def should_buy(candle: Dict, window_data: Dict, active_notes: List[Dict], verbose: bool = False) -> Optional[Dict]:
+    """Buy when ``tunnel_position`` < 0.1."""
+    if not window_data:
+        return None
+    position = window_data.get("tunnel_position", 0)
+
+    if verbose:
+        print(f"[whale_catch] evaluate buy position={position}")
+
+    if position < 0.1:
+        note = {
+            "strategy": "whale_catch",
+            "price": candle["close"],
+            "window": window_data.get("window_label"),
+            "entry_tunnel_position": position,
+            "entry_window_position": window_data.get("window_position"),
+            "timestamp": candle["timestamp"],
+        }
+        return note
+    return None
+
+
+def should_sell(note: Dict, candle: Dict, window_data: Dict, verbose: bool = False) -> bool:
+    """Sell when ``tunnel_position`` > 0.9."""
+    if not window_data:
+        return False
+    position = window_data.get("tunnel_position", 0)
+
+    if verbose:
+        print(f"[whale_catch] evaluate sell position={position}")
+
+    return position > 0.9


### PR DESCRIPTION
## Summary
- implement fish, whale, and knife catch strategies
- each exports `should_buy` and `should_sell`

## Testing
- `python -m py_compile systems/scripts/logic/*.py`

------
https://chatgpt.com/codex/tasks/task_e_68862b273b888326bc64552ab2148515