### PR TITLE
chore: add debug logs for best knobs write

### DIFF
--- a/systems/scripts/sim_tuner.py
+++ b/systems/scripts/sim_tuner.py
@@ -144,8 +144,26 @@ def run_sim_tuner(tag: str, verbose: int = 0) -> None:
         best_knobs[window_name] = study.best_params
 
         try:
+            addlog(
+                f"[DEBUG] Writing to: {out_path.resolve()}",
+                verbose_int=1,
+                verbose_state=verbose,
+            )
+            addlog(
+                f"[DEBUG] Content: {json.dumps(study.best_params)}",
+                verbose_int=2,
+                verbose_state=verbose,
+            )
             with out_path.open("w", encoding="utf-8") as f:
                 json.dump(best_knobs, f, indent=2)
-            addlog(f"[TUNE] ✅ Saved best knobs for {tag} → {out_path}", verbose_int=1, verbose_state=verbose)
+            addlog(
+                f"[TUNE] ✅ Saved best knobs for {tag} → {out_path}",
+                verbose_int=1,
+                verbose_state=verbose,
+            )
         except Exception as e:
-            addlog(f"[ERROR] Failed to write best_knobs file: {e}", verbose_int=1, verbose_state=verbose)
+            addlog(
+                f"[ERROR] Failed to write best_knobs file: {e}",
+                verbose_int=1,
+                verbose_state=verbose,
+            )


### PR DESCRIPTION
## Summary
- add debug logs before writing best knobs to disk

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688fb0a6cf0c83268defeab686a4889c