### PR TITLE
Add candle sync to dry live run and ledger-prefixed output

### DIFF
--- a/systems/live_engine.py
+++ b/systems/live_engine.py
@@ -11,6 +11,7 @@ from tqdm import tqdm
 
 from systems.scripts.handle_top_of_hour import handle_top_of_hour
 from systems.utils.settings_loader import load_settings
+from systems.fetch import fetch_missing_candles
 
 
 def run_live(
@@ -27,6 +28,10 @@ def run_live(
     tick_time = datetime.now(timezone.utc)
 
     if dry:
+        for ledger_key, ledger_cfg in settings.get("ledger_settings", {}).items():
+            tag = ledger_cfg.get("tag")
+            fetch_missing_candles(tag, relative_window="48h", verbose=verbose)
+            print(f"[SYNC] {ledger_key} | {tag} candles up to date")
         print("[LIVE] Running top of hour")
         handle_top_of_hour(tick=tick_time, settings=settings, sim=False)
         return

--- a/systems/scripts/handle_top_of_hour.py
+++ b/systems/scripts/handle_top_of_hour.py
@@ -133,7 +133,7 @@ def handle_top_of_hour(
                                     last_buy_tick[window_name] = current_ts
                                     buy_count += 1
                                     addlog(
-                                        f"[LIVE][BUY] {tag} | {result['filled_amount']:.4f} {wallet_code} @ ${result['avg_price']:.3f}"
+                                        f"[LIVE][BUY] {ledger_name} | {tag} | {result['filled_amount']:.4f} {wallet_code} @ ${result['avg_price']:.3f}"
                                     )
 
                     sell_cd = window_cfg.get("sell_cooldown", 0) * 3600
@@ -162,11 +162,11 @@ def handle_top_of_hour(
                                 last_sell_tick[window_name] = current_ts
                                 sell_count += 1
                                 addlog(
-                                    f"[LIVE][SELL] {tag} | Gain: ${gain:.2f} ({note['gain_pct']:.2%})"
+                                    f"[LIVE][SELL] {ledger_name} | {tag} | Gain: ${gain:.2f} ({note['gain_pct']:.2%})"
                                 )
 
                 summary = ledger.get_account_summary(price)
-                print(f"[LIVE] {tag} | {window_name} window")
+                print(f"[LIVE] {ledger_name} | {tag} | {window_name} window")
                 print(
                     f"✅ Buy attempts: {buy_count} | Sells: {sell_count} | Open Notes: {summary['open_notes']} | Realized Gain: ${summary['realized_gain']:.2f}"
                 )


### PR DESCRIPTION
## Summary
- Auto-fetch and sync recent candles before executing a dry live run
- Prefix all live output with the ledger name for clearer logs

## Testing
- `pytest`
- `python -m systems.live_engine --dry`

------
https://chatgpt.com/codex/tasks/task_e_688d371d81ac832690ff5b5d285568fc