### PR TITLE
Convert coin amounts to USD for output

### DIFF
--- a/systems/live_engine.py
+++ b/systems/live_engine.py
@@ -193,7 +193,7 @@ def run_live(tag: str, window: str, verbose: int = 0) -> None:
             return sum(1 for n in ledger.get_active_notes() if n["strategy"] == name)
 
         emoji_report = (
-            f"\U0001f4ca {tag} | \U0001fa75 ${available_usd:.0f} + \U0001fa99 {available_coin:.2f} {wallet_code} | "
+            f"\U0001f4ca {tag} | \U0001fa75 ${available_usd:.0f} + \U0001fa99 ${coin_balance_usd:.2f} | "
             f"\U0001f41f {active_count('fish_catch')} \U0001f40b {active_count('whale_catch')} \U0001f52a {active_count('knife_catch')}"
         )
         addlog(emoji_report, verbose_int=1, verbose_state=verbose)

--- a/systems/scripts/execution_handler.py
+++ b/systems/scripts/execution_handler.py
@@ -81,9 +81,10 @@ def buy_order(pair_code: str, fiat_symbol: str, usd_amount: float, verbose: int 
         price = float(close[0])
         adjusted_price = price * (1 + slippage)
         coin_amount = round(usd_amount / adjusted_price, 8)
+        usd_equiv = coin_amount * adjusted_price
 
         addlog(
-            f"\nTrying buy with slippage {slippage*100:.2f}% → volume {coin_amount:.6f}",
+            f"\nTrying buy with slippage {slippage*100:.2f}% → ${usd_equiv:.2f}",
             verbose_int=3,
             verbose_state=verbose,
         )

--- a/systems/utils/price_fetcher.py
+++ b/systems/utils/price_fetcher.py
@@ -1,0 +1,16 @@
+import json
+import urllib.request
+
+
+def get_price(symbol: str) -> float | None:
+    """Fetch the latest close price for a trading pair from Kraken."""
+    url = f"https://api.kraken.com/0/public/Ticker?pair={symbol}"
+    try:
+        with urllib.request.urlopen(url) as response:
+            data = json.load(response)
+            result = list(data.get("result", {}).values())
+            if not result:
+                return None
+            return float(result[0]["c"][0])
+    except Exception:
+        return None


### PR DESCRIPTION
## Summary
- centralize Kraken price fetching in `price_fetcher`
- display coin balances in USD in live reports
- log buy attempts with USD instead of coin volume
- summarise Kraken balance logs using USD values

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a580578e08326a2a3b1ad7e7f8425