### PR TITLE
Enforce ledger isolation in trading engines

### DIFF
--- a/systems/fetch.py
+++ b/systems/fetch.py
@@ -58,7 +58,10 @@ def main(argv: list[str] | None = None) -> None:
     verbose = args.verbose
 
     settings = load_settings()
-    ledger_cfg = resolve_ledger_settings(ledger_name, settings)
+    try:
+        ledger_cfg = resolve_ledger_settings(ledger_name, settings)
+    except Exception as e:
+        raise RuntimeError(f"Ledger '{ledger_name}' not found: {e}")
     tag = ledger_cfg["tag"].upper()
     kraken_symbol = ledger_cfg["kraken_name"]
     binance_symbol = ledger_cfg["binance_name"]

--- a/systems/scripts/handle_top_of_hour.py
+++ b/systems/scripts/handle_top_of_hour.py
@@ -67,7 +67,7 @@ def handle_top_of_hour(
         window_settings = ledger_cfg.get("window_settings", {})
         triggered_strategies = {wn.title(): False for wn in window_settings}
         strategy_summary: dict[str, dict] = {}
-        ledger = Ledger.load_ledger(tag=tag)
+        ledger = Ledger.load_ledger(ledger_name)
 
         root: Path = find_project_root()
         cooldown_path = root / "data" / "tmp" / "cooldowns.json"
@@ -298,7 +298,7 @@ def handle_top_of_hour(
                 metadata["last_buy_tick"] = last_buy_tick
                 metadata["last_sell_tick"] = last_sell_tick
             ledger.set_metadata(metadata)
-            save_ledger(ledger_cfg["tag"], ledger)
+            save_ledger(ledger_name, ledger)
 
             usd_balance = float(balance.get(fiat, 0.0))
             coin_balance = float(balance.get(wallet_code, 0.0))


### PR DESCRIPTION
## Summary
- restrict live engine to a single ledger and resolve pair, wallet and fiat codes from that ledger
- confine simulation to its ledger, checking symbol and window scope and writing ledger files per ledger
- load/save ledger files in top-of-hour handler using ledger names and tighten fetch to error on unknown ledgers

## Testing
- `python -m py_compile systems/sim_engine.py systems/live_engine.py systems/scripts/handle_top_of_hour.py systems/fetch.py`
- `python - <<'PY'
from systems.sim_engine import run_simulation
run_simulation('Kris_Ledger', verbose=0)
PY`

------
https://chatgpt.com/codex/tasks/task_e_6890c800fe508326becdbe8a5b031b98