### PR TITLE
feat: add per-strategy investment sizes

### DIFF
--- a/settings/settings.json
+++ b/settings/settings.json
@@ -19,10 +19,12 @@
     "knife_catch_cooldown": 0,
     "whale_catch_cooldown": 1,
     "fish_catch_cooldown": 3,
-    "max_note_usdt": 300.0
+    "max_note_usdt": 300.0,
+    "knife_investment_size": 0.05,
+    "whale_investment_size": 0.07,
+    "fish_investment_size": 0.10
   },
   "simulation_capital": 1000,
-  "investment_size": 0.05,
   "active_strategies": ["fish_catch", "whale_catch", "knife_catch"],
   "minimum_note_size": 10,
   "strategy_limits": {

--- a/systems/live_engine.py
+++ b/systems/live_engine.py
@@ -54,20 +54,30 @@ def evaluate_live_tick(
         settings["general_settings"].get("max_note_usdt", 999999),
     )
 
-    evaluate_buy_df(
-        candle=candle,
-        window_data=window_data,
-        tick=0,
-        cooldowns=cooldowns,
-        last_triggered=last_triggered,
-        tag=tag,
-        sim=False,
-        verbose=verbose,
-        ledger=ledger,
-        get_capital=get_capital,
-        meta=meta,
-        max_note_usdt=max_note_usdt,
+    for key in cooldowns:
+        cooldowns[key] = max(0, cooldowns[key] - 1)
+
+    active = settings.get(
+        "active_strategies",
+        ["fish_catch", "whale_catch", "knife_catch"],
     )
+
+    for strat in active:
+        evaluate_buy_df(
+            candle=candle,
+            window_data=window_data,
+            tick=0,
+            cooldowns=cooldowns,
+            last_triggered=last_triggered,
+            tag=tag,
+            strategy=strat,
+            sim=False,
+            verbose=verbose,
+            ledger=ledger,
+            get_capital=get_capital,
+            meta=meta,
+            max_note_usdt=max_note_usdt,
+        )
 
     to_sell = evaluate_sell_df(
         candle=candle,

--- a/systems/sim_engine.py
+++ b/systems/sim_engine.py
@@ -93,6 +93,11 @@ def run_simulation(tag: str, window: str, verbose: int = 0) -> None:
         "fish_catch": None
     }
 
+    active_strategies = SETTINGS.get(
+        "active_strategies",
+        ["fish_catch", "whale_catch", "knife_catch"],
+    )
+
     should_exit = []
 
     # Start ESC listener
@@ -147,20 +152,25 @@ def run_simulation(tag: str, window: str, verbose: int = 0) -> None:
                 break
 
             if candle and window_data:
-                evaluate_buy_df(
-                    candle=candle,
-                    window_data=window_data,
-                    tick=step,
-                    cooldowns=cooldowns,
-                    last_triggered=last_triggered,
-                    tag=tag,
-                    sim=True,
-                    verbose=verbose,
-                    ledger=ledger,  # ✅ Inject ledger
-                    get_capital=get_capital,
-                    on_buy=deduct_capital,
-                    max_note_usdt=max_note_usdt,
-                )
+                for key in cooldowns:
+                    cooldowns[key] = max(0, cooldowns[key] - 1)
+
+                for strat in active_strategies:
+                    evaluate_buy_df(
+                        candle=candle,
+                        window_data=window_data,
+                        tick=step,
+                        cooldowns=cooldowns,
+                        last_triggered=last_triggered,
+                        tag=tag,
+                        strategy=strat,
+                        sim=True,
+                        verbose=verbose,
+                        ledger=ledger,  # ✅ Inject ledger
+                        get_capital=get_capital,
+                        on_buy=deduct_capital,
+                        max_note_usdt=max_note_usdt,
+                    )
 
                 to_sell = evaluate_sell_df(
                     candle=candle,


### PR DESCRIPTION
## Summary
- add per-strategy investment sizes in configuration
- route strategy-specific investment sizes through evaluate_buy
- ensure sim and live engines pass strategies to evaluate_buy

## Testing
- `pytest`
- `python -m py_compile systems/scripts/evaluate_buy.py systems/sim_engine.py systems/live_engine.py`


------
https://chatgpt.com/codex/tasks/task_e_688b33c6592c832699e9a32c2b3ea7dc