### PR TITLE
feat: prioritize high value sells with cooldown

### DIFF
--- a/systems/sim_engine.py
+++ b/systems/sim_engine.py
@@ -14,7 +14,7 @@ from tqdm import tqdm
 
 from scripts.fetch_canles import fetch_candles
 from scripts.ledger_manager import RamLedger, save_ledger
-from scripts.trade_logic import handle_sells, maybe_buy
+from scripts.trade_logic import maybe_buy
 from systems.scripts.get_window_data import get_wave_window_data_df
 from systems.utils.logger import addlog
 from systems.utils.settings_loader import load_settings
@@ -98,6 +98,7 @@ def run_simulation(tag: str, verbose: int = 0) -> None:
     min_note_usdt = settings.get("general_settings", {}).get("minimum_note_size", 0)
 
     last_buy_tick = {name: float("-inf") for name in windows}
+    last_sell_tick: dict[str, int] = {}
 
     total = len(df)
     with tqdm(total=total, desc="📉 Sim Progress", dynamic_ncols=True) as pbar:
@@ -128,23 +129,34 @@ def run_simulation(tag: str, verbose: int = 0) -> None:
                     verbose=verbose,
                 )
                 before_pnl = ledger.pnl
-                sim_capital, closed_notes = handle_sells(
-                    ledger=ledger,
-                    name=name,
-                    tick=tick,
-                    price=price,
-                    sim_capital=sim_capital,
-                    verbose=verbose,
-                )
-                for note in closed_notes:
-                    addlog(
-                        (
-                            f"[SELL] Tick {tick} | Window: {note['window']} | "
-                            f"Gain: +${note['gain_usdt']:.2f} ({note['gain_pct']:.2%})"
-                        ),
-                        verbose_int=2,
-                        verbose_state=verbose,
-                    )
+                cooldown = cfg.get("cooldown", 0)
+                if tick - last_sell_tick.get(name, -9999) >= cooldown:
+                    active_notes = [
+                        n for n in ledger.get_active_notes() if n["window"] == name
+                    ]
+                    if active_notes:
+                        active_notes.sort(
+                            key=lambda n: n.get("entry_usdt", 0), reverse=True
+                        )
+                        note = active_notes[0]
+                        if price >= note["mature_price"]:
+                            note["exit_tick"] = tick
+                            note["exit_price"] = price
+                            note["exit_usdt"] = note["entry_amount"] * price
+                            note["gain_usdt"] = note["exit_usdt"] - note["entry_usdt"]
+                            note["gain_pct"] = note["gain_usdt"] / note["entry_usdt"]
+                            note["status"] = "Closed"
+                            ledger.close_note(note)
+                            sim_capital += note["exit_usdt"]
+                            last_sell_tick[name] = tick
+                            addlog(
+                                (
+                                    f"[SELL] Tick {tick} | Window: {note['window']} | "
+                                    f"Gain: +${note['gain_usdt']:.2f} ({note['gain_pct']:.2%})"
+                                ),
+                                verbose_int=2,
+                                verbose_state=verbose,
+                            )
                 realised_gain = ledger.pnl - before_pnl
                 if realised_gain:
                     realised_pnl += realised_gain


### PR DESCRIPTION
## Summary
- ensure simulation sells only one note per window each tick
- sort active notes by highest investment before evaluating sale
- enforce per-window sell cooldown tracking last sold tick

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_688bb0419b9c8326b72b600faed3b6e8