### PR TITLE
Use explicit Kraken pair and wallet code

### DIFF
--- a/settings/settings.json
+++ b/settings/settings.json
@@ -4,6 +4,7 @@
       "tag": "DOGEUSD",
       "wallet_code": "XXDG",
       "kraken_name": "DOGE/USD",
+      "kraken_pair": "XXDGZUSD",
       "binance_name": "DOGEUSDT",
       "fiat": "ZUSD",
       "window_settings": {
@@ -33,6 +34,7 @@
       "tag": "SOLUSD",
       "wallet_code": "SOL.F",
       "kraken_name": "SOL/USD",
+      "kraken_pair": "SOLUSD",
       "binance_name": "SOLUSDT",
       "fiat": "DAI",
       "window_settings": {

--- a/systems/scripts/execution_handler.py
+++ b/systems/scripts/execution_handler.py
@@ -71,13 +71,18 @@ def get_available_fiat_balance(exchange, currency: str = "USD") -> float:
     return float(balance.get(currency, 0.0))
 
 def buy_order(
-    pair_code: str, fiat_symbol: str, usd_amount: float, ledger_name: str, verbose: int = 0
+    pair_code: str,
+    fiat_symbol: str,
+    usd_amount: float,
+    ledger_name: str,
+    wallet_code: str,
+    verbose: int = 0,
 ) -> dict:
     api_key, api_secret = load_kraken_keys()
 
     snapshot = _load_snapshot(ledger_name)
     balance = snapshot.get("balance", {})
-    available_usd = float(balance.get(fiat_symbol, 0.0))
+    available_usd = float(balance.get(wallet_code, 0.0))
     if available_usd < usd_amount:
         addlog(
             f"[ABORT] Not enough {fiat_symbol} to buy: ${available_usd:.2f} available, need ${usd_amount:.2f}",
@@ -226,6 +231,7 @@ def execute_buy(
     price: float,
     amount_usd: float,
     ledger_name: str,
+    wallet_code: str,
     verbose: int = 0,
 ) -> dict:
     """Place a real buy order and normalise the result structure.
@@ -234,7 +240,7 @@ def execute_buy(
     currently unused as ``buy_order`` pulls pricing from Kraken directly.
     """
 
-    fills = buy_order(symbol, fiat_code, amount_usd, ledger_name, verbose)
+    fills = buy_order(symbol, fiat_code, amount_usd, ledger_name, wallet_code, verbose)
     if not fills:
         return {}
     return {

--- a/systems/scripts/handle_top_of_hour.py
+++ b/systems/scripts/handle_top_of_hour.py
@@ -152,11 +152,12 @@ def handle_top_of_hour(
                             if invest >= min_usd and invest <= available and invest > 0:
                                 result = execute_buy(
                                     None,
-                                    symbol=tag,
+                                    symbol=ledger_cfg["kraken_pair"],
                                     fiat_code=fiat,
                                     price=price,
                                     amount_usd=invest,
                                     ledger_name=ledger_name,
+                                    wallet_code=wallet_code,
                                 )
                                 if result:
                                     note = {
@@ -219,7 +220,7 @@ def handle_top_of_hour(
                             ) and price >= note.get("mature_price", float("inf")):
                                 result = execute_sell(
                                     None,
-                                    symbol=tag,
+                                    symbol=ledger_cfg["kraken_pair"],
                                     coin_amount=note["entry_amount"],
                                     ledger_name=ledger_name,
                                 )


### PR DESCRIPTION
## Summary
- add `kraken_pair` to each ledger configuration
- trade using Kraken's internal pair codes and pass wallet code through order execution
- look up available balance by wallet code when placing buy orders

## Testing
- `pytest`
- `python -m py_compile systems/scripts/handle_top_of_hour.py systems/scripts/execution_handler.py`


------
https://chatgpt.com/codex/tasks/task_e_688f2d2cabac8326a9bbd9aba265b80d