### PR TITLE
Use wallet code for live fiat balance checks

### DIFF
--- a/systems/scripts/handle_top_of_hour.py
+++ b/systems/scripts/handle_top_of_hour.py
@@ -112,6 +112,7 @@ def handle_top_of_hour(
                                     fiat_code=fiat,
                                     price=price,
                                     amount_usd=invest,
+                                    symbol_info=ledger_cfg,
                                 )
                                 if result:
                                     note = {


### PR DESCRIPTION
## Summary
- ensure live buys verify the correct wallet balance using ledger wallet codes
- pass ledger settings through to buys for accurate balance checks

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688d4011c65883269845a44ee4527356