### PR TITLE
Remove Binance symbol resolution and limit Kraken fetch window

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,11 @@ Thumbs.db
 !data/ledgers/
 !data/ledgers/*.json
 
+# ✅ Allow Kraken symbol snapshots
+!data/snapshots/
+data/snapshots/*
+!data/snapshots/kraken_symbols.json
+
 # ❌ Exclude noisy sim or temp files
 data/tmp/
 data/results/

--- a/data/snapshots/kraken_symbols.json
+++ b/data/snapshots/kraken_symbols.json
@@ -1,0 +1,16 @@
+{
+  "DOGEUSD": {
+    "kraken_tag": "DOGEUSD",
+    "kraken_pair": "XXDGZUSD",
+    "kraken_name": "DOGE/USD",
+    "wallet_code": "XXDG",
+    "fiat_code": "ZUSD"
+  },
+  "SOLUSD": {
+    "kraken_tag": "SOLUSD",
+    "kraken_pair": "SOLUSD",
+    "kraken_name": "SOL/USD",
+    "wallet_code": "SOL",
+    "fiat_code": "ZUSD"
+  }
+}

--- a/scripts/sync_symbols.py
+++ b/scripts/sync_symbols.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Fetch and cache symbol metadata for Kraken and Binance."""
+"""Fetch and cache symbol metadata for Kraken."""
 
 from __future__ import annotations
 
@@ -10,7 +10,6 @@ import requests
 
 SNAPSHOT_DIR = Path("data/snapshots")
 KRAKEN_URL = "https://api.kraken.com/0/public/AssetPairs"
-BINANCE_URL = "https://api.binance.com/api/v3/exchangeInfo"
 PROXIES = {"http": "", "https": ""}
 
 
@@ -33,37 +32,12 @@ def _sync_kraken() -> dict:
     return out
 
 
-def _sync_binance() -> dict:
-    resp = requests.get(BINANCE_URL, timeout=30, proxies=PROXIES)
-    resp.raise_for_status()
-    symbols = resp.json().get("symbols", [])
-    out: dict[str, dict] = {}
-    for sym in symbols:
-        base = sym.get("baseAsset")
-        quote = sym.get("quoteAsset")
-        if not base or not quote:
-            continue
-        canonical_quote = "USD" if quote == "USDT" else quote
-        tag = f"{base}{canonical_quote}"
-        out[tag] = {
-            "binance_tag": sym.get("symbol"),
-            "base_asset": base,
-            "quote_asset": quote,
-        }
-    return out
-
-
 def main() -> None:
     SNAPSHOT_DIR.mkdir(parents=True, exist_ok=True)
 
     kraken_symbols = _sync_kraken()
     (SNAPSHOT_DIR / "kraken_symbols.json").write_text(
         json.dumps(kraken_symbols, indent=2, sort_keys=True)
-    )
-
-    binance_symbols = _sync_binance()
-    (SNAPSHOT_DIR / "binance_symbols.json").write_text(
-        json.dumps(binance_symbols, indent=2, sort_keys=True)
     )
 
 


### PR DESCRIPTION
## Summary
- drop Binance symbol cache and related sync logic
- resolve ledger metadata from Kraken snapshots with static Binance fallbacks
- limit Kraken fetches to 120h and use Binance only beyond that

## Testing
- `python -m systems.fetch --ledger Kris_Ledger --time 48h`
- `python -m systems.fetch --ledger Kris_Ledger --time 240h`
- `python bot.py --mode sim --ledger Kris_Ledger`
- `python bot.py --mode live --ledger Kris_Ledger --dry` *(fails: Missing kraken.yaml)*

------
https://chatgpt.com/codex/tasks/task_e_689100ec12b08326b6fb75343fe363e2