### PR TITLE
Fix verbose CLI handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ Decision logic lives under ``systems/decision_logic`` with one module per strate
 Install dependencies (pandas, tqdm, requests) and run ``bot.py`` with arguments:
 
 ```bash
-python bot.py --mode sim --window 1m --verbose 2  # uses default tag DOGEUSD
+# equivalent ways to control verbosity:
+python bot.py --mode sim --window 1m -vv        # verbose level 2
 python bot.py --mode live --tag SOLUSD --window 3mo --verbose 1 --telegram
 ```
 
@@ -38,7 +39,7 @@ CLI arguments:
 - ``--mode`` – ``sim`` for simulation or ``live`` for live mode.
 - ``--tag`` – trading pair symbol, e.g. ``DOGEUSD`` (default: ``DOGEUSD``).
 - ``--window`` – time window for tunnel metrics such as ``1m`` or ``3mo``.
-- ``--verbose`` – verbosity level (0=silent, 1=standard, 2=debug).
+- ``-v``/``--verbose`` – verbosity level 0–3 (use ``-v``/``-vv``/``-vvv`` or ``--verbose N``).
 - ``--log`` – write all output to ``data/tmp/log.txt``.
 - ``--telegram`` – enable Telegram alerts (requires ``telegram.yaml``).
 

--- a/bot.py
+++ b/bot.py
@@ -16,12 +16,26 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     parser.add_argument("--mode", required=True, help="Execution mode: sim or live")
     parser.add_argument("--tag", required=True, help="Symbol tag, e.g. DOGEUSD")
     parser.add_argument("--window", required=True, help="Candle window, e.g. 1m or 1h")
+    class VerbosityAction(argparse.Action):
+        """Allow ``-v`` flags to stack and ``--verbose`` to accept a level."""
+
+        def __call__(self, parser, namespace, values, option_string=None):
+            level = getattr(namespace, self.dest, 0)
+            if values is None:
+                setattr(namespace, self.dest, level + 1)
+            else:
+                try:
+                    setattr(namespace, self.dest, int(values))
+                except ValueError:
+                    parser.error("--verbose level must be an integer")
+
     parser.add_argument(
         "-v",
         "--verbose",
-        action="count",
+        nargs="?",
+        action=VerbosityAction,
         default=0,
-        help="Increase verbosity level (use -v or -vv)",
+        help="Verbosity level (use -v/-vv or --verbose N)",
     )
     parser.add_argument(
         "--log",

--- a/systems/live_engine.py
+++ b/systems/live_engine.py
@@ -167,8 +167,11 @@ def handle_top_of_hour(
             note_counts=note_counts,
         )
 
-        if verbose == 0:
-            logger.info(report)
+        addlog(
+            report,
+            verbose_int=1,
+            verbose_state=verbose,
+        )
 
     else:
         addlog(


### PR DESCRIPTION
## Summary
- add custom VerbosityAction to support `--verbose N` or `-vv`
- document new verbose usage in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888f1ea65948326b74cbbd2e65efccb