### PR TITLE
Enable strategy toggling via settings

### DIFF
--- a/settings/settings.json
+++ b/settings/settings.json
@@ -13,4 +13,5 @@
   "simulation_capital": 1000,
   "investment_size": 0.07,
   "minimum_note_size": 50
+  ,"active_strategies": ["fish_catch", "whale_catch", "knife_catch"]
 }

--- a/systems/scripts/evaluate_buy.py
+++ b/systems/scripts/evaluate_buy.py
@@ -140,10 +140,16 @@ def evaluate_buy_df(
         if strategy == "knife_catch":
             note["window_position_at_entry"] = window_pos
 
+
         return note
+
+    active = SETTINGS.get(
+        "active_strategies",
+        ["fish_catch", "whale_catch", "knife_catch"],
+    )
     
     # 🐟 Fish Catch
-    if should_buy_fish(candle, window_data, tick, cooldowns):
+    if "fish_catch" in active and should_buy_fish(candle, window_data, tick, cooldowns):
         cooldowns["fish_catch"] = SETTINGS["general_settings"]["fish_catch_cooldown"]
         last_triggered["fish_catch"] = tick
         note = create_note("fish_catch")
@@ -181,7 +187,7 @@ def evaluate_buy_df(
                 triggered = True
 
     # 🐋 Whale Catch
-    if should_buy_whale(candle, window_data, tick, cooldowns):
+    if "whale_catch" in active and should_buy_whale(candle, window_data, tick, cooldowns):
         cooldowns["whale_catch"] = SETTINGS["general_settings"]["whale_catch_cooldown"]
         last_triggered["whale_catch"] = tick
         note = create_note("whale_catch")
@@ -219,7 +225,7 @@ def evaluate_buy_df(
                 triggered = True
 
     # 🔪 Knife Catch
-    if should_buy_knife(candle, window_data, tick, cooldowns):
+    if "knife_catch" in active and should_buy_knife(candle, window_data, tick, cooldowns):
         cooldowns["knife_catch"] = SETTINGS["general_settings"]["knife_catch_cooldown"]
         last_triggered["knife_catch"] = tick
         note = create_note("knife_catch")


### PR DESCRIPTION
## Summary
- add `active_strategies` array in `settings.json`
- evaluate buy strategies only when enabled in configuration

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68882511eb948326b7710b814e590edc