### PR TITLE
Add debug checks around simulation ledger

### DIFF
--- a/systems/scripts/ledger.py
+++ b/systems/scripts/ledger.py
@@ -93,7 +93,13 @@ class Ledger:
         return ledger
 
     @staticmethod
-    def save_ledger(tag: str, ledger: "Ledger") -> None:
+    def save_ledger(
+        tag: str,
+        ledger: "Ledger",
+        *,
+        final_tick: int | None = None,
+        summary: dict | None = None,
+    ) -> None:
         """Persist ``ledger`` to ``data/ledgers/<tag>.json``."""
         root = find_project_root()
         out_dir = root / "data" / "ledgers"
@@ -104,6 +110,16 @@ class Ledger:
             "open_notes": ledger.get_open_notes(),
             "closed_notes": ledger.get_closed_notes(),
         }
+
+        if final_tick is not None:
+            ledger_data["final_tick"] = final_tick
+
+        if summary:
+            ledger_data["closed_notes_count"] = summary.get("closed_notes")
+            ledger_data["open_notes_count"] = summary.get("open_notes")
+            ledger_data["realized_gain"] = summary.get("realized_gain")
+            ledger_data["final_value"] = summary.get("total_value")
+
         metadata = ledger.get_metadata()
         if metadata:
             ledger_data["metadata"] = metadata

--- a/systems/sim_engine.py
+++ b/systems/sim_engine.py
@@ -106,10 +106,23 @@ def run_simulation(tag: str, verbose: int = 0) -> None:
 
     print(f"[SIM] Completed {len(df)} ticks.")
 
+    final_tick = len(df) - 1 if total else -1
     final_price = float(df.iloc[-1]["close"])
     summary = ledger.get_account_summary(final_price)
 
-    Ledger.save_ledger(tag, ledger)
+    print(f"[DEBUG] Final tick: {final_tick}")
+    Ledger.save_ledger(tag, ledger, final_tick=final_tick, summary=summary)
+
+    saved_summary = Ledger.load_ledger(tag).get_account_summary(final_price)
+    if (
+        saved_summary["closed_notes"] != summary["closed_notes"]
+        or saved_summary["realized_gain"] != summary["realized_gain"]
+    ):
+        print(
+            "[WARN] Summary/ledger mismatch: "
+            f"closed_notes {summary['closed_notes']} vs {saved_summary['closed_notes']}, "
+            f"realized_gain {summary['realized_gain']:.2f} vs {saved_summary['realized_gain']:.2f}"
+        )
 
     print(f"Final Price: ${summary['final_price']:.2f}")
     print(f"Total Coin Held: {summary['open_coin_amount']:.6f}")


### PR DESCRIPTION
## Summary
- include final tick and summary metrics in persisted ledger files
- print simulation's final tick and warn if ledger summary diverges after save

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688cf4ede9d48326bb0a6a71e2a948d6