### PR TITLE
feat: restore reporting and telegram alerts

### DIFF
--- a/systems/scripts/ledger.py
+++ b/systems/scripts/ledger.py
@@ -88,13 +88,13 @@ class Ledger:
 
     # Persistence -----------------------------------------------------------
     @staticmethod
-    def load_ledger(tag: str, *, sim: bool = False) -> "Ledger":
-        """Load a ledger for ``tag`` depending on mode."""
+    def load_ledger(ledger_name: str, *, sim: bool = False) -> "Ledger":
+        """Load a ledger for ``ledger_name`` depending on mode."""
         root = find_project_root()
         ledger = Ledger()
 
         if sim:
-            path = root / "data" / "tmp" / "simulation" / f"{tag}.json"
+            path = root / "data" / "tmp" / "simulation" / f"{ledger_name}.json"
             if path.exists():
                 with path.open("r", encoding="utf-8") as f:
                     data = json.load(f)
@@ -103,7 +103,7 @@ class Ledger:
                 ledger.metadata = data.get("metadata", {})
             return ledger
 
-        path = root / "data" / "ledgers" / f"{tag}.json"
+        path = root / "data" / "ledgers" / f"{ledger_name}.json"
         if path.exists():
             with path.open("r", encoding="utf-8") as f:
                 data = json.load(f)


### PR DESCRIPTION
## Summary
- ensure ledger load/save keyed by `ledger_name`
- reinstate per-ledger top-of-hour summaries
- gate buy/sell telegram alerts behind `--telegram`

## Testing
- `python -m py_compile systems/scripts/handle_top_of_hour.py systems/scripts/ledger.py systems/live_engine.py systems/sim_engine.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6890e5f76ab883269587756729f305de