### PR TITLE
Simplify knife sell logic

### DIFF
--- a/systems/decision_logic/knife_catch.py
+++ b/systems/decision_logic/knife_catch.py
@@ -24,47 +24,24 @@ def should_sell_knife(candle, window_data, note, verbose: int = 0) -> bool:
 
 
 def should_sell_notes(notes: list, candle: dict, settings: dict, verbose: int = 0) -> list:
-    to_sell = []
+    """Return all knife notes if any single note hits the ROI margin."""
 
-    # Loop through knife notes for detailed ROI and price comparison
-    for i, note in enumerate(notes):
-        entry_price = note["entry_usdt"] / note["entry_amount"]
-        roi = (candle["close"] * note["entry_amount"] - note["entry_usdt"]) / note["entry_usdt"]
-        current_price = candle["close"]
+    margin = settings.get("knife_group_roi_margin", 0.30)
+    current_price = candle["close"]
 
+    for note in notes:
+        roi = (current_price * note["entry_amount"] - note["entry_usdt"]) / note["entry_usdt"]
         addlog(
-            f"[KNIFE SELL DEBUG] Note {i} | ROI: {roi:.2%} | Entry @ ${entry_price:.5f} | Now @ ${current_price:.5f} | Target Delta: {settings.get('knife_group_roi_margin', 0.30):.2%}",
-            verbose_int=0,
-            verbose_state=verbose
-        )
-        
-        
-    if len(notes) >= 3:
-        current_price = candle["close"]
-        margin = settings.get("knife_group_roi_margin", 0.30)
-
-        current_roi = lambda n: (current_price * n["entry_amount"] - n["entry_usdt"]) / n["entry_usdt"]
-        highest_knife_roi = max(current_roi(n) for n in notes)
-        trigger_roi = (
-            current_price * sum(n["entry_amount"] for n in notes)
-            - sum(n["entry_usdt"] for n in notes)
-        ) / sum(n["entry_usdt"] for n in notes)
-
-        addlog(
-            f"[KNIFE GROUP] {len(notes)} open | Highest ROI: {highest_knife_roi:.2%} | Trigger ROI: {trigger_roi:.2%} | Margin: {margin:.2%}",
+            f"[KNIFE SELL DEBUG] Note ROI: {roi:.2%} vs Margin: {margin:.2%}",
             verbose_int=2,
             verbose_state=verbose,
         )
-
-        for i, n in enumerate(notes):
-            roi = current_roi(n)
+        if roi >= margin:
             addlog(
-                f"[KNIFE DEBUG] Note {i} ROI: {roi:.2%} (Entry @ {n['entry_usdt']:.4f})",
-                verbose_int=3,
+                "[KNIFE SELL TRIGGER] ✅ Exiting all knives — trigger met",
+                verbose_int=1,
                 verbose_state=verbose,
             )
+            return notes  # Sell ALL knife notes
 
-        if trigger_roi >= highest_knife_roi + margin:
-            to_sell = notes
-
-    return to_sell
+    return []


### PR DESCRIPTION
## Summary
- update knife group exit strategy to sell when any note meets ROI margin

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68882fb04f80832680fbc40276b4572e