### PR TITLE
Consolidate ledger persistence to single canonical file

### DIFF
--- a/systems/manual.py
+++ b/systems/manual.py
@@ -11,6 +11,7 @@ from systems.utils.path import find_project_root
 from systems.utils.addlog import addlog
 from systems.scripts.kraken_utils import ensure_snapshot, get_live_price
 from systems.scripts.execution_handler import execute_buy, execute_sell
+from systems.scripts.ledger import save_ledger
 
 
 def _load_ledger(ledger_name: str) -> dict:
@@ -20,14 +21,6 @@ def _load_ledger(ledger_name: str) -> dict:
         with path.open("r", encoding="utf-8") as f:
             return json.load(f)
     return {"trades": []}
-
-
-def _save_ledger(ledger_name: str, ledger: dict) -> None:
-    root = find_project_root()
-    path = root / "data" / "ledgers" / f"{ledger_name}.json"
-    path.parent.mkdir(parents=True, exist_ok=True)
-    with path.open("w", encoding="utf-8") as f:
-        json.dump(ledger, f, indent=2)
 def _coin_label(tag: str) -> str:
     for suffix in ["USD", "USDT", "USDC", "EUR", "GBP", "DAI"]:
         if tag.endswith(suffix):
@@ -103,7 +96,7 @@ def main(argv: Optional[list[str]] = None) -> None:
                     "timestamp": result.get("timestamp"),
                 }
             )
-            _save_ledger(args.ledger, ledger)
+            save_ledger(args.ledger, ledger)
         addlog(
             f"[MANUAL BUY] {args.ledger} | {tag} | ${args.usd:.2f} → {coin_amt:.4f} {coin_str} @ ${price:.4f}",
             verbose_int=1,
@@ -135,7 +128,7 @@ def main(argv: Optional[list[str]] = None) -> None:
                     "timestamp": result.get("timestamp"),
                 }
             )
-            _save_ledger(args.ledger, ledger)
+            save_ledger(args.ledger, ledger)
         else:
             usd_total = args.usd
         addlog(

--- a/systems/scripts/handle_top_of_hour.py
+++ b/systems/scripts/handle_top_of_hour.py
@@ -18,7 +18,7 @@ from systems.scripts.execution_handler import (
     execute_sell,
     load_or_fetch_snapshot,
 )
-from systems.scripts.ledger import Ledger
+from systems.scripts.ledger import Ledger, save_ledger
 from systems.utils.addlog import addlog, send_telegram_message
 from systems.scripts.send_top_hour_report import send_top_hour_report
 from systems.utils.path import find_project_root
@@ -299,7 +299,7 @@ def handle_top_of_hour(
                 metadata["last_buy_tick"] = last_buy_tick
                 metadata["last_sell_tick"] = last_sell_tick
             ledger.set_metadata(metadata)
-            Ledger.save_ledger(tag=ledger_cfg["tag"], ledger=ledger)
+            save_ledger(ledger_cfg["tag"], ledger)
 
             usd_balance = float(balance.get(fiat, 0.0))
             coin_balance = float(balance.get(wallet_code, 0.0))

--- a/systems/sim_engine.py
+++ b/systems/sim_engine.py
@@ -11,7 +11,7 @@ are recorded in a lightweight in-memory ledger.
 from tqdm import tqdm
 
 from systems.scripts.fetch_canles import fetch_candles
-from systems.scripts.ledger import Ledger
+from systems.scripts.ledger import Ledger, save_ledger
 from systems.scripts.handle_top_of_hour import handle_top_of_hour
 from systems.utils.addlog import addlog
 from systems.utils.settings_loader import load_settings
@@ -95,7 +95,7 @@ def run_simulation(tag: str, verbose: int = 0) -> None:
         verbose_int=3,
         verbose_state=verbose,
     )
-    Ledger.save_ledger(tag, ledger, sim=True, final_tick=final_tick, summary=summary)
+    save_ledger(tag, ledger, sim=True, final_tick=final_tick, summary=summary)
 
     saved_summary = Ledger.load_ledger(tag, sim=True).get_account_summary(final_price)
     if (


### PR DESCRIPTION
## Summary
- Remove timestamped ledger snapshots and drop the `data/ledger` directory
- Introduce a unified `save_ledger` helper targeting `data/ledgers/{name}.json`
- Update manual, live, and simulation paths to use the single save function

## Testing
- `pytest -q`
- `python -m py_compile systems/scripts/ledger.py systems/scripts/handle_top_of_hour.py systems/sim_engine.py systems/manual.py`


------
https://chatgpt.com/codex/tasks/task_e_688f5b947fe483269efc4714268523bc