### PR TITLE
refactor: use ledger names instead of tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,15 +30,15 @@ Install dependencies from ``requirements.txt`` (pandas, tqdm, requests,
 krakenex, ccxt and pyyaml) and run ``bot.py`` with arguments:
 
 ```bash
-python bot.py --mode sim --window 1m --verbose 2  # uses default tag DOGEUSD
-python bot.py --mode live --tag SOLDaI --window 3mo --verbose 1 --telegram
+python bot.py --mode sim --ledger Example_Ledger --window 1m --verbose 2
+python bot.py --mode live --ledger Travis_Ledger --window 3mo --verbose 1 --telegram
 python bot.py --mode wallet -v
 ```
 
 CLI arguments:
 
 - ``--mode`` – ``sim``, ``live`` or ``wallet``.
-- ``--tag`` – trading pair symbol, e.g. ``DOGEUSD`` (default: ``DOGEUSD``).
+- ``--ledger`` – ledger name from ``settings.json`` (e.g. ``Travis_Ledger``).
 - ``--window`` – time window for tunnel metrics such as ``1m`` or ``3mo``.
 - ``--verbose`` – verbosity level (0=silent, 1=standard, 2=debug).
 - ``--log`` – write all output to ``data/tmp/log.txt``.
@@ -76,7 +76,7 @@ Results are stored in ``ledgersimulation.json`` under ``data/tmp``. Each note re
   them into ``data/raw/<TAG>.csv``. Example:
 
   ```bash
-  python -m systems.fetch --tag DOGEUSD --time 30d
+  python -m systems.fetch --ledger Travis_Ledger --time 30d
   ```
 
 - ``settings/settings.json`` – adjust strategy cooldowns, investment size and

--- a/systems/scripts/handle_top_of_hour.py
+++ b/systems/scripts/handle_top_of_hour.py
@@ -34,6 +34,7 @@ def handle_top_of_hour(
     candle: dict | None = None,
     ledger: Ledger | None = None,
     ledger_config: dict | None = None,
+    ledger_name: str | None = None,
     **kwargs: Any,
 ) -> None:
     """Run buy/sell evaluations for all windows on an hourly boundary.
@@ -74,14 +75,19 @@ def handle_top_of_hour(
 
         general_cfg = settings.get("general_settings", {})
 
-        for ledger_name, ledger_cfg in settings.get("ledger_settings", {}).items():
+        if ledger_name:
+            ledgers_to_process = {ledger_name: settings["ledger_settings"][ledger_name]}
+        else:
+            ledgers_to_process = settings.get("ledger_settings", {})
+
+        for ledger_name, ledger_cfg in ledgers_to_process.items():
             tag = ledger_cfg["tag"]
             _, quote = split_tag(tag)
             wallet_code = ledger_cfg["wallet_code"]
             window_settings = ledger_cfg.get("window_settings", {})
             triggered_strategies = {wn.title(): False for wn in window_settings}
             strategy_summary: dict[str, dict] = {}
-            ledger = Ledger.load_ledger(tag=ledger_cfg["tag"])
+            ledger = Ledger.load_ledger(ledger_name)
 
             snapshot = load_or_fetch_snapshot(ledger_name)
             if not snapshot:

--- a/systems/scripts/ledger.py
+++ b/systems/scripts/ledger.py
@@ -79,13 +79,13 @@ class Ledger:
 
     # Persistence -----------------------------------------------------------
     @staticmethod
-    def load_ledger(tag: str, *, sim: bool = False) -> "Ledger":
-        """Load a ledger for ``tag`` depending on mode."""
+    def load_ledger(ledger_name: str, *, sim: bool = False) -> "Ledger":
+        """Load a ledger for ``ledger_name`` depending on mode."""
         root = find_project_root()
         ledger = Ledger()
 
         if sim:
-            path = root / "data" / "tmp" / "simulation" / f"{tag}.json"
+            path = root / "data" / "tmp" / "simulation" / f"{ledger_name}.json"
             if path.exists():
                 with path.open("r", encoding="utf-8") as f:
                     data = json.load(f)
@@ -94,7 +94,7 @@ class Ledger:
                 ledger.metadata = data.get("metadata", {})
             return ledger
 
-        path = root / "data" / "ledgers" / f"{tag}.json"
+        path = root / "data" / "ledgers" / f"{ledger_name}.json"
         if path.exists():
             with path.open("r", encoding="utf-8") as f:
                 data = json.load(f)

--- a/systems/utils/resolve_symbol.py
+++ b/systems/utils/resolve_symbol.py
@@ -6,22 +6,18 @@ from systems.utils.settings_loader import load_settings
 SETTINGS = load_settings()
 
 
-def resolve_ledger_settings(tag: str, settings: dict | None = None) -> dict:
-    """Return ledger configuration matching ``tag``."""
+def resolve_ledger_settings(ledger: str, settings: dict | None = None) -> dict:
+    """Return ledger configuration for ``ledger`` key."""
     cfg = settings or SETTINGS
-    tag = tag.upper()
-    for ledger in cfg.get("ledger_settings", {}).values():
-        if ledger.get("tag") == tag:
-            return ledger
-    raise ValueError(f"No ledger found for tag: {tag}")
+    return cfg.get("ledger_settings", {}).get(ledger, {})
 
 
-def resolve_symbol(tag: str) -> dict:
-    """Resolve exchange-specific pair names for ``tag``."""
-    ledger = resolve_ledger_settings(tag)
+def resolve_symbol(ledger: str) -> dict:
+    """Resolve exchange-specific pair names for ``ledger``."""
+    ledger_cfg = resolve_ledger_settings(ledger)
     return {
-        "kraken": ledger["kraken_name"],
-        "binance": ledger["binance_name"],
+        "kraken": ledger_cfg.get("tag"),
+        "binance": ledger_cfg.get("binance_name"),
     }
 
 


### PR DESCRIPTION
## Summary
- replace `--tag` CLI argument with `--ledger`
- thread ledger names through live and simulation engines
- scope hourly processing and fetching using ledger config

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_6891385b8d588326a37170debb37d9b1