### PR TITLE
Remove fiat dependencies in ledger configs and execution

### DIFF
--- a/settings/settings.json
+++ b/settings/settings.json
@@ -6,7 +6,6 @@
       "kraken_name": "DOGE/USD",
       "kraken_pair": "XXDGZUSD",
       "binance_name": "DOGEUSDT",
-      "fiat": "ZUSD",
       "window_settings": {
         "dog": {
           "window_size": "7d",
@@ -21,12 +20,11 @@
       }
     },
     "Travis_Ledger": {
-      "tag": "SOLDaI",
+      "tag": "SOLUSDC",
       "wallet_code": "SOL.F",
-      "kraken_name": "SOL/DAI",
-      "kraken_pair": "SOLDAI",
-      "binance_name": "SOLDAI",
-      "fiat": "DAI",
+      "kraken_name": "SOL/USDC",
+      "kraken_pair": "SOLUSDC",
+      "binance_name": "SOLUSDC",
       "window_settings": {
         "bunny": {
           "window_size": "7d",

--- a/systems/fetch.py
+++ b/systems/fetch.py
@@ -59,7 +59,7 @@ def main(argv: list[str] | None = None) -> None:
 
     settings = load_settings()
     ledger_cfg = resolve_ledger_settings(tag, settings)
-    kraken_symbol = ledger_cfg["kraken_name"]
+    kraken_symbol = ledger_cfg["tag"]
     binance_symbol = ledger_cfg["binance_name"]
 
     start_ts, end_ts = parse_relative_time(time_window)
@@ -274,7 +274,7 @@ def fetch_missing_candles(tag: str, relative_window: str = "48h", verbose: int =
     try:
         settings = load_settings()
         ledger_cfg = resolve_ledger_settings(tag, settings)
-        kraken_symbol = ledger_cfg["kraken_name"]
+        kraken_symbol = ledger_cfg["tag"]
         binance_symbol = ledger_cfg["binance_name"]
     except Exception as e:
         raise RuntimeError(f"[ERROR] Failed to resolve symbol '{tag}': {e}")

--- a/systems/manual.py
+++ b/systems/manual.py
@@ -59,10 +59,8 @@ def main(argv: Optional[list[str]] = None) -> None:
         )
 
     tag = ledger_cfg.get("tag")
-    kraken_pair = ledger_cfg.get("kraken_name")
-    fiat_code = ledger_cfg.get("fiat")
 
-    price = get_live_price(kraken_pair)
+    price = get_live_price(tag)
     if price <= 0:
         raise SystemExit("[ERROR] Live price unavailable (0) — aborting")
 
@@ -74,8 +72,7 @@ def main(argv: Optional[list[str]] = None) -> None:
         if not args.dry:
             result = execute_buy(
                 None,
-                symbol=kraken_pair,
-                fiat_code=fiat_code,
+                symbol=tag,
                 wallet_code=ledger_cfg["wallet_code"],
                 price=price,
                 amount_usd=args.usd,
@@ -89,7 +86,7 @@ def main(argv: Optional[list[str]] = None) -> None:
             ledger.setdefault("trades", []).append(
                 {
                     "action": "buy",
-                    "symbol": kraken_pair,
+                    "symbol": tag,
                     "usd": args.usd,
                     "coin": coin_amt,
                     "price": price,
@@ -106,9 +103,8 @@ def main(argv: Optional[list[str]] = None) -> None:
         if not args.dry:
             result = execute_sell(
                 None,
-                symbol=kraken_pair,
+                symbol=tag,
                 coin_amount=coin_amt,
-                fiat_code=fiat_code,
                 price=price,
                 ledger_name=args.ledger,
                 verbose=args.verbose,
@@ -121,7 +117,7 @@ def main(argv: Optional[list[str]] = None) -> None:
             ledger.setdefault("trades", []).append(
                 {
                     "action": "sell",
-                    "symbol": kraken_pair,
+                    "symbol": tag,
                     "usd": usd_total,
                     "coin": coin_amt,
                     "price": price,

--- a/systems/scripts/send_top_hour_report.py
+++ b/systems/scripts/send_top_hour_report.py
@@ -10,6 +10,7 @@ from zoneinfo import ZoneInfo
 from systems.utils.addlog import addlog, send_telegram_message
 from systems.utils.path import find_project_root
 from systems.utils.settings_loader import load_settings
+from systems.utils.resolve_symbol import split_tag
 
 
 def _get_latest_price(trades: dict, pair: str) -> float:
@@ -59,14 +60,14 @@ def send_top_hour_report(
     settings = load_settings()
     ledger_cfg = settings.get("ledger_settings", {}).get(ledger_name, {})
     wallet_code = ledger_cfg.get("wallet_code", "")
-    fiat_code = ledger_cfg.get("fiat", "")
+    _, fiat_code = split_tag(tag)
 
     balance = snapshot.get("balance", {})
     trades = snapshot.get("trades", {})
 
     usd_balance = float(balance.get(fiat_code, 0.0))
     coin_balance = float(balance.get(wallet_code, 0.0))
-    pair_code = ledger_cfg.get("kraken_name", "").replace("/", "")
+    pair_code = tag
     price = _get_latest_price(trades, pair_code)
     coin_value = coin_balance * price
     total_value = usd_balance + coin_value

--- a/systems/utils/resolve_symbol.py
+++ b/systems/utils/resolve_symbol.py
@@ -23,3 +23,33 @@ def resolve_symbol(tag: str) -> dict:
         "kraken": ledger["kraken_name"],
         "binance": ledger["binance_name"],
     }
+
+
+def split_tag(tag: str) -> tuple[str, str]:
+    """Return base symbol and Kraken quote asset code for ``tag``.
+
+    Parameters
+    ----------
+    tag:
+        Trading pair tag such as ``DOGEUSD`` or ``SOLUSDC``.
+
+    Returns
+    -------
+    tuple[str, str]
+        A tuple ``(base, quote_asset)`` where ``base`` is the base currency
+        symbol and ``quote_asset`` is the Kraken asset code for the quote
+        currency (e.g. ``"ZUSD"`` for USD).
+    """
+    tag = tag.upper()
+    mapping = {
+        "USDT": "USDT",
+        "USDC": "USDC",
+        "DAI": "DAI",
+        "USD": "ZUSD",
+        "EUR": "ZEUR",
+        "GBP": "ZGBP",
+    }
+    for suffix, asset_code in mapping.items():
+        if tag.endswith(suffix):
+            return tag[: -len(suffix)], asset_code
+    return tag, ""


### PR DESCRIPTION
## Summary
- remove `fiat` fields from ledger settings and switch Travis_Ledger to `SOLUSDC`
- validate configured trading pairs against Kraken `AssetPairs` on startup
- rework execution and hourly handler to derive quote assets from pair tags and drop fiat arguments

## Testing
- `pytest`
- `python -m py_compile bot.py systems/fetch.py systems/manual.py systems/scripts/execution_handler.py systems/scripts/handle_top_of_hour.py systems/scripts/send_top_hour_report.py systems/utils/resolve_symbol.py`


------
https://chatgpt.com/codex/tasks/task_e_6891164df408832694a703bdbe479741