### PR TITLE
Derive coin symbol from ledger fiat code

### DIFF
--- a/systems/scripts/send_top_hour_report.py
+++ b/systems/scripts/send_top_hour_report.py
@@ -72,8 +72,10 @@ def send_top_hour_report(
     total_value = usd_balance + coin_value
 
     # Determine display names
-    coin_symbol = tag.replace("USD", "")
     fiat_symbol = fiat_code.replace("Z", "").replace("X", "")
+    coin_symbol = (
+        tag[: -len(fiat_symbol)] if fiat_symbol and tag.endswith(fiat_symbol) else tag
+    )
 
     ct_now = datetime.now(ZoneInfo("America/Chicago")).strftime("%I:%M%p")
     lines = [f"🕒 {ct_now} CT | Ledger: {ledger_name}", ""]


### PR DESCRIPTION
## Summary
- derive coin symbol in hourly report by stripping configured fiat code suffix

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68910dae6b848326a18dfd0efdfeafc2