### PR TITLE
Add sell logic to strategies

### DIFF
--- a/systems/decision_logic/fish_catch.py
+++ b/systems/decision_logic/fish_catch.py
@@ -3,3 +3,10 @@ def should_buy_fish(candle, window_data, tick, cooldowns) -> bool:
     if cooldowns["fish_catch"] <= 0 and tunnel_pos is not None and tunnel_pos < 0.6:
         return True
     return False
+
+
+def should_sell_fish(candle, window_data, note) -> bool:
+    tunnel_pos = window_data.get("tunnel_position")
+    if tunnel_pos is not None and tunnel_pos > 0.9:
+        return True
+    return False

--- a/systems/decision_logic/knife_catch.py
+++ b/systems/decision_logic/knife_catch.py
@@ -7,3 +7,14 @@ def should_buy_knife(candle, window_data, tick, cooldowns, last_window_position=
             if last_window_position is None or window_pos < last_window_position:
                 return True
     return False
+
+
+def should_sell_knife(candle, window_data, note) -> bool:
+    tunnel_pos = window_data.get("tunnel_position")
+    window_pos = window_data.get("window_position")
+    saved_window_pos = note.get("window_position_at_entry")
+
+    if tunnel_pos is not None and tunnel_pos > 0.9:
+        if saved_window_pos is not None and window_pos >= saved_window_pos:
+            return True
+    return False

--- a/systems/decision_logic/whale_catch.py
+++ b/systems/decision_logic/whale_catch.py
@@ -3,3 +3,10 @@ def should_buy_whale(candle, window_data, tick, cooldowns) -> bool:
     if cooldowns["whale_catch"] <= 0 and tunnel_pos is not None and tunnel_pos < 0.1:
         return True
     return False
+
+
+def should_sell_whale(candle, window_data, note) -> bool:
+    tunnel_pos = window_data.get("tunnel_position")
+    if tunnel_pos is not None and tunnel_pos > 0.9:
+        return True
+    return False


### PR DESCRIPTION
## Summary
- extend decision strategies with sell checks

## Testing
- `python -m py_compile systems/decision_logic/knife_catch.py systems/decision_logic/fish_catch.py systems/decision_logic/whale_catch.py`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_688654cc188483269622e669a11a2a75