### PR TITLE
Resolve ledger settings at runtime

### DIFF
--- a/settings/settings.json
+++ b/settings/settings.json
@@ -2,10 +2,6 @@
   "ledger_settings": {
     "Kris_Ledger": {
       "tag": "DOGEUSD",
-      "wallet_code": "XXDG",
-      "kraken_name": "DOGE/USD",
-      "kraken_pair": "XXDGZUSD",
-      "binance_name": "DOGEUSDT",
       "fiat": "ZUSD",
       "window_settings": {
         "fish": {
@@ -32,10 +28,6 @@
     },
     "Travis_Ledger": {
       "tag": "SOLUSD",
-      "wallet_code": "SOL.F",
-      "kraken_name": "SOL/USD",
-      "kraken_pair": "SOLUSD",
-      "binance_name": "SOLUSDT",
       "fiat": "DAI",
       "window_settings": {
         "bunny": {

--- a/systems/fetch.py
+++ b/systems/fetch.py
@@ -64,7 +64,7 @@ def main(argv: list[str] | None = None) -> None:
         raise RuntimeError(f"Ledger '{ledger_name}' not found: {e}")
     tag = ledger_cfg["tag"].upper()
     kraken_symbol = ledger_cfg["kraken_name"]
-    binance_symbol = ledger_cfg["binance_name"]
+    binance_symbol = ledger_cfg["binance_tag"]
     log_prefix = f"[FETCH] {ledger_name} | {tag}"
 
     def log(message: str, **kwargs) -> None:
@@ -284,7 +284,7 @@ def fetch_missing_candles(
         ledger_cfg = resolve_ledger_settings(ledger_name, settings)
         tag = ledger_cfg["tag"].upper()
         kraken_symbol = ledger_cfg["kraken_name"]
-        binance_symbol = ledger_cfg["binance_name"]
+        binance_symbol = ledger_cfg["binance_tag"]
     except Exception as e:
         raise RuntimeError(f"[ERROR] Failed to resolve ledger '{ledger_name}': {e}")
 

--- a/systems/live_engine.py
+++ b/systems/live_engine.py
@@ -27,7 +27,7 @@ def run_live(
     ledger_cfg = resolve_ledger_settings(ledger_name, settings)
     kraken_pair = ledger_cfg.get("kraken_pair")
     wallet_code = ledger_cfg.get("wallet_code")
-    fiat_code = ledger_cfg.get("fiat")
+    fiat_code = ledger_cfg.get("fiat_code")
     _ = kraken_pair, wallet_code, fiat_code  # Ensure variables are resolved
     tick_time = datetime.now(timezone.utc)
 

--- a/systems/scripts/handle_top_of_hour.py
+++ b/systems/scripts/handle_top_of_hour.py
@@ -63,7 +63,7 @@ def handle_top_of_hour(
         tag = ledger_cfg["tag"]
         kraken_pair = ledger_cfg["kraken_name"]
         wallet_code = ledger_cfg["wallet_code"]
-        fiat = ledger_cfg["fiat"]
+        fiat = ledger_cfg["fiat_code"]
         window_settings = ledger_cfg.get("window_settings", {})
         triggered_strategies = {wn.title(): False for wn in window_settings}
         strategy_summary: dict[str, dict] = {}

--- a/systems/scripts/send_top_hour_report.py
+++ b/systems/scripts/send_top_hour_report.py
@@ -10,6 +10,7 @@ from zoneinfo import ZoneInfo
 from systems.utils.addlog import addlog, send_telegram_message
 from systems.utils.path import find_project_root
 from systems.utils.settings_loader import load_settings
+from systems.utils.resolve_symbol import resolve_ledger_settings
 
 
 def _get_latest_price(trades: dict, pair: str) -> float:
@@ -57,9 +58,9 @@ def send_top_hour_report(
         return
 
     settings = load_settings()
-    ledger_cfg = settings.get("ledger_settings", {}).get(ledger_name, {})
+    ledger_cfg = resolve_ledger_settings(ledger_name, settings)
     wallet_code = ledger_cfg.get("wallet_code", "")
-    fiat_code = ledger_cfg.get("fiat", "")
+    fiat_code = ledger_cfg.get("fiat_code", "")
 
     balance = snapshot.get("balance", {})
     trades = snapshot.get("trades", {})


### PR DESCRIPTION
## Summary
- Collapse ledger settings to just tag/fiat/window parameters
- Resolve Kraken and Binance metadata dynamically from cached symbol snapshots
- Update engines and reports to consume resolved `binance_tag`, `fiat_code`, and other metadata

## Testing
- `python -m py_compile systems/utils/resolve_symbol.py systems/fetch.py systems/live_engine.py systems/manual.py systems/scripts/handle_top_of_hour.py systems/scripts/send_top_hour_report.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6890d8eca45083269d1e0d67bce3642d