### PR TITLE
Implement hourly multi-coin live loop

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -14,7 +14,14 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     """Parse command line arguments."""
     parser = argparse.ArgumentParser(description="WindowSurfer bot entrypoint")
     parser.add_argument("--mode", required=True, help="Execution mode: sim or live")
-    parser.add_argument("--tag", required=True, help="Symbol tag, e.g. DOGEUSD")
+    parser.add_argument(
+        "--tag",
+        required=False,
+        help=(
+            "Symbol tag, e.g. DOGEUSD. If omitted, all symbols from config are "
+            "processed every hour"
+        ),
+    )
     parser.add_argument("--window", required=True, help="Candle window, e.g. 1m or 1h")
     parser.add_argument(
         "-v",


### PR DESCRIPTION
## Summary
- allow live mode to process all configured symbols
- update command line options so --tag is optional
- loop across symbols and call `handle_top_of_hour`

## Testing
- `pytest -q`
- `python bot.py --mode live --verbose 1 --window 1h` *(fails: ModuleNotFoundError: No module named 'tqdm')*

------
https://chatgpt.com/codex/tasks/task_e_688a824850b88326994982e9b60faf3d