### PR TITLE
Persist tuning knobs after each trial

### DIFF
--- a/systems/scripts/sim_tuner.py
+++ b/systems/scripts/sim_tuner.py
@@ -126,6 +126,19 @@ def run_sim_tuner(tag: str, verbose: int = 0) -> None:
                     verbose_int=1,
                     verbose_state=verbose,
                 )
+            # Persist knobs after every trial
+            best_knobs[window_name] = dict(trial.params)
+            try:
+                with out_path.open("w", encoding="utf-8") as f:
+                    json.dump(best_knobs, f, indent=2)
+                    f.flush()
+                    os.fsync(f.fileno())
+            except Exception as e:
+                addlog(
+                    f"[ERROR] Failed to write best_knobs file: {e}",
+                    verbose_int=1,
+                    verbose_state=verbose,
+                )
             return score
 
         if verbose <= 0:
@@ -141,32 +154,3 @@ def run_sim_tuner(tag: str, verbose: int = 0) -> None:
             verbose_int=1,
             verbose_state=verbose,
         )
-
-        best_knobs[window_name] = study.best_params
-
-        try:
-            addlog(
-                f"[DEBUG] Writing to: {out_path.resolve()}",
-                verbose_int=1,
-                verbose_state=verbose,
-            )
-            addlog(
-                f"[DEBUG] Content: {json.dumps(study.best_params)}",
-                verbose_int=2,
-                verbose_state=verbose,
-            )
-            with out_path.open("w", encoding="utf-8") as f:
-                json.dump(best_knobs, f, indent=2)
-                f.flush()
-                os.fsync(f.fileno())
-            addlog(
-                f"[TUNE] ✅ Saved best knobs for {tag} → {out_path.resolve()}",
-                verbose_int=1,
-                verbose_state=verbose,
-            )
-        except Exception as e:
-            addlog(
-                f"[ERROR] Failed to write best_knobs file: {e}",
-                verbose_int=1,
-                verbose_state=verbose,
-            )


### PR DESCRIPTION
## Summary
- Persist tuning knob values to `data/tmp/best_knobs/{tag}.json` after every Optuna trial
- Remove final write of study best parameters to avoid overwriting per-trial progress

## Testing
- `python -m py_compile systems/scripts/sim_tuner.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688fb8202ca08326bdb6fca309489c43