### PR TITLE
feat: compute liquidatable account value

### DIFF
--- a/systems/scripts/ledger.py
+++ b/systems/scripts/ledger.py
@@ -46,6 +46,15 @@ class Ledger:
     def get_closed_notes(self) -> List[Dict]:
         return list(self.closed_notes)
 
+    def get_total_liquid_value(self) -> float:
+        """Return all capital that could be withdrawn immediately."""
+        realised_pnl = sum(n["gain_usdt"] for n in self.get_closed_notes())
+        open_value = sum(
+            n["entry_amount"] * n["entry_price"] for n in self.get_open_notes()
+        )
+        idle_capital = self.get_capital()
+        return realised_pnl + open_value + idle_capital
+
     # Summary ---------------------------------------------------------------
     def get_account_summary(self, starting_capital: float) -> dict:
         realised_pnl = sum(n.get("gain_usdt", 0) for n in self.get_closed_notes())
@@ -53,7 +62,7 @@ class Ledger:
         open_value = sum(
             n.get("entry_amount", 0) * n.get("entry_price", 0) for n in self.get_open_notes()
         )
-        ending_value = idle_capital + open_value + realised_pnl
+        ending_value = self.get_total_liquid_value()
         net_gain = ending_value - starting_capital
         roi = (net_gain / starting_capital) * 100 if starting_capital else 0.0
 

--- a/systems/sim_engine.py
+++ b/systems/sim_engine.py
@@ -33,7 +33,7 @@ def run_simulation(tag: str, verbose: int = 0) -> None:
         raise ValueError("No windows defined in settings['general_settings']['windows']")
 
     sim_capital = float(settings.get("simulation_capital", 0))
-    start_capital = sim_capital
+    starting_capital = sim_capital
     ledger = Ledger(sim_capital)
 
     addlog(f"[SIM] Starting simulation for {tag}", verbose_int=1, verbose_state=verbose)
@@ -125,10 +125,12 @@ def run_simulation(tag: str, verbose: int = 0) -> None:
             ledger.set_capital(sim_capital)
             pbar.update(1)
 
-    summary = ledger.get_account_summary(start_capital)
-    save_ledger(ledger, summary["ending_value"])
+    total_liquid = ledger.get_total_liquid_value()
+    save_ledger(ledger, total_liquid)
     print(f"[SIM] Completed {len(df)} ticks.")
-    for k, v in summary.items():
-        label = k.replace("_", " ").title()
-        print(f"[SIM] {label}: {v}")
+    print(f"[SIM] Liquidatable value: {total_liquid:.2f}")
+    print(f"[SIM] Net gain: {total_liquid - starting_capital:.2f}")
+    print(
+        f"[SIM] ROI: {(total_liquid - starting_capital) / starting_capital * 100:.2f}%"
+    )
 


### PR DESCRIPTION
## Summary
- add `get_total_liquid_value` to `Ledger` for realized PnL, open note value, and idle capital
- update simulation engine to report liquidatable value, net gain, and ROI at run end

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688c83f467b08326b87222737fe7109e