### PR TITLE
Use resolved metadata across fetch, sim, and live paths

### DIFF
--- a/systems/fetch.py
+++ b/systems/fetch.py
@@ -62,7 +62,7 @@ def main(argv: list[str] | None = None) -> None:
         ledger_cfg = resolve_ledger_settings(ledger_name, settings)
     except Exception as e:
         raise RuntimeError(f"Ledger '{ledger_name}' not found: {e}")
-    tag = ledger_cfg["tag"].upper()
+    tag = ledger_cfg["tag"]
     kraken_symbol = ledger_cfg["kraken_name"]
     binance_symbol = ledger_cfg["binance_tag"]
     log_prefix = f"[FETCH] {ledger_name} | {tag}"
@@ -282,7 +282,7 @@ def fetch_missing_candles(
     try:
         settings = load_settings()
         ledger_cfg = resolve_ledger_settings(ledger_name, settings)
-        tag = ledger_cfg["tag"].upper()
+        tag = ledger_cfg["tag"]
         kraken_symbol = ledger_cfg["kraken_name"]
         binance_symbol = ledger_cfg["binance_tag"]
     except Exception as e:

--- a/systems/live_engine.py
+++ b/systems/live_engine.py
@@ -25,10 +25,7 @@ def run_live(
     """Run the live trading engine for ``ledger_name``."""
     settings = load_settings()
     ledger_cfg = resolve_ledger_settings(ledger_name, settings)
-    kraken_pair = ledger_cfg.get("kraken_pair")
-    wallet_code = ledger_cfg.get("wallet_code")
-    fiat_code = ledger_cfg.get("fiat_code")
-    _ = kraken_pair, wallet_code, fiat_code  # Ensure variables are resolved
+    tag = ledger_cfg.get("tag")
     tick_time = datetime.now(timezone.utc)
 
     def _run_top_of_hour(ts: datetime) -> None:
@@ -42,14 +39,17 @@ def run_live(
         )
 
     if dry:
-        tag = ledger_cfg.get("tag")
         fetch_missing_candles(ledger_name, relative_window="48h", verbose=verbose)
         addlog(
             f"[SYNC] {ledger_name} | {tag} candles up to date",
             verbose_int=1,
             verbose_state=verbose,
         )
-        addlog("[LIVE] Running top of hour", verbose_int=1, verbose_state=verbose)
+        addlog(
+            f"[LIVE] {ledger_name} | {tag} Running top of hour",
+            verbose_int=1,
+            verbose_state=verbose,
+        )
         _run_top_of_hour(tick_time)
         return
 
@@ -70,7 +70,11 @@ def run_live(
                 time.sleep(1)
                 pbar.update(1)
 
-        addlog("[LIVE] Running top of hour", verbose_int=1, verbose_state=verbose)
+        addlog(
+            f"[LIVE] {ledger_name} | {tag} Running top of hour",
+            verbose_int=1,
+            verbose_state=verbose,
+        )
         _run_top_of_hour(datetime.now(timezone.utc))
 
 

--- a/systems/scripts/handle_top_of_hour.py
+++ b/systems/scripts/handle_top_of_hour.py
@@ -61,7 +61,7 @@ def handle_top_of_hour(
 
         ledger_cfg = resolve_ledger_settings(ledger_name, settings)
         tag = ledger_cfg["tag"]
-        kraken_pair = ledger_cfg["kraken_name"]
+        kraken_pair = ledger_cfg["kraken_pair"]
         wallet_code = ledger_cfg["wallet_code"]
         fiat = ledger_cfg["fiat_code"]
         window_settings = ledger_cfg.get("window_settings", {})

--- a/systems/sim_engine.py
+++ b/systems/sim_engine.py
@@ -23,10 +23,10 @@ def run_simulation(ledger_name: str, verbose: int = 0) -> None:
     """Run a historical simulation for ``ledger_name``."""
     settings = load_settings()
     ledger_config = resolve_ledger_settings(ledger_name, settings)
-    tag = ledger_config["tag"].upper()
+    tag = ledger_config["tag"]
 
     root = find_project_root()
-    sim_path = root / "data" / "tmp" / "simulation" / f"{ledger_name}.json"
+    sim_path = root / "data" / "tmp" / "simulation" / f"{tag}.json"
     if sim_path.exists():
         sim_path.unlink()
 
@@ -110,10 +110,10 @@ def run_simulation(ledger_name: str, verbose: int = 0) -> None:
         verbose_int=3,
         verbose_state=verbose,
     )
-    save_ledger(ledger_name, ledger, sim=True, final_tick=final_tick, summary=summary)
+    save_ledger(tag, ledger, sim=True, final_tick=final_tick, summary=summary)
 
     saved_summary = (
-        Ledger.load_ledger(ledger_name, sim=True).get_account_summary(final_price)
+        Ledger.load_ledger(tag, sim=True).get_account_summary(final_price)
     )
     if (
         saved_summary["closed_notes"] != summary["closed_notes"]


### PR DESCRIPTION
## Summary
- resolve ledger settings for each module and avoid raw tag usage
- drive simulation ledger files by resolved symbol tag
- log live engine activity with resolved tag and use kraken pair for live trades

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6890db3c34808326864fc51dfdd402e1