### PR TITLE
feat: save Kraken snapshots to dedicated directory

### DIFF
--- a/systems/scripts/prime_kraken_snapshot.py
+++ b/systems/scripts/prime_kraken_snapshot.py
@@ -38,7 +38,7 @@ def prime_kraken_snapshot(api_key: str, api_secret: str, ledger_name: str, verbo
     }
 
     root = find_project_root()
-    snap_dir = root / "data" / "tmp" / "kraken_snapshots"
+    snap_dir = root / "data" / "snapshots"
     snap_dir.mkdir(parents=True, exist_ok=True)
     path = snap_dir / f"{ledger_name}.json"
     with open(path, "w") as f:


### PR DESCRIPTION
## Summary
- store hourly Kraken snapshot data under `data/snapshots`

## Testing
- `python -m py_compile systems/scripts/prime_kraken_snapshot.py`
- `ls -lh data/snapshots/*.json`


------
https://chatgpt.com/codex/tasks/task_e_688e646b623083268c0262fee9521308