### PR TITLE
refactor: migrate to ledger settings

### DIFF
--- a/settings/settings.json
+++ b/settings/settings.json
@@ -1,35 +1,48 @@
 {
-  "symbol_settings": {
-    "DOGEUSD": {
-      "owner": "Chris",
+  "ledger_settings": {
+    "Kris_Ledger": {
+      "tag": "DOGEUSD",
       "wallet_code": "XXDG",
       "kraken_name": "DOGE/USD",
       "binance_name": "DOGEUSDT",
-      "fiat": "ZUSD"
+      "fiat": "ZUSD",
+      "window_settings": {
+        "fish": {
+          "window_size": "1d",
+          "buy_cooldown": 4,
+          "sell_cooldown": 8,
+          "min_roi": 0.15,
+          "investment_fraction": 0.1,
+          "buy_floor": 0.25,
+          "sell_ceiling": 0.75,
+          "max_open_notes": 100
+        }
+      }
     },
-    "SOLUSD": {
-      "owner": "Travis",
+    "Travis_Ledger": {
+      "tag": "SOLUSD",
       "wallet_code": "SOL.F",
       "kraken_name": "SOL/USD",
       "binance_name": "SOLUSDT",
-      "fiat": "DAI"
+      "fiat": "DAI",
+      "window_settings": {
+        "fish": {
+          "window_size": "1d",
+          "buy_cooldown": 4,
+          "sell_cooldown": 8,
+          "min_roi": 0.15,
+          "investment_fraction": 0.1,
+          "buy_floor": 0.25,
+          "sell_ceiling": 0.75,
+          "max_open_notes": 100
+        }
+      }
     }
   },
   "general_settings": {
-    "windows": {
-      "fish": {
-        "window_size": "1d",
-        "buy_cooldown": 4,
-        "sell_cooldown": 8,
-        "min_roi": 0.15,
-        "investment_fraction": 0.1,
-        "buy_floor": 0.25,
-        "sell_ceiling": 0.75,
-        "max_open_notes": 100
-      }
-    },
     "max_note_usdt": 500.0,
     "minimum_note_size": 10
   },
   "simulation_capital": 10000
 }
+

--- a/systems/fetch.py
+++ b/systems/fetch.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from typing import List
 import sys
 import pandas as pd
-from systems.utils.resolve_symbol import resolve_symbol
+from systems.utils.resolve_symbol import resolve_ledger_settings
 from systems.utils.settings_loader import load_settings
 
 if __package__ is None or __package__ == "":
@@ -58,12 +58,9 @@ def main(argv: list[str] | None = None) -> None:
     verbose = args.verbose
 
     settings = load_settings()
-    if tag not in settings.get("symbol_settings", {}):
-        raise ValueError(f"Unknown symbol tag: {tag}")
-
-    symbols = resolve_symbol(tag)
-    kraken_symbol = symbols["kraken"]
-    binance_symbol = symbols["binance"]
+    ledger_cfg = resolve_ledger_settings(tag, settings)
+    kraken_symbol = ledger_cfg["kraken_name"]
+    binance_symbol = ledger_cfg["binance_name"]
 
     start_ts, end_ts = parse_relative_time(time_window)
     out_path = get_raw_path(tag)
@@ -275,9 +272,10 @@ def fetch_missing_candles(tag: str, relative_window: str = "48h", verbose: int =
     tag = tag.upper()
 
     try:
-        symbols = resolve_symbol(tag)
-        kraken_symbol = symbols["kraken"]
-        binance_symbol = symbols["binance"]
+        settings = load_settings()
+        ledger_cfg = resolve_ledger_settings(tag, settings)
+        kraken_symbol = ledger_cfg["kraken_name"]
+        binance_symbol = ledger_cfg["binance_name"]
     except Exception as e:
         raise RuntimeError(f"[ERROR] Failed to resolve symbol '{tag}': {e}")
 

--- a/systems/scripts/handle_top_of_hour.py
+++ b/systems/scripts/handle_top_of_hour.py
@@ -16,7 +16,7 @@ def handle_top_of_hour(
     tick: int,
     candle: dict,
     ledger: Ledger,
-    settings: dict,
+    ledger_config: dict,
     sim: bool,
     **kwargs: Any,
 ) -> None:
@@ -30,8 +30,8 @@ def handle_top_of_hour(
         Candle data for this tick.
     ledger:
         Ledger tracking open and closed notes.
-    settings:
-        Application settings.
+    ledger_config:
+        Ledger-specific configuration.
     sim:
         ``True`` when running in simulation mode. Live logic is not yet
         implemented.
@@ -47,7 +47,7 @@ def handle_top_of_hour(
     state: Dict[str, Any] = kwargs.get("state", {})
     verbose = kwargs.get("verbose", 0)
 
-    windows = settings.get("general_settings", {}).get("windows", {})
+    windows = ledger_config.get("window_settings", {})
     if not windows or df is None or offset is None:
         return
 

--- a/systems/sim_engine.py
+++ b/systems/sim_engine.py
@@ -15,19 +15,18 @@ from systems.scripts.ledger import Ledger
 from systems.scripts.handle_top_of_hour import handle_top_of_hour
 from systems.utils.logger import addlog
 from systems.utils.settings_loader import load_settings
+from systems.utils.resolve_symbol import resolve_ledger_settings
 
 
 def run_simulation(tag: str, verbose: int = 0) -> None:
     """Run a historical simulation for ``tag``."""
     settings = load_settings()
     tag = tag.upper()
-    symbol_meta = settings.get("symbol_settings", {}).get(tag)
-    if symbol_meta is None:
-        raise ValueError(f"Unknown symbol tag: {tag}")
+    ledger_config = resolve_ledger_settings(tag, settings)
 
-    windows = settings.get("general_settings", {}).get("windows", {})
+    windows = ledger_config.get("window_settings", {})
     if not windows:
-        raise ValueError("No windows defined in settings['general_settings']['windows']")
+        raise ValueError("No windows defined for ledger")
 
     sim_capital = float(settings.get("simulation_capital", 0))
     ledger = Ledger()
@@ -64,7 +63,7 @@ def run_simulation(tag: str, verbose: int = 0) -> None:
                     tick=tick,
                     candle=candle,
                     ledger=ledger,
-                    settings=settings,
+                    ledger_config=ledger_config,
                     sim=True,
                     df=df,
                     offset=offset,

--- a/systems/utils/resolve_symbol.py
+++ b/systems/utils/resolve_symbol.py
@@ -1,16 +1,25 @@
-from systems.scripts.loader import load_settings
+"""Helpers for resolving symbol and ledger configuration."""
+
+from systems.utils.settings_loader import load_settings
+
 
 SETTINGS = load_settings()
 
 
-def resolve_symbol(tag: str) -> dict:
+def resolve_ledger_settings(tag: str, settings: dict | None = None) -> dict:
+    """Return ledger configuration matching ``tag``."""
+    cfg = settings or SETTINGS
     tag = tag.upper()
-    entry = SETTINGS.get("symbol_settings", {}).get(tag)
+    for ledger in cfg.get("ledger_settings", {}).values():
+        if ledger.get("tag") == tag:
+            return ledger
+    raise ValueError(f"No ledger found for tag: {tag}")
 
-    if not entry:
-        raise ValueError(f"No settings found for tag: {tag}")
 
+def resolve_symbol(tag: str) -> dict:
+    """Resolve exchange-specific pair names for ``tag``."""
+    ledger = resolve_ledger_settings(tag)
     return {
-        "kraken": entry["kraken_name"],
-        "binance": entry["binance_name"]
+        "kraken": ledger["kraken_name"],
+        "binance": ledger["binance_name"],
     }


### PR DESCRIPTION
## Summary
- replace symbol_settings with new ledger-based configuration
- add ledger resolver utilities and update data fetcher and simulation engine
- adapt window handler to read window settings from each ledger

## Testing
- `python -m py_compile systems/utils/resolve_symbol.py systems/fetch.py systems/sim_engine.py systems/scripts/handle_top_of_hour.py`


------
https://chatgpt.com/codex/tasks/task_e_688d04d2511483268b2a303968e79160