### PR TITLE
Mirror buy/sell logs to Telegram

### DIFF
--- a/systems/utils/addlog.py
+++ b/systems/utils/addlog.py
@@ -79,3 +79,6 @@ def addlog(
     if LOGGING_ENABLED:
         with open(LOGFILE_PATH, "a", encoding="utf-8") as f:
             f.write(message + "\n")
+
+    if message.startswith("[LIVE][BUY]") or message.startswith("[SELL]"):
+        send_telegram_message(message)


### PR DESCRIPTION
## Summary
- mirror buy and sell log messages to Telegram by reusing the existing log string

## Testing
- `python -m py_compile systems/utils/addlog.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688e7f34daf88326a785f8337e5e415a