### PR TITLE
refactor: replace prints with addlog

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -75,18 +75,17 @@ def main(argv: list[str] | None = None) -> None:
         balances = get_kraken_balance(verbose)
 
         if verbose >= 1:
-            print("[WALLET] Kraken Balance")
-            if verbose >= 2:
-                print(balances)
+            addlog("[WALLET] Kraken Balance", verbose_int=1, verbose_state=verbose)
+            addlog(str(balances), verbose_int=2, verbose_state=verbose)
             for asset, amount in balances.items():
                 val = float(amount)
                 if val == 0:
                     continue
                 fmt = f"{val:.2f}" if val > 1 else f"{val:.6f}"
                 if asset.upper() in {"ZUSD", "USD", "USDT"}:
-                    print(f"{asset}: ${fmt}")
+                    addlog(f"{asset}: ${fmt}", verbose_int=1, verbose_state=verbose)
                 else:
-                    print(f"{asset}: {fmt}")
+                    addlog(f"{asset}: {fmt}", verbose_int=1, verbose_state=verbose)
         return
 
     if mode == "sim":

--- a/systems/live_engine.py
+++ b/systems/live_engine.py
@@ -12,6 +12,7 @@ from tqdm import tqdm
 from systems.scripts.handle_top_of_hour import handle_top_of_hour
 from systems.utils.settings_loader import load_settings
 from systems.fetch import fetch_missing_candles
+from systems.utils.logger import addlog
 
 
 def run_live(
@@ -31,8 +32,12 @@ def run_live(
         for ledger_key, ledger_cfg in settings.get("ledger_settings", {}).items():
             tag = ledger_cfg.get("tag")
             fetch_missing_candles(tag, relative_window="48h", verbose=verbose)
-            print(f"[SYNC] {ledger_key} | {tag} candles up to date")
-        print("[LIVE] Running top of hour")
+            addlog(
+                f"[SYNC] {ledger_key} | {tag} candles up to date",
+                verbose_int=1,
+                verbose_state=verbose,
+            )
+        addlog("[LIVE] Running top of hour", verbose_int=1, verbose_state=verbose)
         handle_top_of_hour(
             tick=tick_time,
             settings=settings,
@@ -59,7 +64,7 @@ def run_live(
                 time.sleep(1)
                 pbar.update(1)
 
-        print("[LIVE] Running top of hour")
+        addlog("[LIVE] Running top of hour", verbose_int=1, verbose_state=verbose)
         handle_top_of_hour(
             tick=datetime.now(timezone.utc),
             settings=settings,

--- a/systems/scripts/handle_top_of_hour.py
+++ b/systems/scripts/handle_top_of_hour.py
@@ -239,9 +239,15 @@ def handle_top_of_hour(
                     verbose_int=2,
                     verbose_state=True,
                 )
-                print(f"[LIVE] {ledger_name} | {tag} | {window_name} window")
-                print(
-                    f"✅ Buy attempts: {buy_count} | Sells: {sell_count} | Open Notes: {summary['open_notes']} | Realized Gain: ${summary['realized_gain']:.2f}"
+                addlog(
+                    f"[LIVE] {ledger_name} | {tag} | {window_name} window",
+                    verbose_int=1,
+                    verbose_state=True,
+                )
+                addlog(
+                    f"✅ Buy attempts: {buy_count} | Sells: {sell_count} | Open Notes: {summary['open_notes']} | Realized Gain: ${summary['realized_gain']:.2f}",
+                    verbose_int=1,
+                    verbose_state=True,
                 )
 
             if not dry_run:

--- a/systems/sim_engine.py
+++ b/systems/sim_engine.py
@@ -80,13 +80,21 @@ def run_simulation(tag: str, verbose: int = 0) -> None:
 
             pbar.update(1)
 
-    print(f"[SIM] Completed {len(df)} ticks.")
+    addlog(
+        f"[SIM] Completed {len(df)} ticks.",
+        verbose_int=1,
+        verbose_state=verbose,
+    )
 
     final_tick = len(df) - 1 if total else -1
     final_price = float(df.iloc[-1]["close"])
     summary = ledger.get_account_summary(final_price)
 
-    print(f"[DEBUG] Final tick: {final_tick}")
+    addlog(
+        f"[DEBUG] Final tick: {final_tick}",
+        verbose_int=3,
+        verbose_state=verbose,
+    )
     Ledger.save_ledger(tag, ledger, sim=True, final_tick=final_tick, summary=summary)
 
     saved_summary = Ledger.load_ledger(tag, sim=True).get_account_summary(final_price)
@@ -94,18 +102,44 @@ def run_simulation(tag: str, verbose: int = 0) -> None:
         saved_summary["closed_notes"] != summary["closed_notes"]
         or saved_summary["realized_gain"] != summary["realized_gain"]
     ):
-        print(
+        addlog(
             "[WARN] Summary/ledger mismatch: "
             f"closed_notes {summary['closed_notes']} vs {saved_summary['closed_notes']}, "
-            f"realized_gain {summary['realized_gain']:.2f} vs {saved_summary['realized_gain']:.2f}"
+            f"realized_gain {summary['realized_gain']:.2f} vs {saved_summary['realized_gain']:.2f}",
+            verbose_int=1,
+            verbose_state=verbose,
         )
 
-    print(f"Final Price: ${summary['final_price']:.2f}")
-    print(f"Total Coin Held: {summary['open_coin_amount']:.6f}")
-    print(f"Final Value (USD): ${summary['total_value']:.2f}")
+    addlog(
+        f"Final Price: ${summary['final_price']:.2f}",
+        verbose_int=1,
+        verbose_state=verbose,
+    )
+    addlog(
+        f"Total Coin Held: {summary['open_coin_amount']:.6f}",
+        verbose_int=1,
+        verbose_state=verbose,
+    )
+    addlog(
+        f"Final Value (USD): ${summary['total_value']:.2f}",
+        verbose_int=1,
+        verbose_state=verbose,
+    )
 
     if verbose:
-        print(f"Buy cooldown skips: {state['buy_cooldown_skips']}")
-        print(f"Sell cooldown skips: {state['sell_cooldown_skips']}")
-    print(f"Min ROI gate hits: {state['min_roi_gate_hits']}")
+        addlog(
+            f"Buy cooldown skips: {state['buy_cooldown_skips']}",
+            verbose_int=2,
+            verbose_state=verbose,
+        )
+        addlog(
+            f"Sell cooldown skips: {state['sell_cooldown_skips']}",
+            verbose_int=2,
+            verbose_state=verbose,
+        )
+    addlog(
+        f"Min ROI gate hits: {state['min_roi_gate_hits']}",
+        verbose_int=1,
+        verbose_state=verbose,
+    )
 


### PR DESCRIPTION
## Summary
- route wallet balance output through addlog for verbosity control
- use addlog for live engine sync and hourly run messages
- standardize simulation logging and summaries via addlog
- convert live summary prints in handle_top_of_hour to addlog

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688dfe21da7c8326b92d92ae705b5101