### PR TITLE
Add strategy trade breakdown summary

### DIFF
--- a/systems/scripts/ledger.py
+++ b/systems/scripts/ledger.py
@@ -119,3 +119,21 @@ class RamLedger(LedgerBase):
         total_gain = sum(float(n.get("gain_pct", 0)) for n in self.closed_notes)
         avg_gain = total_gain / max(len(self.closed_notes), 1)
         return avg_gain / months
+
+    def get_trade_counts_by_strategy(self) -> dict:
+        """Count total and open trades per strategy."""
+        counts = {}
+
+        for note in self.closed_notes + self.open_notes:
+            strategy = note.get("strategy", "unknown")
+            if strategy not in counts:
+                counts[strategy] = {"total": 0, "open": 0}
+            counts[strategy]["total"] += 1
+
+        for note in self.open_notes:
+            strategy = note.get("strategy", "unknown")
+            if strategy not in counts:
+                counts[strategy] = {"total": 0, "open": 0}
+            counts[strategy]["open"] += 1
+
+        return counts

--- a/systems/sim_engine.py
+++ b/systems/sim_engine.py
@@ -145,6 +145,15 @@ def print_simulation_summary(ledger, ticks_run=None, candle_minutes=60) -> None:
     tqdm.write(f"Avg Gain %:     {summary['total_gain_pct']:.2%}")
     tqdm.write(f"Est Balance:    ${summary['estimated_kraken_balance']:.2f}")
 
+    strategy_counts = ledger.get_trade_counts_by_strategy()
+
+    tqdm.write("\n🎣 Strategy Breakdown")
+    for strategy in ["knife_catch", "whale_catch", "fish_catch"]:
+        data = strategy_counts.get(strategy, {"total": 0, "open": 0})
+        total = data["total"]
+        open_count = data["open"]
+        tqdm.write(f"{strategy.replace('_', ' ').title():<15}: {total} trades ({open_count} open)")
+
     if ticks_run:
         gain_per_month = ledger.get_avg_gain_per_month(ticks_run, candle_minutes)
         roi_per_month = ledger.get_roi_per_month(ticks_run, candle_minutes)


### PR DESCRIPTION
## Summary
- add `get_trade_counts_by_strategy` to RamLedger
- show strategy breakdown in `print_simulation_summary`

## Testing
- `python -m py_compile systems/scripts/ledger.py systems/sim_engine.py`
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement pandas)*
- `python bot.py --mode sim --tag DOGEUSD --window 1h` *(fails: No module named 'tqdm')*

------
https://chatgpt.com/codex/tasks/task_e_6886648552ac8326a5a7416af9d7e2b8