### PR TITLE
Implement evaluate_sell_df and integrate into simulation

### DIFF
--- a/systems/scripts/evaluate_sell.py
+++ b/systems/scripts/evaluate_sell.py
@@ -1,0 +1,23 @@
+from systems.decision_logic.fish_catch import should_sell_fish
+from systems.decision_logic.whale_catch import should_sell_whale
+from systems.decision_logic.knife_catch import should_sell_knife
+
+
+def evaluate_sell_df(
+    candle: dict,
+    window_data: dict,
+    tick: int,
+    notes: list[dict],
+    verbose: bool = False
+) -> list[dict]:
+    """Given current market state and open notes, returns list of notes to be sold."""
+    sell_list = []
+    for note in notes:
+        strategy = note.get("strategy")
+        if strategy == "fish_catch" and should_sell_fish(candle, window_data, note):
+            sell_list.append(note)
+        elif strategy == "whale_catch" and should_sell_whale(candle, window_data, note):
+            sell_list.append(note)
+        elif strategy == "knife_catch" and should_sell_knife(candle, window_data, note):
+            sell_list.append(note)
+    return sell_list

--- a/systems/sim_engine.py
+++ b/systems/sim_engine.py
@@ -6,6 +6,7 @@ from systems.utils.path import find_project_root
 from systems.scripts.get_candle_data import get_candle_data_df
 from systems.scripts.get_window_data import get_window_data_df
 from systems.scripts.evaluate_buy import evaluate_buy_df
+from systems.scripts.evaluate_sell import evaluate_sell_df
 import pandas as pd
 
 def listen_for_keys(should_exit_flag: list) -> None:
@@ -75,6 +76,19 @@ def run_simulation(tag: str, window: str, verbose: bool = False) -> None:
                     verbose=verbose,
                     ledger=ledger  # ✅ Inject ledger
                 )
+
+                to_sell = evaluate_sell_df(
+                    candle=candle,
+                    window_data=window_data,
+                    tick=step,
+                    notes=ledger.get_active_notes(),
+                    verbose=verbose,
+                )
+                for note in to_sell:
+                    ledger.close_note(note)
+                    tqdm.write(
+                        f"[SELL] Tick {step} | Strategy: {note['strategy']} | Gain: {note.get('gain_pct', 0):.2%}"
+                    )
             else:
                 tqdm.write(f"[STEP {step+1}] ❌ Incomplete data (candle or window)")
 


### PR DESCRIPTION
## Summary
- implement `evaluate_sell_df` for closing notes based on strategy
- incorporate sell evaluation into the simulation loop

## Testing
- `python -m py_compile systems/scripts/evaluate_sell.py systems/sim_engine.py`

------
https://chatgpt.com/codex/tasks/task_e_688654fc8c2883268984b70535be1b2a