### PR TITLE
Use ledger config for live trade assets

### DIFF
--- a/systems/manual.py
+++ b/systems/manual.py
@@ -60,7 +60,6 @@ def main(argv: Optional[list[str]] = None) -> None:
 
     tag = ledger_cfg.get("tag")
     kraken_pair = ledger_cfg.get("kraken_name")
-    fiat_code = ledger_cfg.get("fiat")
 
     price = get_live_price(kraken_pair)
     if price <= 0:
@@ -75,8 +74,6 @@ def main(argv: Optional[list[str]] = None) -> None:
             result = execute_buy(
                 None,
                 symbol=kraken_pair,
-                fiat_code=fiat_code,
-                wallet_code=ledger_cfg["wallet_code"],
                 price=price,
                 amount_usd=args.usd,
                 ledger_name=args.ledger,
@@ -108,7 +105,6 @@ def main(argv: Optional[list[str]] = None) -> None:
                 None,
                 symbol=kraken_pair,
                 coin_amount=coin_amt,
-                fiat_code=fiat_code,
                 price=price,
                 ledger_name=args.ledger,
                 verbose=args.verbose,

--- a/systems/scripts/handle_top_of_hour.py
+++ b/systems/scripts/handle_top_of_hour.py
@@ -149,11 +149,9 @@ def handle_top_of_hour(
                                 result = execute_buy(
                                     client=client,
                                     symbol=kraken_pair,
-                                    fiat_code=fiat,
                                     price=price,
                                     amount_usd=invest,
                                     ledger_name=ledger_name,
-                                    wallet_code=wallet_code,
                                 )
                                 if result:
                                     note = {
@@ -218,7 +216,6 @@ def handle_top_of_hour(
                                     client=client,
                                     symbol=kraken_pair,
                                     coin_amount=note["entry_amount"],
-                                    fiat_code=fiat,
                                     ledger_name=ledger_name,
                                 )
                                 note["exit_price"] = result["avg_price"]


### PR DESCRIPTION
## Summary
- remove fiat_code and wallet_code overrides from live trade execution
- resolve fiat, wallet, and pair exclusively from ledger config
- update hourly handler and manual tool to use new execution API

## Testing
- `pytest`
- `python -m py_compile systems/scripts/execution_handler.py systems/scripts/handle_top_of_hour.py systems/manual.py`

------
https://chatgpt.com/codex/tasks/task_e_68906353a0408326b245eb02edcdd186