### PR TITLE
Require explicit currency for fiat balance lookup

### DIFF
--- a/systems/scripts/execution_handler.py
+++ b/systems/scripts/execution_handler.py
@@ -97,7 +97,9 @@ def _kraken_request(endpoint: str, data: dict, api_key: str, api_secret: str) ->
     return result
 
 
-def get_available_fiat_balance(exchange, currency: str = "USD") -> float:
+def get_available_fiat_balance(exchange, currency: str) -> float:
+    if not currency:
+        raise ValueError("currency is required")
     try:
         balance = exchange.fetch_free_balance()
     except Exception:


### PR DESCRIPTION
## Summary
- require callers to provide currency when fetching available fiat balance
- validate currency argument and raise an error when missing

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6891122020288326934f67aeb802db07