### PR TITLE
Add cooldown windows and minimum ROI gate

### DIFF
--- a/settings/settings.json
+++ b/settings/settings.json
@@ -21,7 +21,7 @@
         "window_size": "1d",
         "buy_cooldown": 4,
         "sell_cooldown": 4,
-        "min_roi_pct": 2.5,
+        "min_roi": 0.04,
         "investment_fraction": 0.03,
         "buy_floor": 0.2,
         "sell_ceiling": 0.8,

--- a/settings/settings.json
+++ b/settings/settings.json
@@ -19,14 +19,15 @@
     "windows": {
       "fish": {
         "window_size": "1d",
-        "cooldown": 1,
+        "buy_cooldown": 4,
+        "sell_cooldown": 4,
+        "min_roi_pct": 2.5,
         "investment_fraction": 0.03,
         "buy_floor": 0.2,
         "sell_ceiling": 0.8,
         "max_open_notes": 100
       }
     },
-    "roi_gain_multiplier": 1,
     "max_note_usdt": 300.0,
     "minimum_note_size": 5
   },

--- a/systems/scripts/evaluate_buy.py
+++ b/systems/scripts/evaluate_buy.py
@@ -39,7 +39,7 @@ def evaluate_buy(
                 amount = invest / price
                 configured_mature = wave["floor"] + wave["range"] * cfg.get("sell_ceiling", 1)
                 configured_roi = (configured_mature - price) / price
-                min_roi = cfg.get("min_roi_pct", 0) / 100.0
+                min_roi = cfg.get("min_roi", 0)
                 target_roi = max(configured_roi, min_roi)
                 mature_price = price * (1 + target_roi)
                 note = {

--- a/systems/scripts/evaluate_buy.py
+++ b/systems/scripts/evaluate_buy.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 """Buy helper for the simulation engine."""
 
-from typing import Dict
+from typing import Dict, Tuple
 
 from systems.scripts.ledger import Ledger
 from systems.utils.logger import addlog
@@ -21,33 +21,42 @@ def evaluate_buy(
     max_note_usdt: float,
     min_note_usdt: float,
     verbose: int,
-) -> float:
-    """Attempt to open a new note if buy conditions are met."""
+) -> Tuple[float, bool]:
+    """Attempt to open a new note if buy conditions are met.
+
+    Returns updated capital and whether the attempt was skipped due to cooldown.
+    """
     position = wave["position_in_window"]
+    buy_cooldown = cfg.get("buy_cooldown", 0)
+    if tick - last_buy_tick.get(name, float("-inf")) < buy_cooldown:
+        return sim_capital, True
     if position <= cfg.get("buy_floor", 0):
-        cooldown = cfg.get("cooldown", 0)
-        if tick - last_buy_tick.get(name, float("-inf")) >= cooldown:
-            open_for_window = [n for n in ledger.get_active_notes() if n["window"] == name]
-            if len(open_for_window) < cfg.get("max_open_notes", 0):
-                invest = sim_capital * cfg.get("investment_fraction", 0)
-                invest = min(invest, max_note_usdt)
-                if invest >= min_note_usdt and invest <= sim_capital:
-                    amount = invest / price
-                    mature_price = wave["floor"] + wave["range"] * cfg.get("sell_ceiling", 1)
-                    note = {
-                        "window": name,
-                        "entry_tick": tick,
-                        "entry_price": price,
-                        "entry_amount": amount,
-                        "mature_price": mature_price,
-                        "status": "Open",
-                    }
-                    ledger.open_note(note)
-                    sim_capital -= invest
-                    last_buy_tick[name] = tick
-                    addlog(
-                        f"[BUY] {name} tick {tick} price={price:.6f}",
-                        verbose_int=2,
-                        verbose_state=verbose,
-                    )
-    return sim_capital
+        open_for_window = [n for n in ledger.get_active_notes() if n["window"] == name]
+        if len(open_for_window) < cfg.get("max_open_notes", 0):
+            invest = sim_capital * cfg.get("investment_fraction", 0)
+            invest = min(invest, max_note_usdt)
+            if invest >= min_note_usdt and invest <= sim_capital:
+                amount = invest / price
+                configured_mature = wave["floor"] + wave["range"] * cfg.get("sell_ceiling", 1)
+                configured_roi = (configured_mature - price) / price
+                min_roi = cfg.get("min_roi_pct", 0) / 100.0
+                target_roi = max(configured_roi, min_roi)
+                mature_price = price * (1 + target_roi)
+                note = {
+                    "window": name,
+                    "entry_tick": tick,
+                    "buy_tick": tick,
+                    "entry_price": price,
+                    "entry_amount": amount,
+                    "mature_price": mature_price,
+                    "status": "Open",
+                }
+                ledger.open_note(note)
+                sim_capital -= invest
+                last_buy_tick[name] = tick
+                addlog(
+                    f"[BUY] {name} tick {tick} price={price:.6f}",
+                    verbose_int=2,
+                    verbose_state=verbose,
+                )
+    return sim_capital, False

--- a/systems/scripts/evaluate_sell.py
+++ b/systems/scripts/evaluate_sell.py
@@ -22,7 +22,7 @@ def evaluate_sell(
     Returns updated capital, the list of notes closed at this tick, and the
     number of notes that failed the minimum ROI requirement.
     """
-    min_roi = cfg.get("min_roi_pct", 0) / 100.0
+    min_roi = cfg.get("min_roi", 0)
     to_close: List[Dict] = []
     roi_skipped = 0
     for note in ledger.get_active_notes():

--- a/systems/scripts/evaluate_sell.py
+++ b/systems/scripts/evaluate_sell.py
@@ -13,16 +13,26 @@ def evaluate_sell(
     name: str,
     tick: int,
     price: float,
+    cfg: Dict,
     sim_capital: float,
     verbose: int,
-) -> Tuple[float, List[Dict]]:
+) -> Tuple[float, List[Dict], int]:
     """Close notes that have reached their target price.
 
-    Returns updated capital and the list of notes closed at this tick.
+    Returns updated capital, the list of notes closed at this tick, and the
+    number of notes that failed the minimum ROI requirement.
     """
+    min_roi = cfg.get("min_roi_pct", 0) / 100.0
     to_close: List[Dict] = []
+    roi_skipped = 0
     for note in ledger.get_active_notes():
         if note["window"] != name:
+            continue
+        actual_roi = (price - note["entry_price"]) / note["entry_price"]
+        if actual_roi < min_roi:
+            if not note.get("min_roi_blocked"):
+                roi_skipped += 1
+                note["min_roi_blocked"] = True
             continue
         if price >= note["mature_price"]:
             gain = (price - note["entry_price"]) * note["entry_amount"]
@@ -39,4 +49,4 @@ def evaluate_sell(
         ledger.close_note(note)
         sim_capital += note["entry_amount"] * price
         closed.append(note)
-    return sim_capital, closed
+    return sim_capital, closed, roi_skipped


### PR DESCRIPTION
## Summary
- configure per-window `buy_cooldown`, `sell_cooldown`, and `min_roi_pct`
- enforce buy cooldowns and minimum ROI targets when opening notes
- block sells until minimum ROI is met and surface cooldown/ROI statistics

## Testing
- `python bot.py --mode sim --tag DOGEUSD -v`

------
https://chatgpt.com/codex/tasks/task_e_688ceb2960288326981308154f0fc3f8