### PR TITLE
Propagate tag argument across engines

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,14 +29,14 @@ Decision logic lives under ``systems/decision_logic`` with one module per strate
 Install dependencies (pandas, tqdm, requests) and run ``bot.py`` with arguments:
 
 ```bash
-python bot.py --mode sim --tag DOGEUSD --window 1m --verbose 2
+python bot.py --mode sim --window 1m --verbose 2  # uses default tag DOGEUSD
 python bot.py --mode live --tag SOLUSD --window 3mo --verbose 1
 ```
 
 CLI arguments:
 
 - ``--mode`` – ``sim`` for simulation or ``live`` for live mode.
-- ``--tag`` – trading pair symbol, e.g. ``DOGEUSD``.
+- ``--tag`` – trading pair symbol, e.g. ``DOGEUSD`` (default: ``DOGEUSD``).
 - ``--window`` – time window for tunnel metrics such as ``1m`` or ``3mo``.
 - ``--verbose`` – verbosity level (0=silent, 1=standard, 2=debug).
 

--- a/bot.py
+++ b/bot.py
@@ -13,7 +13,12 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     """Parse command line arguments."""
     parser = argparse.ArgumentParser(description="WindowSurfer bot entrypoint")
     parser.add_argument("--mode", required=True, help="Execution mode: sim or live")
-    parser.add_argument("--tag", required=True, help="Symbol tag, e.g. DOGEUSD")
+    parser.add_argument(
+        "--tag",
+        required=False,
+        default="DOGEUSD",
+        help="Symbol tag, e.g. DOGEUSD (default: DOGEUSD)",
+    )
     parser.add_argument(
         "--window", required=True, help="Candle window, e.g. 1m or 1h"
     )

--- a/systems/live_engine.py
+++ b/systems/live_engine.py
@@ -28,6 +28,10 @@ def run_live(tag: str, window: str, verbose: int = 0, debug: bool = False) -> No
     if verbose >= 1:
         tqdm.write(f"[LIVE] Running live mode for {tag} on window {window}")
 
+    # Resolve exchange symbols for future use
+    from systems.utils.resolve_symbol import resolve_symbol
+    symbols = resolve_symbol(tag)
+
     should_exit = []
 
     if msvcrt:
@@ -103,6 +107,7 @@ def handle_top_of_hour(tag: str, window: str, verbose: int = 0) -> None:
             ledger=ledger,
             cooldowns=cooldowns,
             last_triggered=last_triggered,
+            tag=tag,
             verbose=verbose
         )
 
@@ -117,6 +122,7 @@ def evaluate_live_tick(
     ledger,
     cooldowns: dict,
     last_triggered: dict,
+    tag: str,
     verbose: int = 0
 ) -> None:
     from systems.scripts.evaluate_buy import evaluate_buy_df
@@ -128,6 +134,7 @@ def evaluate_live_tick(
         tick=0,  # No time series index in live mode
         cooldowns=cooldowns,
         last_triggered=last_triggered,
+        tag=tag,
         sim=False,
         verbose=verbose,
         ledger=ledger
@@ -138,6 +145,7 @@ def evaluate_live_tick(
         window_data=window_data,
         tick=0,
         notes=ledger.get_active_notes(),
+        tag=tag,
         verbose=verbose
     )
 

--- a/systems/scripts/evaluate_buy.py
+++ b/systems/scripts/evaluate_buy.py
@@ -38,6 +38,7 @@ def evaluate_buy_df(
     tick: int,
     cooldowns: dict,
     last_triggered: dict,
+    tag: str,
     sim: bool = False,
     verbose: int = 0,
     ledger=None  # <- Inject ledger if in RAM mode
@@ -52,7 +53,7 @@ def evaluate_buy_df(
         _log_initialized["sim"] = True
 
     if verbose >= 2:
-        tqdm.write(f"[EVAL] Evaluating Buy for 🐟🐋🔪")
+        tqdm.write(f"[EVAL] Evaluating Buy for {tag} 🐟🐋🔪")
 
     tunnel_pos = window_data.get("tunnel_position", 0)
     window_pos = window_data.get("window_position", 0)

--- a/systems/scripts/evaluate_sell.py
+++ b/systems/scripts/evaluate_sell.py
@@ -9,13 +9,14 @@ def evaluate_sell_df(
     window_data: dict,
     tick: int,
     notes: list[dict],
+    tag: str,
     verbose: int = 0
 ) -> list[dict]:
     """Given current market state and open notes, returns list of notes to be sold."""
     sell_list = []
 
     if verbose >= 2:
-        tqdm.write(f"[EVAL] Evaluating Sell for 🐟🐋🔪")
+        tqdm.write(f"[EVAL] Evaluating Sell for {tag} 🐟🐋🔪")
 
 
     for note in notes:

--- a/systems/sim_engine.py
+++ b/systems/sim_engine.py
@@ -27,6 +27,10 @@ def run_simulation(tag: str, window: str, verbose: int = 0) -> None:
     if verbose >= 1:
         print(f"[SIM] Running simulation for {tag} on window {window}")
 
+    # Resolve exchange symbols (kraken/binance) for future use
+    from systems.utils.resolve_symbol import resolve_symbol
+    symbols = resolve_symbol(tag)
+
     from systems.scripts.ledger import RamLedger
     ledger = RamLedger()
 
@@ -85,6 +89,7 @@ def run_simulation(tag: str, window: str, verbose: int = 0) -> None:
                     tick=step,
                     cooldowns=cooldowns,
                     last_triggered=last_triggered,
+                    tag=tag,
                     sim=True,
                     verbose=verbose,
                     ledger=ledger  # ✅ Inject ledger
@@ -95,6 +100,7 @@ def run_simulation(tag: str, window: str, verbose: int = 0) -> None:
                     window_data=window_data,
                     tick=step,
                     notes=ledger.get_active_notes(),
+                    tag=tag,
                     verbose=verbose,
                 )
                 


### PR DESCRIPTION
## Summary
- make `--tag` optional with default `DOGEUSD`
- document default tag behavior
- propagate `tag` parameter through simulation and live engines
- prepare for future symbol resolution via `resolve_symbol`
- update evaluate scripts to accept tag input

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68867f1bfbac8326a30d94e1cc504d71