### PR TITLE
Add live engine with dry-run top-of-hour trigger

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -28,6 +28,16 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         ),
     )
     parser.add_argument(
+        "--window",
+        required=False,
+        help="Window name (forward-compatible)",
+    )
+    parser.add_argument(
+        "--dry",
+        action="store_true",
+        help="Run live mode once immediately and exit",
+    )
+    parser.add_argument(
         "-v",
         "--verbose",
         action="count",
@@ -82,7 +92,12 @@ def main(argv: list[str] | None = None) -> None:
     if mode == "sim":
         run_simulation(tag=args.tag.upper(), verbose=args.verbose)
     elif mode == "live":
-        run_live(tag=args.tag.upper() if args.tag else None, verbose=args.verbose)
+        run_live(
+            tag=args.tag.upper() if args.tag else None,
+            window=args.window,
+            dry=args.dry,
+            verbose=args.verbose,
+        )
     else:
         addlog("Error: --mode must be either 'sim', 'live', or 'wallet'")
         sys.exit(1)

--- a/systems/scripts/handle_top_of_hour.py
+++ b/systems/scripts/handle_top_of_hour.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 """Execute trading logic at the top of each hour."""
 
-from typing import Dict, Any
+from datetime import datetime
+from typing import Any, Dict
 
 from systems.scripts.evaluate_buy import evaluate_buy
 from systems.scripts.evaluate_sell import evaluate_sell
@@ -13,11 +14,12 @@ from systems.utils.logger import addlog
 
 def handle_top_of_hour(
     *,
-    tick: int,
-    candle: dict,
-    ledger: Ledger,
-    ledger_config: dict,
+    tick: int | datetime,
     sim: bool,
+    settings: dict | None = None,
+    candle: dict | None = None,
+    ledger: Ledger | None = None,
+    ledger_config: dict | None = None,
     **kwargs: Any,
 ) -> None:
     """Run buy/sell evaluations for all windows on an hourly boundary.
@@ -40,6 +42,15 @@ def handle_top_of_hour(
         ``offset`` for window calculations along with a mutable ``state``
         dictionary containing capital and cooldown counters.
     """
+
+    if not sim:
+        print("[LIVE] Top of Hour triggered")
+        print(f"Timestamp: {tick}")
+        print("[LIVE] Placeholder for per-ledger actions")
+        return
+
+    if candle is None or ledger is None or ledger_config is None:
+        return
 
     # Extract common context
     df = kwargs.get("df")


### PR DESCRIPTION
## Summary
- add `--window` and `--dry` options to CLI and wire through to live engine
- implement real `systems/live_engine` with progress bar and dry run support
- extend `handle_top_of_hour` to handle live mode and print a placeholder

## Testing
- `pytest`
- `python bot.py --mode live --dry`


------
https://chatgpt.com/codex/tasks/task_e_688d0949b7bc83269ce86944b8e8bbf9