### PR TITLE
Refactor log verbosity levels

### DIFF
--- a/systems/decision_logic/knife_catch.py
+++ b/systems/decision_logic/knife_catch.py
@@ -61,7 +61,7 @@ def should_sell_notes(notes: list, candle: dict, settings: dict, verbose: int = 
 
         addlog(
             f"[KNIFE SELL DEBUG] Note {i} ROI: {roi:.2%} | Entry @ ${note['entry_usdt']:.2f} | Now @ ${current_price:.2f} | Margin: {margin:.2%}",
-            verbose_int=2,
+            verbose_int=3,
             verbose_state=verbose,
         )
 
@@ -79,7 +79,7 @@ def should_sell_notes(notes: list, candle: dict, settings: dict, verbose: int = 
     if trigger_hit:
         addlog(
             "[KNIFE SELL TRIGGER] ✅ ROI met & all notes profitable — selling all",
-            verbose_int=1,
+            verbose_int=2,
             verbose_state=verbose,
         )
         return notes

--- a/systems/live_engine.py
+++ b/systems/live_engine.py
@@ -23,14 +23,14 @@ def ensure_latest_candles(tag: str, lookback: str = "48h", verbose: int = 1) -> 
     try:
         addlog(
             f"[SYNC] Checking for missing candles in last {lookback} for {tag}",
-            verbose_int=1,
+            verbose_int=2,
             verbose_state=verbose,
         )
         fetch_missing_candles(tag, relative_window=lookback, verbose=verbose)
     except Exception as e:
         addlog(
             f"[ERROR] Failed to fetch missing candles: {e}",
-            verbose_int=1,
+            verbose_int=2,
             verbose_state=verbose,
         )
 
@@ -97,7 +97,11 @@ def evaluate_live_tick(
         )
 
 def run_live(tag: str, window: str, verbose: int = 0) -> None:
-    addlog(f"[LIVE] Running live mode for {tag} on window {window}", verbose_int=1, verbose_state=verbose)
+    addlog(
+        f"[LIVE] Running live mode for {tag} on window {window}",
+        verbose_int=2,
+        verbose_state=verbose,
+    )
 
     settings = load_settings()
     meta = settings["symbol_settings"][tag]
@@ -153,7 +157,11 @@ def run_live(tag: str, window: str, verbose: int = 0) -> None:
         window_data = get_window_data_json(tag, window, candle_offset=0)
 
         if not candle or not window_data:
-            addlog("[ERROR] Missing candle or window data", verbose_int=1, verbose_state=verbose)
+            addlog(
+                "[ERROR] Missing candle or window data",
+                verbose_int=2,
+                verbose_state=verbose,
+            )
             continue
 
         exchange = ccxt.kraken({"enableRateLimit": True})
@@ -190,4 +198,8 @@ def run_live(tag: str, window: str, verbose: int = 0) -> None:
         )
         addlog(emoji_report, verbose_int=1, verbose_state=verbose)
 
-        addlog("[CYCLE] Top-of-hour cycle complete. Waiting for next hour...", verbose_int=1, verbose_state=verbose)
+        addlog(
+            "[CYCLE] Top-of-hour cycle complete. Waiting for next hour...",
+            verbose_int=2,
+            verbose_state=verbose,
+        )

--- a/systems/scripts/evaluate_buy.py
+++ b/systems/scripts/evaluate_buy.py
@@ -290,7 +290,7 @@ def evaluate_buy_df(
     addlog(
         f"🧠 Tunnel {{w={tunnel_low:.4f}, h={tunnel_height:.4f}, p={tunnel_pos:.4f}, t={tunnel_pct:.1f}%}} "
         f"Window {{p={window_pos:.4f}}}",
-        verbose_int=2,
+        verbose_int=3,
         verbose_state=verbose,
     )
 

--- a/systems/scripts/execution_handler.py
+++ b/systems/scripts/execution_handler.py
@@ -61,13 +61,21 @@ def buy_order(pair_code: str, fiat_symbol: str, usd_amount: float, verbose: int 
         price_resp = requests.get(f"https://api.kraken.com/0/public/Ticker?pair={pair_code}").json()
         ticker_result = price_resp.get("result", {})
         if not ticker_result:
-            addlog("[ERROR] Invalid ticker response: missing result", verbose_int=1, verbose_state=verbose)
+            addlog(
+                "[ERROR] Invalid ticker response: missing result",
+                verbose_int=2,
+                verbose_state=verbose,
+            )
             continue
         ticker_key = next(iter(ticker_result))
         ticker_data = ticker_result.get(ticker_key, {})
         close = ticker_data.get("c")
         if not close:
-            addlog("[ERROR] Invalid ticker response: missing close price", verbose_int=1, verbose_state=verbose)
+            addlog(
+                "[ERROR] Invalid ticker response: missing close price",
+                verbose_int=2,
+                verbose_state=verbose,
+            )
             continue
 
         price = float(close[0])
@@ -76,7 +84,7 @@ def buy_order(pair_code: str, fiat_symbol: str, usd_amount: float, verbose: int 
 
         addlog(
             f"\nTrying buy with slippage {slippage*100:.2f}% → volume {coin_amount:.6f}",
-            verbose_int=1,
+            verbose_int=3,
             verbose_state=verbose,
         )
 
@@ -97,7 +105,7 @@ def buy_order(pair_code: str, fiat_symbol: str, usd_amount: float, verbose: int 
             trades = trades_resp["result"]["trades"]
             for tid, trade in trades.items():
                 if trade["ordertxid"] == txid:
-                    addlog("Trade found in history", verbose_int=1, verbose_state=verbose)
+                    addlog("Trade found in history", verbose_int=2, verbose_state=verbose)
                     return {
                         "kraken_txid": txid,
                         "symbol": pair_code,
@@ -109,7 +117,7 @@ def buy_order(pair_code: str, fiat_symbol: str, usd_amount: float, verbose: int 
                     }
             time.sleep(0.6)
 
-        addlog("Slippage level failed, trying next...", verbose_int=1, verbose_state=verbose)
+        addlog("Slippage level failed, trying next...", verbose_int=3, verbose_state=verbose)
 
     raise Exception("Buy order failed — no fill found within timeout.")
 
@@ -145,7 +153,7 @@ def sell_order(pair_code: str, fiat_symbol: str, usd_amount: float, verbose: int
         trades = trades_resp["result"]["trades"]
         for tid, trade in trades.items():
             if trade["ordertxid"] == txid:
-                addlog("Sell trade found in history", verbose_int=1, verbose_state=verbose)
+                addlog("Sell trade found in history", verbose_int=2, verbose_state=verbose)
                 return {
                     "kraken_txid": txid,
                     "symbol": pair_code,

--- a/systems/scripts/get_candle_data.py
+++ b/systems/scripts/get_candle_data.py
@@ -98,7 +98,7 @@ def get_candle_data(tag: str, row_offset: int = 0, verbose: int = 0) -> Dict[str
 
     addlog(
         f"[get_candle_data] tag={tag} row_offset={row_offset}",
-        verbose_int=1,
+        verbose_int=3,
         verbose_state=verbose,
     )
 
@@ -143,7 +143,7 @@ def get_candle_data(tag: str, row_offset: int = 0, verbose: int = 0) -> Dict[str
 
     addlog(
         f"[get_candle_data] result={result}",
-        verbose_int=2,
+        verbose_int=3,
         verbose_state=verbose,
     )
 

--- a/systems/scripts/get_window_data.py
+++ b/systems/scripts/get_window_data.py
@@ -59,7 +59,7 @@ def get_window_data_json(tag: str, window: str, candle_offset: int = 0) -> dict 
 def get_window_data(tag: str, window: str, candle_offset: int = 0, verbose: int = 0) -> dict | None:
     addlog(
         f"[get_window_data] tag={tag} window={window} candle_offset={candle_offset}",
-        verbose_int=1,
+        verbose_int=3,
         verbose_state=verbose,
     )
 
@@ -71,13 +71,13 @@ def get_window_data(tag: str, window: str, candle_offset: int = 0, verbose: int 
     except FileNotFoundError:
         addlog(
             f"[ERROR] Data file not found: {path}",
-            verbose_int=1,
+            verbose_int=2,
             verbose_state=verbose,
         )
         return None
 
     if df.empty:
-        addlog("[WARN] CSV is empty", verbose_int=1, verbose_state=verbose)
+        addlog("[WARN] CSV is empty", verbose_int=2, verbose_state=verbose)
         return None
 
     # Convert window to duration in candles (assume hourly)
@@ -92,7 +92,7 @@ def get_window_data(tag: str, window: str, candle_offset: int = 0, verbose: int 
     if window_df.empty:
         addlog(
             "[WARN] No candle data in computed window slice",
-            verbose_int=1,
+            verbose_int=2,
             verbose_state=verbose,
         )
         return None
@@ -106,7 +106,7 @@ def get_window_data(tag: str, window: str, candle_offset: int = 0, verbose: int 
     except IndexError:
         addlog(
             f"[ERROR] Not enough candles to read offset {candle_offset}",
-            verbose_int=1,
+            verbose_int=2,
             verbose_state=verbose,
         )
         return None
@@ -124,7 +124,7 @@ def get_window_data(tag: str, window: str, candle_offset: int = 0, verbose: int 
 
     addlog(
         f"[get_window_data] result={result}",
-        verbose_int=2,
+        verbose_int=3,
         verbose_state=verbose,
     )
 

--- a/systems/scripts/kraken_utils.py
+++ b/systems/scripts/kraken_utils.py
@@ -46,7 +46,7 @@ def get_kraken_balance(verbose: int = 0) -> dict:
     result = _kraken_request("Balance", {}, api_key, api_secret).get("result", {})
     addlog(
         f"[INFO] Kraken balance fetched: {result}",
-        verbose_int=2,
+        verbose_int=3,
         verbose_state=verbose,
     )
     return {k: float(v) for k, v in result.items()}

--- a/systems/sim_engine.py
+++ b/systems/sim_engine.py
@@ -42,7 +42,7 @@ def run_simulation(tag: str, window: str, verbose: int = 0) -> None:
     )
     addlog(
         f"[SIM] Running simulation for {tag} on window {window}",
-        verbose_int=1,
+        verbose_int=2,
         verbose_state=verbose,
     )
 
@@ -103,7 +103,7 @@ def run_simulation(tag: str, window: str, verbose: int = 0) -> None:
             if should_exit:
                 addlog(
                     "\n🚪 ESC detected — exiting simulation early.",
-                    verbose_int=1,
+                    verbose_int=2,
                     verbose_state=verbose,
                 )
 
@@ -111,7 +111,7 @@ def run_simulation(tag: str, window: str, verbose: int = 0) -> None:
                 elapsed = duration_from_candle_count(step + 1, candle_interval_minutes=60)
                 addlog(
                     f"⏱️  Simulated Range: {elapsed} ({step + 1} ticks of {total_rows})",
-                    verbose_int=1,
+                    verbose_int=2,
                     verbose_state=verbose,
                 )
 
@@ -124,7 +124,7 @@ def run_simulation(tag: str, window: str, verbose: int = 0) -> None:
                     unrealized_value = sum(n["entry_amount"] * last_price for n in open_notes)
                     addlog(
                         f"[INFO] Mark-to-market added from open notes: ${unrealized_value:.2f}",
-                        verbose_int=1,
+                        verbose_int=2,
                         verbose_state=verbose,
                     )
                     ending_capital = sim_capital + unrealized_value
@@ -190,7 +190,7 @@ def run_simulation(tag: str, window: str, verbose: int = 0) -> None:
             else:
                 addlog(
                     f"[STEP {step+1}] ❌ Incomplete data (candle or window)",
-                    verbose_int=1,
+                    verbose_int=2,
                     verbose_state=verbose,
                 )
 
@@ -205,7 +205,7 @@ def run_simulation(tag: str, window: str, verbose: int = 0) -> None:
         unrealized_value = sum(n["entry_amount"] * last_price for n in open_notes)
         addlog(
             f"[INFO] Mark-to-market added from open notes: ${unrealized_value:.2f}",
-            verbose_int=1,
+            verbose_int=2,
             verbose_state=verbose,
         )
         ending_capital = sim_capital + unrealized_value
@@ -239,7 +239,7 @@ def save_ledger_to_file(ledger, filename="ledgersimulation.json", verbose: int =
     from tqdm import tqdm
     addlog(
         f"\n🧾 Ledger saved to: {output_path}",
-        verbose_int=1,
+        verbose_int=2,
         verbose_state=verbose,
     )
     


### PR DESCRIPTION
## Summary
- route messages to verbosity tiers for live and simulated engines
- send internal debug output to level 3
- keep critical buy/sell output at level 1

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a489aa37c8326be4ca8ec70412923