### PR TITLE
Disable telegram in sim engine

### DIFF
--- a/systems/sim_engine.py
+++ b/systems/sim_engine.py
@@ -7,7 +7,11 @@ except ImportError:  # pragma: no cover - Windows-only
 import json
 from tqdm import tqdm
 from systems.utils.path import find_project_root
-from systems.utils.logger import addlog
+from systems.utils.logger import (
+    addlog,
+    init_logger,
+    LOGGING_ENABLED,
+)
 from systems.scripts.get_candle_data import get_candle_data_df
 from systems.scripts.get_window_data import get_window_data_df
 from systems.scripts.evaluate_buy import evaluate_buy_df
@@ -31,6 +35,11 @@ def listen_for_keys(should_exit_flag: list) -> None:
                     break
 
 def run_simulation(tag: str, window: str, verbose: int = 0) -> None:
+    init_logger(
+        logging_enabled=LOGGING_ENABLED,
+        verbose_level=verbose,
+        telegram_enabled=False,
+    )
     addlog(
         f"[SIM] Running simulation for {tag} on window {window}",
         verbose_int=1,


### PR DESCRIPTION
## Summary
- ensure telegram alerts are disabled for simulations

## Testing
- `python -m py_compile systems/sim_engine.py systems/utils/logger.py bot.py`


------
https://chatgpt.com/codex/tasks/task_e_6887c801c61083269eb2cae0ec489a3a