### PR TITLE
feat: add progressive wave scaling

### DIFF
--- a/scripts/evaluate_buy.py
+++ b/scripts/evaluate_buy.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+"""Evaluate buy conditions with optional progressive scaling."""
+
+from typing import Dict
+
+from scripts.ledger_manager import RamLedger
+from systems.utils.logger import addlog
+
+
+def evaluate_buy(
+    *,
+    ledger: RamLedger,
+    name: str,
+    cfg: Dict,
+    wave: Dict,
+    tick: int,
+    total_ticks: int,
+    price: float,
+    sim_capital: float,
+    last_buy_tick: Dict[str, int],
+    max_note_usdt: float,
+    min_note_usdt: float,
+    verbose: int,
+) -> float:
+    """Attempt to open a new note if buy conditions are met."""
+
+    position = wave["position_in_window"]
+    base_floor = cfg.get("buy_floor", 0.0)
+
+    if cfg.get("buy_scale"):
+        progress = tick / total_ticks if total_ticks else 1.0
+        progress = min(progress, 1.0)
+        threshold = base_floor * (1.0 - progress)
+    else:
+        threshold = base_floor
+
+    if position <= threshold:
+        cooldown = cfg.get("cooldown", 0)
+        if tick - last_buy_tick.get(name, float("-inf")) >= cooldown:
+            open_for_window = [n for n in ledger.get_active_notes() if n["window"] == name]
+            if len(open_for_window) < cfg.get("max_open_notes", 0):
+                invest = sim_capital * cfg.get("investment_fraction", 0)
+                invest = min(invest, max_note_usdt)
+                if invest >= min_note_usdt and invest <= sim_capital:
+                    amount = invest / price
+                    mature_price = wave["floor"] + wave["range"] * cfg.get("sell_ceiling", 1)
+                    note = {
+                        "window": name,
+                        "entry_tick": tick,
+                        "entry_price": price,
+                        "entry_usdt": invest,
+                        "entry_amount": amount,
+                        "mature_price": mature_price,
+                        "status": "Open",
+                    }
+                    ledger.open_note(note)
+                    sim_capital -= invest
+                    last_buy_tick[name] = tick
+                    addlog(
+                        f"[BUY] {name} tick {tick} price={price:.6f}",
+                        verbose_int=2,
+                        verbose_state=verbose,
+                    )
+    return sim_capital

--- a/scripts/evaluate_sell.py
+++ b/scripts/evaluate_sell.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+"""Evaluate sell conditions with optional progressive scaling."""
+
+from typing import Dict, List, Tuple
+
+from scripts.ledger_manager import RamLedger
+from systems.utils.logger import addlog
+
+
+def evaluate_sell(
+    *,
+    ledger: RamLedger,
+    name: str,
+    cfg: Dict,
+    wave: Dict,
+    tick: int,
+    total_ticks: int,
+    price: float,
+    sim_capital: float,
+    last_sell_tick: Dict[str, int],
+    verbose: int,
+) -> Tuple[float, List[Dict]]:
+    """Close notes that meet sell conditions.
+
+    Returns updated capital and list of notes closed at this tick.
+    """
+
+    cooldown = cfg.get("cooldown", 0)
+    if tick - last_sell_tick.get(name, -9999) < cooldown:
+        return sim_capital, []
+
+    position = wave["position_in_window"]
+    base_ceiling = cfg.get("sell_ceiling", 1.0)
+
+    if cfg.get("sell_scale"):
+        progress = tick / total_ticks if total_ticks else 1.0
+        progress = min(progress, 1.0)
+        threshold = base_ceiling * progress
+    else:
+        threshold = base_ceiling
+
+    closed: List[Dict] = []
+    if position >= threshold:
+        active = [n for n in ledger.get_active_notes() if n["window"] == name]
+        if active:
+            active.sort(key=lambda n: n.get("entry_usdt", 0), reverse=True)
+            note = active[0]
+            note["exit_tick"] = tick
+            note["exit_price"] = price
+            note["exit_usdt"] = note["entry_amount"] * price
+            note["gain_usdt"] = note["exit_usdt"] - note["entry_usdt"]
+            note["gain_pct"] = note["gain_usdt"] / note["entry_usdt"]
+            note["status"] = "Closed"
+            ledger.close_note(note)
+            sim_capital += note["exit_usdt"]
+            last_sell_tick[name] = tick
+            closed.append(note)
+            addlog(
+                f"[SELL] {name} tick {tick} price={price:.6f}",
+                verbose_int=2,
+                verbose_state=verbose,
+            )
+    return sim_capital, closed

--- a/settings/settings.json
+++ b/settings/settings.json
@@ -23,6 +23,8 @@
         "investment_fraction": 0.10,
         "buy_floor": 0.1,
         "sell_ceiling": 0.9,
+        "buy_scale": true,
+        "sell_scale": true,
         "max_open_notes": 10
       },
       "whale": {
@@ -31,6 +33,8 @@
         "investment_fraction": 0.07,
         "buy_floor": 0.1,
         "sell_ceiling": 0.9,
+        "buy_scale": true,
+        "sell_scale": true,
         "max_open_notes": 10
       },
       "knife": {
@@ -39,6 +43,8 @@
         "investment_fraction": 0.05,
         "buy_floor": 0.1,
         "sell_ceiling": 0.9,
+        "buy_scale": true,
+        "sell_scale": true,
         "max_open_notes": 10
       }
     },


### PR DESCRIPTION
## Summary
- add optional buy/sell scaling config per window
- implement evaluate_buy/evaluate_sell with time-based scaling
- wire sim engine to provide tick progress for scaling logic

## Testing
- `python -m py_compile scripts/evaluate_buy.py scripts/evaluate_sell.py systems/sim_engine.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688be712dfc48326a5a43d7c08ca063d