### PR TITLE
Fix capital tracking in simulation engine

### DIFF
--- a/systems/sim_engine.py
+++ b/systems/sim_engine.py
@@ -160,7 +160,6 @@ def run_simulation(tag: str, verbose: int = 0) -> None:
                 realised_gain = ledger.pnl - before_pnl
                 if realised_gain:
                     realised_pnl += realised_gain
-                    sim_capital -= realised_gain
 
             pbar.update(1)
 
@@ -168,7 +167,7 @@ def run_simulation(tag: str, verbose: int = 0) -> None:
     open_value = sum(
         n["entry_amount"] * last_price for n in ledger.get_active_notes()
     )
-    end_value = sim_capital + open_value + realised_pnl
+    end_value = sim_capital + open_value
     summarize_simulation(
         ledger=ledger,
         start_capital=start_capital,


### PR DESCRIPTION
## Summary
- ensure realised gains no longer reduce available simulation capital
- compute ending portfolio value from remaining capital plus open positions to avoid double counting

## Testing
- `python -m pytest` *(no tests found)*
- `pip install -r requirements.txt` *(failed: Could not find a version that satisfies pandas due to proxy restrictions)*
- `python bot.py --mode sim --tag DOGEUSD -v` *(failed: ModuleNotFoundError: No module named 'tqdm')*


------
https://chatgpt.com/codex/tasks/task_e_688bd68f82f88326a3f95449f2ef96d1