### PR TITLE
feat: enforce max note size

### DIFF
--- a/settings/settings.json
+++ b/settings/settings.json
@@ -1,36 +1,34 @@
 {
   "symbol_settings": {
     "DOGEUSD": {
-	  "owner": "Chris",
-	  "wallet_code": "XXDG",
+      "owner": "Chris",
+      "wallet_code": "XXDG",
       "kraken_name": "DOGE/USD",
       "binance_name": "DOGEUSDT",
-	  "fiat": "ZUSD"
+      "fiat": "ZUSD"
     },
     "SOLUSD": {
-    "owner": "Travis",
-    "wallet_code": "SOL.F",
-    "kraken_name": "SOL/USD",
-    "binance_name": "SOLUSDT",
-    "fiat": "DAI"
-  }
+      "owner": "Travis",
+      "wallet_code": "SOL.F",
+      "kraken_name": "SOL/USD",
+      "binance_name": "SOLUSDT",
+      "fiat": "DAI"
+    }
   },
   "general_settings": {
     "knife_catch_cooldown": 0,
     "whale_catch_cooldown": 1,
-    "fish_catch_cooldown": 3
+    "fish_catch_cooldown": 3,
+    "max_note_usdt": 300.0
   },
   "simulation_capital": 1000,
   "investment_size": 0.05,
   "active_strategies": ["fish_catch", "whale_catch", "knife_catch"],
   "minimum_note_size": 10,
-
   "strategy_limits": {
     "knife_catch": {
       "max_open_notes": 10
     }
   },
-
   "knife_group_roi_margin": 0.25
-
 }

--- a/systems/live_engine.py
+++ b/systems/live_engine.py
@@ -44,8 +44,15 @@ def evaluate_live_tick(
     from systems.scripts.evaluate_buy import evaluate_buy_df
     from systems.scripts.evaluate_sell import evaluate_sell_df
 
+    settings = load_settings()
+
     def get_capital():
         return get_available_fiat_balance(exchange, meta["fiat"])
+
+    max_note_usdt = meta.get(
+        "max_note_usdt",
+        settings["general_settings"].get("max_note_usdt", 999999),
+    )
 
     evaluate_buy_df(
         candle=candle,
@@ -58,7 +65,8 @@ def evaluate_live_tick(
         verbose=verbose,
         ledger=ledger,
         get_capital=get_capital,
-        meta=meta
+        meta=meta,
+        max_note_usdt=max_note_usdt,
     )
 
     to_sell = evaluate_sell_df(

--- a/systems/scripts/evaluate_buy.py
+++ b/systems/scripts/evaluate_buy.py
@@ -54,7 +54,8 @@ def evaluate_buy_df(
     ledger=None,
     get_capital=None,
     on_buy=None,
-    meta=None  # ✅ THIS IS THE KEY FIX
+    meta=None,  # ✅ THIS IS THE KEY FIX
+    max_note_usdt: float = 999999,
 ) -> bool:
 
 
@@ -121,20 +122,20 @@ def evaluate_buy_df(
     def create_note(strategy: str):
         nonlocal available_capital
         usd_amount = available_capital * INVESTMENT_SIZE
-        if usd_amount < MINIMUM_NOTE_SIZE:
+        entry_usdt = min(usd_amount, max_note_usdt)
+        if entry_usdt < MINIMUM_NOTE_SIZE:
             min_size = MINIMUM_NOTE_SIZE
             addlog(
-                f"[SKIP] Note below minimum size (${usd_amount:.2f} < ${min_size})",
+                f"[SKIP] Note below minimum size (${entry_usdt:.2f} < ${min_size})",
                 verbose_int=1,
                 verbose_state=verbose,
             )
             return None
 
         # Deduct from local capital so sequential notes honor updates
-        available_capital -= usd_amount
+        available_capital -= entry_usdt
 
-        entry_amount = usd_amount / close_price
-        entry_usdt = usd_amount
+        entry_amount = entry_usdt / close_price
         note = {
             "symbol": tag,
             "strategy": strategy,

--- a/systems/sim_engine.py
+++ b/systems/sim_engine.py
@@ -1,4 +1,3 @@
-
 import threading
 try:
     import msvcrt
@@ -59,6 +58,8 @@ def run_simulation(tag: str, window: str, verbose: int = 0) -> None:
 
     sim_capital = float(config.get("simulation_capital", 0))
     start_capital = sim_capital
+
+    max_note_usdt = SETTINGS["general_settings"].get("max_note_usdt", 999999)
 
     def get_capital():
         return sim_capital
@@ -158,6 +159,7 @@ def run_simulation(tag: str, window: str, verbose: int = 0) -> None:
                     ledger=ledger,  # ✅ Inject ledger
                     get_capital=get_capital,
                     on_buy=deduct_capital,
+                    max_note_usdt=max_note_usdt,
                 )
 
                 to_sell = evaluate_sell_df(


### PR DESCRIPTION
## Summary
- add `max_note_usdt` setting to cap buy sizes
- clip entry amount in `evaluate_buy_df`
- respect `max_note_usdt` in simulation and live engines

## Testing
- `python -m py_compile systems/live_engine.py systems/sim_engine.py systems/scripts/evaluate_buy.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688b25ff6f508326ab75b841afd3ea0c