### PR TITLE
Add reusable balance check for Kraken

### DIFF
--- a/systems/scripts/evaluate_buy.py
+++ b/systems/scripts/evaluate_buy.py
@@ -9,6 +9,7 @@ from systems.decision_logic.knife_catch import should_buy_knife
 from systems.decision_logic.whale_catch import should_buy_whale
 from systems.scripts.ledger import RamLedger
 from systems.scripts.execution_handler import buy_order
+from systems.scripts.kraken_utils import get_kraken_balance
 
 SETTINGS_PATH = Path(find_project_root()) / "settings" / "settings.json"
 with open(SETTINGS_PATH, "r", encoding="utf-8") as f:
@@ -93,6 +94,17 @@ def evaluate_buy_df(
     kraken_symbol = symbols["kraken"]
 
     live = not sim
+
+    if live:
+        kraken_bal = get_kraken_balance(verbose=verbose)
+        usd_balance = kraken_bal.get("ZUSD", 0.0)
+        if usd_balance < MINIMUM_NOTE_SIZE:
+            addlog(
+                f"[SKIP] Not enough capital to trade (${usd_balance:.2f} < ${MINIMUM_NOTE_SIZE:.2f})",
+                verbose_int=1,
+                verbose_state=verbose,
+            )
+            return False
 
     open_notes = ledger.get_active_notes() if ledger else []
     knife_notes = [n for n in open_notes if n.get("strategy") == "knife_catch"]

--- a/systems/scripts/execution_handler.py
+++ b/systems/scripts/execution_handler.py
@@ -8,6 +8,7 @@ from urllib.parse import urlencode
 from systems.scripts.kraken_auth import load_kraken_keys
 from systems.utils.resolve_symbol import resolve_symbol
 from systems.utils.logger import addlog
+from systems.scripts.kraken_utils import get_kraken_balance  # use shared util now
 
 KRAKEN_ORDER_TIMEOUT = 6
 SLIPPAGE_STEPS = [0.0, 0.002, 0.004, 0.007, 0.01]
@@ -36,17 +37,6 @@ def _kraken_request(endpoint: str, data: dict, api_key: str, api_secret: str) ->
     if "error" in result and result["error"]:
         raise Exception(f"Kraken API error: {result['error']}")
     return result
-
-def get_kraken_balance(verbose: int = 0) -> dict:
-    api_key, api_secret = load_kraken_keys()
-    result = _kraken_request("Balance", {}, api_key, api_secret).get("result", {})
-    addlog(
-        f"[INFO] Kraken balance fetched: {result}",
-        verbose_int=2,
-        verbose_state=verbose,
-    )
-    return {k: float(v) for k, v in result.items()}
-
 
 def get_available_fiat_balance(exchange, currency: str = "USD") -> float:
     """Return available fiat balance from a CCXT exchange object."""

--- a/systems/scripts/kraken_utils.py
+++ b/systems/scripts/kraken_utils.py
@@ -5,6 +5,9 @@ import hmac
 import base64
 from urllib.parse import urlencode
 
+from systems.scripts.kraken_auth import load_kraken_keys
+from systems.utils.logger import addlog
+
 KRAKEN_API_URL = "https://api.kraken.com"
 
 def _kraken_request(endpoint: str, data: dict, api_key: str, api_secret: str) -> dict:
@@ -33,3 +36,17 @@ def _kraken_request(endpoint: str, data: dict, api_key: str, api_secret: str) ->
         raise Exception(f"Kraken API error: {result['error']}")
 
     return result
+
+
+def get_kraken_balance(verbose: int = 0) -> dict:
+    # Import here to avoid circular dependency when execution_handler imports this module
+    from systems.scripts.execution_handler import _kraken_request
+
+    api_key, api_secret = load_kraken_keys()
+    result = _kraken_request("Balance", {}, api_key, api_secret).get("result", {})
+    addlog(
+        f"[INFO] Kraken balance fetched: {result}",
+        verbose_int=2,
+        verbose_state=verbose,
+    )
+    return {k: float(v) for k, v in result.items()}


### PR DESCRIPTION
## Summary
- expose `get_kraken_balance` in `kraken_utils` for reuse
- remove old inline balance helper from `execution_handler`
- check live USD balance inside buy evaluation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68883fa0463483268d65d83ad538f5c2