### PR TITLE
refactor: separate telegram logging

### DIFF
--- a/systems/scripts/handle_top_of_hour.py
+++ b/systems/scripts/handle_top_of_hour.py
@@ -15,7 +15,7 @@ from systems.scripts.get_window_data import get_wave_window_data_df
 from systems.scripts.kraken_utils import get_live_price, get_kraken_balance
 from systems.scripts.execution_handler import execute_buy, execute_sell
 from systems.scripts.ledger import Ledger
-from systems.utils.addlog import addlog
+from systems.utils.addlog import addlog, send_telegram_message
 from systems.utils.path import find_project_root
 from systems.utils.top_hour_report import format_top_of_hour_report
 
@@ -243,14 +243,17 @@ def handle_top_of_hour(
                     verbose_int=2,
                     verbose_state=True,
                 )
-                addlog(
+                message = (
                     f"[LIVE] {ledger_name} | {tag} | {window_name} window\n"
                     f"✅ Buy attempts: {buy_count} | Sells: {sell_count} | "
-                    f"Open Notes: {summary['open_notes']} | Realized Gain: ${summary['realized_gain']:.2f}",
+                    f"Open Notes: {summary['open_notes']} | Realized Gain: ${summary['realized_gain']:.2f}"
+                )
+                addlog(
+                    message,
                     verbose_int=1,
                     verbose_state=True,
-                    telegram=True,
                 )
+                send_telegram_message(message)
 
             if not dry_run:
                 metadata["last_buy_tick"] = last_buy_tick

--- a/systems/utils/addlog.py
+++ b/systems/utils/addlog.py
@@ -45,11 +45,28 @@ def init_logger(
             _TELEGRAM_WARNED = True
 
 
+def send_telegram_message(message: str) -> None:
+    """Send a Telegram message if credentials are available."""
+    global _TELEGRAM_WARNED
+    if not (TELEGRAM_ENABLED and TELEGRAM_TOKEN and TELEGRAM_CHAT_ID):
+        return
+    try:
+        url = f"https://api.telegram.org/bot{TELEGRAM_TOKEN}/sendMessage"
+        requests.post(
+            url,
+            data={"chat_id": TELEGRAM_CHAT_ID, "text": message},
+            timeout=5,
+        )
+    except Exception as exc:
+        if not _TELEGRAM_WARNED:
+            tqdm.write(f"[WARN] Telegram send failed: {exc}")
+            _TELEGRAM_WARNED = True
+
+
 def addlog(
     message: str,
     verbose_int: int = 1,
     verbose_state: int | None = None,
-    telegram: bool = False,
 ) -> None:
     """Write a log message if ``verbose_int`` is within ``verbose_state``."""
     if verbose_state is None:
@@ -59,19 +76,6 @@ def addlog(
 
     if should_output:
         tqdm.write(message)
-        if telegram and TELEGRAM_ENABLED and TELEGRAM_TOKEN and TELEGRAM_CHAT_ID:
-            try:
-                url = f"https://api.telegram.org/bot{TELEGRAM_TOKEN}/sendMessage"
-                requests.post(
-                    url,
-                    data={"chat_id": TELEGRAM_CHAT_ID, "text": message},
-                    timeout=5,
-                )
-            except Exception as exc:
-                global _TELEGRAM_WARNED
-                if not _TELEGRAM_WARNED:
-                    tqdm.write(f"[WARN] Telegram send failed: {exc}")
-                    _TELEGRAM_WARNED = True
 
     if LOGGING_ENABLED:
         with open(LOGFILE_PATH, "a", encoding="utf-8") as f:

--- a/test_send_telegram.py
+++ b/test_send_telegram.py
@@ -1,0 +1,12 @@
+"""Utility script to send a test message via the Telegram bot."""
+
+from __future__ import annotations
+
+from systems.utils.addlog import send_telegram_message, init_logger
+
+
+if __name__ == "__main__":
+    init_logger(telegram_enabled=True)
+    send_telegram_message("✅ This is a test message from WindowSurfer bot.")
+    print("Message sent.")
+


### PR DESCRIPTION
## Summary
- separate Telegram messaging from `addlog` with new `send_telegram_message` helper
- update log calls to use new helper
- add `test_send_telegram.py` script for sending a test bot message

## Testing
- `python -m py_compile systems/utils/addlog.py systems/scripts/handle_top_of_hour.py test_send_telegram.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688e4f2fe9488326b92b9f2f6f47e706