### PR TITLE
refactor: require fiat code for sells

### DIFF
--- a/systems/scripts/execution_handler.py
+++ b/systems/scripts/execution_handler.py
@@ -314,18 +314,18 @@ def execute_sell(
     *,
     symbol: str,
     coin_amount: float,
-    fiat_code: str | None = None,
+    fiat_code: str,
     price: float | None = None,
     ledger_name: str,
     verbose: int = 0,
 ) -> dict:
     """Place a real sell order and normalise the result structure.
 
-    ``fiat_code`` defaults to ``ZUSD`` when not provided. ``price`` is optional
-    and, if absent, the current live price is fetched to estimate USD notional.
+    ``fiat_code`` must be provided explicitly. ``price`` is optional and, if
+    absent, the current live price is fetched to estimate USD notional.
     """
 
-    fiat = fiat_code or "ZUSD"
+    fiat = fiat_code
     sell_price = price if price is not None else get_live_price(symbol)
     usd_amount = coin_amount * sell_price
     result = sell_order(symbol, fiat, usd_amount, ledger_name, verbose)


### PR DESCRIPTION
## Summary
- require `fiat_code` in `execute_sell` instead of defaulting to `ZUSD`
- ensure callers provide a fiat code explicitly

## Testing
- `python -m py_compile systems/scripts/execution_handler.py systems/manual.py systems/scripts/handle_top_of_hour.py`


------
https://chatgpt.com/codex/tasks/task_e_6890fcbb24fc8326aab4ac38913676bd