### PR TITLE
Enable live order execution when buying

### DIFF
--- a/systems/scripts/evaluate_buy.py
+++ b/systems/scripts/evaluate_buy.py
@@ -140,14 +140,26 @@ def evaluate_buy_df(
             note = create_note("fish_catch")
             if note:
                 if live:
-                    fills = buy_order(kraken_symbol, note["entry_usdt"])
+                    addlog(
+                        f"[EXEC] Live buy triggered for {tag}",
+                        verbose_int=1,
+                        verbose_state=verbose,
+                    )
+                    fills = buy_order(tag, note["entry_amount"], verbose=verbose)
+
                     note["entry_price"] = fills["price"]
                     note["entry_amount"] = fills["volume"]
                     note["entry_usdt"] = fills["cost"]
                     note["fee"] = fills["fee"]
                     note["entry_ts"] = fills["timestamp"]
                     note["kraken_txid"] = fills["kraken_txid"]
-                ledger.add_note(note)
+                else:
+                    note["entry_price"] = candle["close"]
+                    note["entry_amount"] = note["entry_usdt"] / candle["close"]
+                    note["entry_ts"] = candle.get("ts", 0)
+
+                note["status"] = "Open"
+                ledger.open_note(note)
                 if on_buy:
                     on_buy(note)
                 triggered = True
@@ -161,14 +173,26 @@ def evaluate_buy_df(
             note = create_note("whale_catch")
             if note:
                 if live:
-                    fills = buy_order(kraken_symbol, note["entry_usdt"])
+                    addlog(
+                        f"[EXEC] Live buy triggered for {tag}",
+                        verbose_int=1,
+                        verbose_state=verbose,
+                    )
+                    fills = buy_order(tag, note["entry_amount"], verbose=verbose)
+
                     note["entry_price"] = fills["price"]
                     note["entry_amount"] = fills["volume"]
                     note["entry_usdt"] = fills["cost"]
                     note["fee"] = fills["fee"]
                     note["entry_ts"] = fills["timestamp"]
                     note["kraken_txid"] = fills["kraken_txid"]
-                ledger.add_note(note)
+                else:
+                    note["entry_price"] = candle["close"]
+                    note["entry_amount"] = note["entry_usdt"] / candle["close"]
+                    note["entry_ts"] = candle.get("ts", 0)
+
+                note["status"] = "Open"
+                ledger.open_note(note)
                 if on_buy:
                     on_buy(note)
                 triggered = True
@@ -182,14 +206,26 @@ def evaluate_buy_df(
             note = create_note("knife_catch")
             if note:
                 if live:
-                    fills = buy_order(kraken_symbol, note["entry_usdt"])
+                    addlog(
+                        f"[EXEC] Live buy triggered for {tag}",
+                        verbose_int=1,
+                        verbose_state=verbose,
+                    )
+                    fills = buy_order(tag, note["entry_amount"], verbose=verbose)
+
                     note["entry_price"] = fills["price"]
                     note["entry_amount"] = fills["volume"]
                     note["entry_usdt"] = fills["cost"]
                     note["fee"] = fills["fee"]
                     note["entry_ts"] = fills["timestamp"]
                     note["kraken_txid"] = fills["kraken_txid"]
-                ledger.add_note(note)
+                else:
+                    note["entry_price"] = candle["close"]
+                    note["entry_amount"] = note["entry_usdt"] / candle["close"]
+                    note["entry_ts"] = candle.get("ts", 0)
+
+                note["status"] = "Open"
+                ledger.open_note(note)
                 if on_buy:
                     on_buy(note)
                 triggered = True

--- a/systems/scripts/ledger.py
+++ b/systems/scripts/ledger.py
@@ -10,6 +10,11 @@ class LedgerBase(ABC):
     """Abstract interface for ledger implementations."""
 
     @abstractmethod
+    def open_note(self, note: Dict) -> None:
+        """Add a new open note to the ledger."""
+        raise NotImplementedError
+
+    @abstractmethod
     def get_active_notes(self) -> List[Dict]:
         """Return a list of currently open notes"""
         raise NotImplementedError
@@ -40,6 +45,11 @@ class RamLedger(LedgerBase):
         if "note_id" not in note:
             note["note_id"] = str(uuid.uuid4())
         self.open_notes.append(note)
+
+    # Maintain backward compatibility with new API
+    def open_note(self, note: Dict) -> None:
+        """Alias for ``add_note`` to open a new note."""
+        self.add_note(note)
 
 
     def close_note(self, note: Dict) -> None:


### PR DESCRIPTION
## Summary
- trigger `buy_order` in evaluate_buy to place live orders
- inject fills into note data and track status
- add `open_note` method to RamLedger for new API

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688802fe06308326b12a4175dd595c89