### PR TITLE
Add knife note limit

### DIFF
--- a/settings/settings.json
+++ b/settings/settings.json
@@ -15,6 +15,12 @@
   "active_strategies": [ "knife_catch"],
   "minimum_note_size": 20,
 
+  "strategy_limits": {
+    "knife_catch": {
+      "max_open_notes": 3
+    }
+  },
+
   "knife_group_roi_margin": 0.15
 
 }

--- a/systems/decision_logic/knife_catch.py
+++ b/systems/decision_logic/knife_catch.py
@@ -1,9 +1,37 @@
 from systems.utils.logger import addlog
 
-def should_buy_knife(candle, window_data, tick, cooldowns, last_window_position=None) -> bool:
+
+def should_buy_knife(
+    candle,
+    window_data,
+    tick,
+    cooldowns,
+    active_notes,
+    last_window_position=None,
+    settings=None,
+    verbose: int = 0,
+) -> bool:
+    """Determine if a new knife note should be opened."""
+
+    knife_limit = (
+        settings.get("strategy_limits", {})
+        .get("knife_catch", {})
+        .get("max_open_notes", 99)
+        if settings
+        else 99
+    )
+
+    if len(active_notes) >= knife_limit:
+        addlog(
+            f"[KNIFE BLOCKED] Max knife notes reached: {knife_limit}",
+            verbose_int=2,
+            verbose_state=verbose,
+        )
+        return False
+
     tunnel_pos = window_data.get("tunnel_position")
     window_pos = window_data.get("window_position")
-    
+
     if cooldowns["knife_catch"] <= 0:
         if tunnel_pos is not None and abs(tunnel_pos) < 0.01:
             if last_window_position is None or window_pos < last_window_position:


### PR DESCRIPTION
## Summary
- configure knife catch note limits in `settings.json`
- restrict new knife notes in `should_buy_knife`
- track open knife notes in `evaluate_buy.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888321cb8988326b8aa5aef9aa55d10