### PR TITLE
Prioritize sell notes by estimated gain

### DIFF
--- a/systems/scripts/evaluate_sell.py
+++ b/systems/scripts/evaluate_sell.py
@@ -76,5 +76,20 @@ def evaluate_sell_df(
         verbose_state=verbose,
     )
 
+    sell_list.sort(
+        key=lambda note: (
+            note.get("entry_amount", 0) * candle["close"]
+            - note.get("entry_usdt", 0)
+        ),
+        reverse=True,
+    )
+
+    for note in sell_list:
+        projected_gain = note["entry_amount"] * candle["close"] - note["entry_usdt"]
+        addlog(
+            f"[PRIORITY SELL] Strategy: {note['strategy']} | Est Gain: ${projected_gain:.2f}",
+            verbose_int=2,
+            verbose_state=verbose,
+        )
 
     return sell_list


### PR DESCRIPTION
## Summary
- sort sell decisions in `evaluate_sell_df` by potential gain
- log sorted sell order for clarity

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68880a7fbb6883269034761cf8d38673