### PR TITLE
Use ledger based resolution in CLI

### DIFF
--- a/systems/live_engine.py
+++ b/systems/live_engine.py
@@ -118,6 +118,11 @@ def _parse_args(argv: Optional[list[str]] = None) -> argparse.Namespace:
 
 def main(argv: Optional[list[str]] = None) -> None:
     args = _parse_args(argv)
+    if not args.ledger:
+        raise RuntimeError("Missing required --ledger argument.")
+    settings = load_settings()
+    ledger_cfg = resolve_ledger_settings(args.ledger, settings)
+    tag = ledger_cfg["tag"]
     run_live(
         ledger_name=args.ledger,
         window=args.window,


### PR DESCRIPTION
## Summary
- load settings and resolve ledger configuration in the bot entrypoint
- validate ledger argument before starting the live engine

## Testing
- `pytest`
- `python -m py_compile bot.py systems/live_engine.py`


------
https://chatgpt.com/codex/tasks/task_e_6890f78f97948326982652c35685b58c