### PR TITLE
Add instrumentation for tuning and simulation

### DIFF
--- a/scripts/ledger_manager.py
+++ b/scripts/ledger_manager.py
@@ -45,14 +45,19 @@ def save_ledger(ledger: RamLedger, capital: float) -> None:
     out_dir = root / "data" / "tmp"
     out_dir.mkdir(parents=True, exist_ok=True)
     out_path = out_dir / "ledgersimulation.json"
-    with out_path.open("w", encoding="utf-8") as f:
-        json.dump(
-            {
-                "capital": capital,
-                "open_notes": ledger.open_notes,
-                "closed_notes": ledger.closed_notes,
-                "pnl": ledger.pnl,
-            },
-            f,
-            indent=2,
-        )
+    print("[LEDGER] Saving ledger to:", out_path)
+    try:
+        with out_path.open("w", encoding="utf-8") as f:
+            json.dump(
+                {
+                    "capital": capital,
+                    "open_notes": ledger.open_notes,
+                    "closed_notes": ledger.closed_notes,
+                    "pnl": ledger.pnl,
+                },
+                f,
+                indent=2,
+            )
+    except Exception as exc:
+        print("[LEDGER] Failed to save ledger:", exc)
+        print("[LEDGER] Ledger summary:", json.dumps(ledger.get_summary()))

--- a/systems/sim_engine.py
+++ b/systems/sim_engine.py
@@ -84,7 +84,9 @@ def summarize_simulation(
 
 def run_simulation(tag: str, verbose: int = 0) -> None:
     """Run a historical simulation for ``tag``."""
+    print("[SIM] Simulation engine entered")
     settings = load_settings()
+    print("[SIM] Settings loaded:", list(settings.get("general_settings", {}).keys()))
     tag = tag.upper()
     symbol_meta = settings.get("symbol_settings", {}).get(tag)
     if symbol_meta is None:
@@ -169,4 +171,5 @@ def run_simulation(tag: str, verbose: int = 0) -> None:
         total_ticks=len(df),
         verbose=verbose,
     )
+    print("[SIM] Exiting simulation")
 

--- a/systems/tune.py
+++ b/systems/tune.py
@@ -42,6 +42,7 @@ def run_tuner(*, tag: str, trials: int = 20, verbose: int = 0) -> None:
     trial_records: List[Dict[str, Any]] = []
 
     def objective(trial: optuna.trial.Trial) -> float:
+        print(f"[TUNE] Trial {trial.number} started")
         settings = json.loads(json.dumps(base_settings))
         trial_windows: Dict[str, Dict[str, Any]] = {}
         flat_params: Dict[str, Any] = {}
@@ -73,6 +74,7 @@ def run_tuner(*, tag: str, trials: int = 20, verbose: int = 0) -> None:
 
         run_simulation(tag=tag, verbose=0)
 
+        print("[TUNE] Simulation completed, reading ledger...")
         ledger_path = root / "data" / "tmp" / "ledgersimulation.json"
         with ledger_path.open("r", encoding="utf-8") as f:
             ledger = json.load(f)

--- a/systems/utils/logger.py
+++ b/systems/utils/logger.py
@@ -48,28 +48,5 @@ def init_logger(
 def addlog(
     message: str, verbose_int: int = 1, verbose_state: int | None = None
 ) -> None:
-    """Write a log message if ``verbose_int`` is within ``verbose_state``."""
-    if verbose_state is None:
-        verbose_state = DEFAULT_VERBOSE_STATE
-
-    should_output = verbose_int <= verbose_state
-
-    if should_output:
-        tqdm.write(message)
-        if TELEGRAM_ENABLED and TELEGRAM_TOKEN and TELEGRAM_CHAT_ID:
-            try:
-                url = f"https://api.telegram.org/bot{TELEGRAM_TOKEN}/sendMessage"
-                requests.post(
-                    url,
-                    data={"chat_id": TELEGRAM_CHAT_ID, "text": message},
-                    timeout=5,
-                )
-            except Exception as exc:
-                global _TELEGRAM_WARNED
-                if not _TELEGRAM_WARNED:
-                    tqdm.write(f"[WARN] Telegram send failed: {exc}")
-                    _TELEGRAM_WARNED = True
-
-    if LOGGING_ENABLED:
-        with open(LOGFILE_PATH, "a", encoding="utf-8") as f:
-            f.write(message + "\n")
+    """Temporary stub to bypass logger and output directly."""
+    print(message)


### PR DESCRIPTION
## Summary
- Add tuning diagnostics to `tune.objective` to track trial start and ledger reading
- Print sim engine entry, settings keys, and exit for `run_simulation`
- Replace custom logger with direct `print`
- Log ledger save path and provide stdout fallback when writing fails

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688bf3d85b108326bd59a5850ad76b91