### PR TITLE
Fix live_engine settings lookup

### DIFF
--- a/systems/live_engine.py
+++ b/systems/live_engine.py
@@ -8,7 +8,7 @@ from systems.utils.logger import addlog
 from systems.scripts.get_candle_data import get_candle_data_json
 from systems.scripts.get_window_data import get_window_data_json
 from systems.fetch import fetch_missing_candles
-from systems.scripts.loader import load_settings
+from systems.utilities.path import load_settings
 from systems.scripts.execution_handler import get_available_fiat_balance
 
 
@@ -84,10 +84,11 @@ def handle_top_of_hour(tag: str, window: str, verbose: int = 0) -> None:
 
         # Initialize on first run, or eventually pass as arg
         ledger = RamLedger()
+        settings = load_settings()
         cooldowns = {
-            "knife_catch": SETTINGS["general_settings"]["knife_catch_cooldown"],
-            "whale_catch": SETTINGS["general_settings"]["whale_catch_cooldown"],
-            "fish_catch": SETTINGS["general_settings"]["fish_catch_cooldown"]
+            "knife_catch": settings["general_settings"]["knife_catch_cooldown"],
+            "whale_catch": settings["general_settings"]["whale_catch_cooldown"],
+            "fish_catch": settings["general_settings"]["fish_catch_cooldown"]
         }
         last_triggered = {
             "knife_catch": None,

--- a/systems/utilities/path.py
+++ b/systems/utilities/path.py
@@ -1,0 +1,10 @@
+import json
+from systems.utils.path import find_project_root
+
+
+def load_settings():
+    """Load settings.json from the project settings directory."""
+    root = find_project_root()
+    settings_path = root / "settings" / "settings.json"
+    with open(settings_path, "r", encoding="utf-8") as f:
+        return json.load(f)


### PR DESCRIPTION
## Summary
- create `systems.utilities.path.load_settings` helper
- update `live_engine` to fetch settings locally

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887e55d950c8326a60fae5d336b9ed5