### PR TITLE
Refactor ledger saving to store only raw state

### DIFF
--- a/systems/scripts/ledger.py
+++ b/systems/scripts/ledger.py
@@ -6,13 +6,15 @@ from typing import Dict, List
 
 
 class Ledger:
-    """Track open/closed notes, realised PnL and idle capital."""
+    """Track raw trade state and compute summary metrics on demand."""
 
     def __init__(self, capital: float = 0.0) -> None:
         self.capital: float = capital
         self.open_notes: List[Dict] = []
         self.closed_notes: List[Dict] = []
-        self.pnl: float = 0.0
+        self.deposits: List[Dict] = []
+        self.withdrawals: List[Dict] = []
+        self.metadata: Dict = {}
 
     # Basic note management -------------------------------------------------
     def open_note(self, note: Dict) -> None:
@@ -20,14 +22,11 @@ class Ledger:
         self.open_notes.append(note)
 
     def close_note(self, note: Dict) -> None:
-        """Move ``note`` from open to closed and update realised PnL."""
+        """Move ``note`` from open to closed."""
         if note not in self.open_notes:
             return
         self.open_notes.remove(note)
         self.closed_notes.append(note)
-        entry = float(note.get("entry_usdt", 0))
-        exit_ = float(note.get("exit_usdt", 0))
-        self.pnl += exit_ - entry
 
     # Capital helpers -------------------------------------------------------
     def set_capital(self, value: float) -> None:
@@ -35,6 +34,27 @@ class Ledger:
 
     def get_capital(self) -> float:
         return self.capital
+
+    # Deposit/withdraw helpers ---------------------------------------------
+    def add_deposit(self, amount: float) -> None:
+        self.deposits.append({"amount": float(amount)})
+        self.capital += float(amount)
+
+    def add_withdrawal(self, amount: float) -> None:
+        self.withdrawals.append({"amount": float(amount)})
+        self.capital -= float(amount)
+
+    def get_deposits(self) -> List[Dict]:
+        return list(self.deposits)
+
+    def get_withdrawals(self) -> List[Dict]:
+        return list(self.withdrawals)
+
+    def set_metadata(self, metadata: Dict) -> None:
+        self.metadata = metadata
+
+    def get_metadata(self) -> Dict:
+        return dict(self.metadata)
 
     # Accessors -------------------------------------------------------------
     def get_open_notes(self) -> List[Dict]:
@@ -48,33 +68,34 @@ class Ledger:
 
     def get_total_liquid_value(self) -> float:
         """Return all capital that could be withdrawn immediately."""
-        realised_pnl = sum(n["gain_usdt"] for n in self.get_closed_notes())
+        realised = sum(n.get("gain_usdt", 0) for n in self.get_closed_notes())
         open_value = sum(
-            n["entry_amount"] * n["entry_price"] for n in self.get_open_notes()
+            n.get("entry_amount", 0) * n.get("entry_price", 0)
+            for n in self.get_open_notes()
         )
         idle_capital = self.get_capital()
-        return realised_pnl + open_value + idle_capital
+        return realised + open_value + idle_capital
 
     # Summary ---------------------------------------------------------------
     def get_account_summary(self, starting_capital: float) -> dict:
-        realised_pnl = sum(n.get("gain_usdt", 0) for n in self.get_closed_notes())
+        realised = sum(n.get("gain_usdt", 0) for n in self.get_closed_notes())
         idle_capital = self.get_capital()
         open_value = sum(
-            n.get("entry_amount", 0) * n.get("entry_price", 0) for n in self.get_open_notes()
+            n.get("entry_amount", 0) * n.get("entry_price", 0)
+            for n in self.get_open_notes()
         )
-        ending_value = self.get_total_liquid_value()
-        net_gain = ending_value - starting_capital
+        total_value = realised + open_value + idle_capital
+        net_gain = total_value - starting_capital
         roi = (net_gain / starting_capital) * 100 if starting_capital else 0.0
 
         return {
             "starting_capital": round(starting_capital, 2),
-            "realised_pnl": round(realised_pnl, 2),
+            "realised_gain": round(realised, 2),
+            "open_value": round(open_value, 2),
             "idle_capital": round(idle_capital, 2),
-            "open_note_value": round(open_value, 2),
-            "ending_value": round(ending_value, 2),
+            "total_value": round(total_value, 2),
             "net_gain": round(net_gain, 2),
-            "roi_pct": round(roi, 2),
+            "roi": round(roi, 2),
             "closed_notes": len(self.get_closed_notes()),
             "open_notes": len(self.get_open_notes()),
-            "total_notes": len(self.get_closed_notes()) + len(self.get_open_notes()),
         }

--- a/systems/sim_engine.py
+++ b/systems/sim_engine.py
@@ -125,12 +125,10 @@ def run_simulation(tag: str, verbose: int = 0) -> None:
             ledger.set_capital(sim_capital)
             pbar.update(1)
 
-    total_liquid = ledger.get_total_liquid_value()
-    save_ledger(ledger, total_liquid)
+    save_ledger(tag, ledger)
+    summary = ledger.get_account_summary(starting_capital)
     print(f"[SIM] Completed {len(df)} ticks.")
-    print(f"[SIM] Liquidatable value: {total_liquid:.2f}")
-    print(f"[SIM] Net gain: {total_liquid - starting_capital:.2f}")
-    print(
-        f"[SIM] ROI: {(total_liquid - starting_capital) / starting_capital * 100:.2f}%"
-    )
+    for k, v in summary.items():
+        label = k.replace("_", " ").title()
+        print(f"[SIM] {label}: {v}")
 


### PR DESCRIPTION
## Summary
- ensure ledgers only persist raw trading data
- add deposit/withdraw tracking and live summary methods to Ledger
- print final account summary using ledger helpers

## Testing
- `pytest`
- `python -m py_compile scripts/ledger_manager.py systems/scripts/ledger.py systems/sim_engine.py`


------
https://chatgpt.com/codex/tasks/task_e_688c8ab2ce048326afc5a1adf12e2946