### PR TITLE
Fix ledger loading from old files

### DIFF
--- a/systems/scripts/ledger.py
+++ b/systems/scripts/ledger.py
@@ -169,8 +169,9 @@ class FileLedger(RamLedger):
         try:
             with open(self.path, "r", encoding="utf-8") as f:
                 data = json.load(f)
-            self.open_notes = data.get("open_notes", [])
-            self.closed_notes = data.get("closed_notes", [])
+            # Support legacy key names from older ledgers
+            self.open_notes = data.get("open_notes", data.get("open", []))
+            self.closed_notes = data.get("closed_notes", data.get("closed", []))
             self.pnl = sum(
                 float(n.get("exit_usdt", 0)) - float(n.get("entry_usdt", 0))
                 for n in self.closed_notes


### PR DESCRIPTION
## Summary
- add fallback keys for open/closed notes when loading a FileLedger

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6889280d5d70832689055985b5a954e3