### PR TITLE
chore: persist ledger state only

### DIFF
--- a/systems/scripts/ledger.py
+++ b/systems/scripts/ledger.py
@@ -117,7 +117,6 @@ class Ledger:
             ledger.closed_notes = data.get("closed_notes", [])
             ledger.deposits = data.get("deposits", [])
             ledger.withdrawals = data.get("withdrawals", [])
-            ledger.capital = data.get("capital", 0.0)
             ledger.metadata = data.get("metadata", {})
         return ledger
 
@@ -134,7 +133,6 @@ class Ledger:
             "closed_notes": ledger.get_closed_notes(),
             "deposits": ledger.get_deposits(),
             "withdrawals": ledger.get_withdrawals(),
-            "capital": ledger.get_capital(),
         }
         metadata = ledger.get_metadata()
         if metadata:

--- a/systems/sim_engine.py
+++ b/systems/sim_engine.py
@@ -18,6 +18,14 @@ from systems.utils.logger import addlog
 from systems.utils.settings_loader import load_settings
 
 
+def assert_summary_match(summary_dict: dict, ledger: Ledger, starting_capital: float) -> None:
+    """Ensure ``summary_dict`` reflects ``ledger`` state."""
+    true_summary = ledger.get_account_summary(starting_capital)
+    for k, v in summary_dict.items():
+        assert abs(true_summary[k] - v) < 1e-2, (
+            f"[ASSERT FAIL] Mismatch in {k}: {v} ≠ {true_summary[k]}"
+        )
+
 
 def run_simulation(tag: str, verbose: int = 0) -> None:
     """Run a historical simulation for ``tag``."""
@@ -130,4 +138,6 @@ def run_simulation(tag: str, verbose: int = 0) -> None:
     for k, v in summary.items():
         label = k.replace("_", " ").title()
         print(f"[SIM] {label}: {v}")
+
+    assert_summary_match(summary, ledger, starting_capital)
 


### PR DESCRIPTION
## Summary
- drop derived metrics from ledger persistence
- validate simulation summary against ledger state

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688c8f72f77c8326a1944075c9b62017