### PR TITLE
refactor: rename logger and add telegram override

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -7,7 +7,7 @@ import sys
 
 from systems.live_engine import run_live
 from systems.sim_engine import run_simulation
-from systems.utils.logger import init_logger, addlog
+from systems.utils.addlog import init_logger, addlog
 
 
 def parse_args(argv: list[str]) -> argparse.Namespace:

--- a/systems/fetch.py
+++ b/systems/fetch.py
@@ -18,7 +18,7 @@ from systems.utils.time import parse_relative_time
 from systems.utils.path import find_project_root
 
 from tqdm import tqdm
-from systems.utils.logger import addlog
+from systems.utils.addlog import addlog
 from systems.scripts.fetch_core import (
     _fetch_kraken,
     _fetch_binance,

--- a/systems/live_engine.py
+++ b/systems/live_engine.py
@@ -12,7 +12,7 @@ from tqdm import tqdm
 from systems.scripts.handle_top_of_hour import handle_top_of_hour
 from systems.utils.settings_loader import load_settings
 from systems.fetch import fetch_missing_candles
-from systems.utils.logger import addlog
+from systems.utils.addlog import addlog
 
 
 def run_live(

--- a/systems/scripts/evaluate_buy.py
+++ b/systems/scripts/evaluate_buy.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Dict, Tuple
 
 from systems.scripts.ledger import Ledger
-from systems.utils.logger import addlog
+from systems.utils.addlog import addlog
 
 
 def evaluate_buy(

--- a/systems/scripts/execution_handler.py
+++ b/systems/scripts/execution_handler.py
@@ -6,7 +6,7 @@ import base64
 from urllib.parse import urlencode
 
 from systems.scripts.kraken_auth import load_kraken_keys
-from systems.utils.logger import addlog
+from systems.utils.addlog import addlog
 from systems.scripts.kraken_utils import (
     get_kraken_balance,
     get_live_price,

--- a/systems/scripts/get_candle_data.py
+++ b/systems/scripts/get_candle_data.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from typing import Dict, Any
 
 from systems.utils.path import find_project_root
-from systems.utils.logger import addlog
+from systems.utils.addlog import addlog
 
 
 def _extract_candle_row(df, row_offset: int = 0) -> dict | None:

--- a/systems/scripts/handle_top_of_hour.py
+++ b/systems/scripts/handle_top_of_hour.py
@@ -15,7 +15,7 @@ from systems.scripts.get_window_data import get_wave_window_data_df
 from systems.scripts.kraken_utils import get_live_price, get_kraken_balance
 from systems.scripts.execution_handler import execute_buy, execute_sell
 from systems.scripts.ledger import Ledger
-from systems.utils.logger import addlog
+from systems.utils.addlog import addlog
 from systems.utils.path import find_project_root
 
 
@@ -240,14 +240,12 @@ def handle_top_of_hour(
                     verbose_state=True,
                 )
                 addlog(
-                    f"[LIVE] {ledger_name} | {tag} | {window_name} window",
+                    f"[LIVE] {ledger_name} | {tag} | {window_name} window\n"
+                    f"✅ Buy attempts: {buy_count} | Sells: {sell_count} | "
+                    f"Open Notes: {summary['open_notes']} | Realized Gain: ${summary['realized_gain']:.2f}",
                     verbose_int=1,
                     verbose_state=True,
-                )
-                addlog(
-                    f"✅ Buy attempts: {buy_count} | Sells: {sell_count} | Open Notes: {summary['open_notes']} | Realized Gain: ${summary['realized_gain']:.2f}",
-                    verbose_int=1,
-                    verbose_state=True,
+                    telegram=True,
                 )
 
             if not dry_run:

--- a/systems/scripts/kraken_utils.py
+++ b/systems/scripts/kraken_utils.py
@@ -6,7 +6,7 @@ import base64
 from urllib.parse import urlencode
 
 from systems.scripts.kraken_auth import load_kraken_keys
-from systems.utils.logger import addlog
+from systems.utils.addlog import addlog
 from systems.utils.price_fetcher import get_price
 
 KRAKEN_API_URL = "https://api.kraken.com"

--- a/systems/scripts/trade_logic.py
+++ b/systems/scripts/trade_logic.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Dict
 
 from systems.scripts.ledger import Ledger
-from systems.utils.logger import addlog
+from systems.utils.addlog import addlog
 
 
 def maybe_buy(

--- a/systems/sim_engine.py
+++ b/systems/sim_engine.py
@@ -13,7 +13,7 @@ from tqdm import tqdm
 from systems.scripts.fetch_canles import fetch_candles
 from systems.scripts.ledger import Ledger
 from systems.scripts.handle_top_of_hour import handle_top_of_hour
-from systems.utils.logger import addlog
+from systems.utils.addlog import addlog
 from systems.utils.settings_loader import load_settings
 from systems.utils.resolve_symbol import resolve_ledger_settings
 from systems.utils.path import find_project_root

--- a/systems/utils/addlog.py
+++ b/systems/utils/addlog.py
@@ -46,7 +46,10 @@ def init_logger(
 
 
 def addlog(
-    message: str, verbose_int: int = 1, verbose_state: int | None = None
+    message: str,
+    verbose_int: int = 1,
+    verbose_state: int | None = None,
+    telegram: bool = False,
 ) -> None:
     """Write a log message if ``verbose_int`` is within ``verbose_state``."""
     if verbose_state is None:
@@ -56,7 +59,7 @@ def addlog(
 
     if should_output:
         tqdm.write(message)
-        if TELEGRAM_ENABLED and TELEGRAM_TOKEN and TELEGRAM_CHAT_ID:
+        if telegram and TELEGRAM_ENABLED and TELEGRAM_TOKEN and TELEGRAM_CHAT_ID:
             try:
                 url = f"https://api.telegram.org/bot{TELEGRAM_TOKEN}/sendMessage"
                 requests.post(


### PR DESCRIPTION
## Summary
- rename `logger.py` to `addlog.py`
- add optional `telegram` flag to `addlog` for per-message Telegram control
- funnel live trading summary prints through `addlog(..., telegram=True)`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688dffab8f7c832696e993f6a1ef71a6