### PR TITLE
check fiat balance before live buy

### DIFF
--- a/systems/scripts/execution_handler.py
+++ b/systems/scripts/execution_handler.py
@@ -186,15 +186,19 @@ def execute_buy(
     Parameters are kept for API compatibility; ``client`` and ``price`` are
     currently unused as ``buy_order`` pulls pricing from Kraken directly.
     """
-    if client is not None:
+    if client is None:
+        balance = get_kraken_balance(verbose)
+        fiat_balance = float(balance.get(fiat_code, 0.0))
+    else:
         fiat_balance = get_available_fiat_balance(client, fiat_code)
-        if fiat_balance < amount_usd:
-            addlog(
-                f"[SKIP] Insufficient funds to buy {symbol} — need ${amount_usd:.2f}, have ${fiat_balance:.2f}",
-                verbose_int=1,
-                verbose_state=verbose,
-            )
-            return None
+
+    if fiat_balance < amount_usd:
+        addlog(
+            f"[SKIP] Insufficient funds to buy {symbol} — need ${amount_usd:.2f}, have ${fiat_balance:.2f}",
+            verbose_int=1,
+            verbose_state=verbose,
+        )
+        return None
 
     fills = buy_order(symbol, fiat_code, amount_usd, verbose)
     if not fills:


### PR DESCRIPTION
## Summary
- verify live USD balance before placing Kraken buy orders
- skip buy and log a warning when funds are insufficient

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688d3cac2dbc83269d6b46a66fd8c282