### PR TITLE
Fix validation to use cached Kraken AssetPairs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,8 @@ Thumbs.db
 # ✅ Allow core state folders
 !data/ledgers/
 !data/ledgers/*.json
+!data/snapshots/
+!data/snapshots/*.json
 
 # ❌ Exclude noisy sim or temp files
 data/tmp/

--- a/data/snapshots/asset_pairs.json
+++ b/data/snapshots/asset_pairs.json
@@ -1,0 +1,20 @@
+{
+  "XXDGZUSD": {
+    "altname": "DOGEUSD",
+    "wsname": "DOGE/USD",
+    "base": "XXDG",
+    "quote": "ZUSD",
+    "pair_decimals": 5,
+    "lot_decimals": 8,
+    "pair": "DOGEUSD"
+  },
+  "SOLUSDC": {
+    "altname": "SOLUSDC",
+    "wsname": "SOL/USDC",
+    "base": "SOL",
+    "quote": "USDC",
+    "pair_decimals": 1,
+    "lot_decimals": 8,
+    "pair": "SOLUSDC"
+  }
+}

--- a/systems/utils/asset_pairs.py
+++ b/systems/utils/asset_pairs.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import json
+from typing import Dict, Any
+
+import requests
+
+from .path import find_project_root
+
+CACHE_FILE = find_project_root() / "data" / "snapshots" / "asset_pairs.json"
+
+
+def load_asset_pairs() -> Dict[str, Any]:
+    """Load Kraken AssetPairs from cache or live API.
+
+    Returns
+    -------
+    dict
+        Mapping of pair keys to info dictionaries as provided by Kraken.
+    """
+    if CACHE_FILE.exists():
+        try:
+            with CACHE_FILE.open("r", encoding="utf-8") as fh:
+                return json.load(fh)
+        except Exception:
+            pass
+
+    resp = requests.get("https://api.kraken.com/0/public/AssetPairs", timeout=10)
+    data = resp.json().get("result", {})
+
+    try:
+        CACHE_FILE.parent.mkdir(parents=True, exist_ok=True)
+        with CACHE_FILE.open("w", encoding="utf-8") as fh:
+            json.dump(data, fh)
+    except Exception:
+        # Caching is best-effort; ignore failures.
+        pass
+
+    return data


### PR DESCRIPTION
## Summary
- load Kraken AssetPairs from a cached JSON snapshot before attempting API calls
- validate tags against asset pair altnames and raise errors for unknown pairs
- include a snapshot of AssetPairs containing DOGEUSD for offline use

## Testing
- `python3 bot.py --mode live -vvv --dry` *(fails: Missing kraken.yaml in project root)*

------
https://chatgpt.com/codex/tasks/task_e_689123ecbcec83268daa708ce081cd5c