### PR TITLE
Add Optuna tuning mode and knobs configuration

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -16,8 +16,8 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     parser.add_argument(
         "--mode",
         required=True,
-        choices=["sim", "live", "wallet"],
-        help="Execution mode: sim, live, or wallet",
+        choices=["sim", "live", "wallet", "tune"],
+        help="Execution mode: sim, live, wallet, or tune",
     )
     parser.add_argument(
         "--tag",
@@ -27,6 +27,7 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
             "processed every hour"
         ),
     )
+    parser.add_argument("--window", required=False, help="Candle window, e.g. 1m or 1h")
     parser.add_argument(
         "-v",
         "--verbose",
@@ -57,6 +58,8 @@ def main(argv: list[str] | None = None) -> None:
     )
 
     mode = args.mode.lower()
+    tag = args.tag.upper() if args.tag else None
+    window = args.window
     verbose = args.verbose
 
     if mode == "wallet":
@@ -80,11 +83,15 @@ def main(argv: list[str] | None = None) -> None:
         return
 
     if mode == "sim":
-        run_simulation(tag=args.tag.upper(), verbose=args.verbose)
+        run_simulation(tag=tag or "DOGEUSD", verbose=verbose)
     elif mode == "live":
-        run_live(tag=args.tag.upper() if args.tag else None, verbose=args.verbose)
+        run_live(tag=tag, verbose=verbose)
+    elif mode == "tune":
+        from systems.tune import run_tuner
+
+        run_tuner(tag=tag or "DOGEUSD", window=window or "1h", verbose=verbose)
     else:
-        addlog("Error: --mode must be either 'sim', 'live', or 'wallet'")
+        addlog("Error: --mode must be either 'sim', 'live', 'wallet', or 'tune'")
         sys.exit(1)
 
 

--- a/settings/knobs.json
+++ b/settings/knobs.json
@@ -1,0 +1,10 @@
+{
+  "fish": {
+    "window_size": ["2d", "3d", "4d", "5d"],
+    "cooldown": [0, 6],
+    "investment_fraction": [0.01, 0.2],
+    "buy_floor": [0.05, 0.3],
+    "sell_ceiling": [0.7, 0.99],
+    "max_open_notes": [5, 15]
+  }
+}

--- a/systems/tune.py
+++ b/systems/tune.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+"""Optuna-based hyperparameter tuner for window strategies."""
+
+import json
+from typing import Any, Dict
+
+import optuna
+
+from systems.utils.logger import addlog
+from systems.utils.path import find_project_root
+from systems.sim_engine import run_simulation
+
+
+_DEF_ROLE = "fish"
+
+
+def _load_knobs() -> Dict[str, Dict[str, Any]]:
+    """Load knob definitions from ``settings/knobs.json``."""
+    root = find_project_root()
+    path = root / "settings" / "knobs.json"
+    with path.open("r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def run_tuner(
+    *,
+    tag: str,
+    window: str,
+    role: str = _DEF_ROLE,
+    trials: int = 20,
+    verbose: int = 0,
+) -> None:
+    """Run Optuna tuner for a single role."""
+    tag = tag.upper()
+    knobs = _load_knobs().get(role)
+    if knobs is None:
+        raise ValueError(f"Unknown role '{role}' in knobs.json")
+
+    root = find_project_root()
+    settings_path = root / "settings" / "settings.json"
+    with settings_path.open("r", encoding="utf-8") as f:
+        base_settings = json.load(f)
+
+    def objective(trial: optuna.trial.Trial) -> float:
+        settings = json.loads(json.dumps(base_settings))
+        window_cfg = settings.setdefault("general_settings", {}).setdefault("windows", {}).setdefault(role, {})
+        for key, spec in knobs.items():
+            if isinstance(spec, list) and spec and isinstance(spec[0], str):
+                val = trial.suggest_categorical(key, spec)
+            elif isinstance(spec, list) and len(spec) == 2:
+                low, high = spec
+                if isinstance(low, int) and isinstance(high, int):
+                    val = trial.suggest_int(key, low, high)
+                else:
+                    val = trial.suggest_float(key, float(low), float(high))
+            else:
+                raise ValueError(f"Invalid spec for {key}: {spec}")
+            window_cfg[key] = val
+
+        import systems.sim_engine as sim_engine  # local import for patching
+
+        def _patched_load_settings():
+            return settings
+
+        sim_engine.load_settings = _patched_load_settings
+
+        run_simulation(tag=tag, verbose=0)
+
+        ledger_path = root / "data" / "tmp" / "ledgersimulation.json"
+        with ledger_path.open("r", encoding="utf-8") as f:
+            ledger = json.load(f)
+
+        pnl = float(ledger.get("pnl", 0.0))
+        notes = ledger.get("open_notes", []) + ledger.get("closed_notes", [])
+        events = []
+        for note in notes:
+            entry = int(note.get("entry_tick", 0))
+            exit_ = note.get("exit_tick")
+            exit_tick = int(exit_) if exit_ is not None else entry + 10**9
+            amt = float(note.get("entry_usdt", 0.0))
+            events.append((entry, amt))
+            events.append((exit_tick, -amt))
+        active = 0.0
+        capital_used = 0.0
+        for tick, delta in sorted(events, key=lambda x: x[0]):
+            active += delta
+            capital_used = max(capital_used, active)
+        if capital_used == 0:
+            return 0.0
+        return pnl / capital_used
+
+    optuna.logging.set_verbosity(optuna.logging.WARNING)
+    study = optuna.create_study(direction="maximize")
+    study.optimize(objective, n_trials=trials)
+
+    best = study.best_params
+    addlog(f"[TUNE] Best params for {role}: {best}", verbose_int=1, verbose_state=verbose)
+
+    out_dir = root / "data" / "tmp"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_path = out_dir / f"tune_best_{role}.json"
+    with out_path.open("w", encoding="utf-8") as f:
+        json.dump(best, f, indent=2)
+
+    print(f"Best parameters for {role}: {best}")
+


### PR DESCRIPTION
## Summary
- add settings/knobs.json describing search spaces for tuning fish window parameters
- implement systems.tune.run_tuner using Optuna and simulation engine
- extend bot CLI with `--mode tune` and window argument

## Testing
- `pytest`
- `pip install optuna` *(fails: Could not find a version that satisfies the requirement optuna)*

------
https://chatgpt.com/codex/tasks/task_e_688be3f3bc88832692bbcf07249cb1bc