### PR TITLE
feat: preload and validate trading symbols

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -10,6 +10,8 @@ from pathlib import Path
 from systems.live_engine import run_live
 from systems.sim_engine import run_simulation
 from systems.utils.addlog import init_logger, addlog
+from systems.utils.settings_loader import load_settings
+from systems.utils.symbol_mapper import ensure_all_symbols_loaded
 
 
 def parse_args(argv: list[str]) -> argparse.Namespace:
@@ -115,6 +117,9 @@ def main(argv: list[str] | None = None) -> None:
                 else:
                     addlog(f"{asset}: {fmt}", verbose_int=1, verbose_state=verbose)
         return
+
+    settings = load_settings()
+    ensure_all_symbols_loaded(settings)
 
     if mode == "sim":
         run_simulation(tag=args.tag.upper(), verbose=args.verbose)

--- a/systems/fetch.py
+++ b/systems/fetch.py
@@ -9,7 +9,7 @@ from typing import List
 import sys
 import pandas as pd
 from systems.utils.resolve_symbol import resolve_ledger_settings
-from systems.utils.symbol_mapper import get_symbol_config
+from systems.utils.symbol_mapper import get_symbol_config, ensure_all_symbols_loaded
 from systems.utils.settings_loader import load_settings
 
 if __package__ is None or __package__ == "":
@@ -59,6 +59,7 @@ def main(argv: list[str] | None = None) -> None:
     verbose = args.verbose
 
     settings = load_settings()
+    ensure_all_symbols_loaded(settings)
     ledger_cfg = resolve_ledger_settings(tag, settings)
     symbol_cfg = get_symbol_config(tag)
     kraken_symbol = symbol_cfg["kraken"]["wsname"]
@@ -275,6 +276,7 @@ def fetch_missing_candles(tag: str, relative_window: str = "48h", verbose: int =
 
     try:
         settings = load_settings()
+        ensure_all_symbols_loaded(settings)
         ledger_cfg = resolve_ledger_settings(tag, settings)
         symbol_cfg = get_symbol_config(tag)
         kraken_symbol = symbol_cfg["kraken"]["wsname"]

--- a/systems/live_engine.py
+++ b/systems/live_engine.py
@@ -11,6 +11,7 @@ from tqdm import tqdm
 
 from systems.scripts.handle_top_of_hour import handle_top_of_hour
 from systems.utils.settings_loader import load_settings
+from systems.utils.symbol_mapper import ensure_all_symbols_loaded
 from systems.fetch import fetch_missing_candles
 from systems.utils.addlog import addlog
 
@@ -26,6 +27,7 @@ def run_live(
     Parameters are currently placeholders for forward compatibility.
     """
     settings = load_settings()
+    ensure_all_symbols_loaded(settings)
     tick_time = datetime.now(timezone.utc)
 
     if dry:

--- a/systems/sim_engine.py
+++ b/systems/sim_engine.py
@@ -15,6 +15,7 @@ from systems.scripts.ledger import Ledger, save_ledger
 from systems.scripts.handle_top_of_hour import handle_top_of_hour
 from systems.utils.addlog import addlog
 from systems.utils.settings_loader import load_settings
+from systems.utils.symbol_mapper import ensure_all_symbols_loaded
 from systems.utils.resolve_symbol import resolve_ledger_settings
 from systems.utils.path import find_project_root
 
@@ -22,6 +23,7 @@ from systems.utils.path import find_project_root
 def run_simulation(tag: str, verbose: int = 0) -> None:
     """Run a historical simulation for ``tag``."""
     settings = load_settings()
+    ensure_all_symbols_loaded(settings)
     tag = tag.upper()
     ledger_config = resolve_ledger_settings(tag, settings)
 

--- a/systems/utils/symbol_mapper.py
+++ b/systems/utils/symbol_mapper.py
@@ -138,3 +138,32 @@ def get_symbol_config(tag: str) -> dict:
     if "kraken" not in cfg or "binance" not in cfg:
         raise ValueError(f"Incomplete symbol data for '{tag}'")
     return cfg
+
+
+def ensure_all_symbols_loaded(settings: dict) -> None:
+    """Validate that all ledger tags exist in the symbol cache.
+
+    Parameters
+    ----------
+    settings:
+        Settings dictionary containing ``ledger_settings``.
+
+    Raises
+    ------
+    RuntimeError
+        If any tags cannot be resolved after cache refresh.
+    """
+
+    missing: list[str] = []
+    for ledger_cfg in settings.get("ledger_settings", {}).values():
+        tag = ledger_cfg.get("tag")
+        if not tag:
+            continue
+        try:
+            get_symbol_config(tag)
+        except ValueError:
+            missing.append(tag)
+    if missing:
+        raise RuntimeError(
+            f"[SYMBOL ERROR] The following tags are missing from Kraken/Binance: {missing}"
+        )


### PR DESCRIPTION
## Summary
- ensure all ledger tags are loaded into the symbol cache upfront
- validate symbols before running simulations, live trading, or fetching data
- refresh symbol cache only once per run and fail fast if any tags are missing

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6890712c3bac832685a1ffd951b2ae33