### PR TITLE
feat: support multi-window tuning

### DIFF
--- a/settings/knobs.json
+++ b/settings/knobs.json
@@ -1,9 +1,25 @@
 {
   "fish": {
-    "window_size": ["2d", "3d", "4d", "5d"],
-    "cooldown": [0, 6],
+    "window_size": ["1d", "2d", "3d"],
+    "cooldown": [0, 24],
     "investment_fraction": [0.01, 0.2],
-    "buy_floor": [0.05, 0.3],
+    "buy_floor": [0.1, 0.5],
+    "sell_ceiling": [0.7, 0.99],
+    "max_open_notes": [5, 15]
+  },
+  "whale": {
+    "window_size": ["5d", "7d", "10d"],
+    "cooldown": [12, 72],
+    "investment_fraction": [0.05, 0.3],
+    "buy_floor": [0.1, 0.5],
+    "sell_ceiling": [0.7, 0.99],
+    "max_open_notes": [5, 15]
+  },
+  "knife": {
+    "window_size": ["14d", "20d", "30d"],
+    "cooldown": [100, 200],
+    "investment_fraction": [0.1, 0.5],
+    "buy_floor": [0.2, 0.6],
     "sell_ceiling": [0.7, 0.99],
     "max_open_notes": [5, 15]
   }


### PR DESCRIPTION
## Summary
- support simultaneous tuning for all window roles and save best composite config
- add multi-role knob ranges for fish, whale and knife

## Testing
- `python -m py_compile systems/tune.py`
- `python -m json.tool settings/knobs.json >/dev/null`
- `pytest >/tmp/pytest.log && tail -n 20 /tmp/pytest.log`


------
https://chatgpt.com/codex/tasks/task_e_688bed0e58f08326b6041be3058bcb81