### PR TITLE
Use dynamic maturity ROI and remove sell cooldowns

### DIFF
--- a/settings/knobs.json
+++ b/settings/knobs.json
@@ -2,19 +2,19 @@
   "DOGEUSD": {
     "dog": {
       "buy_cooldown": [1, 200],
-      "sell_cooldown": [1, 200],
       "min_roi": [0.1, 1.0],
       "buy_floor": [0.1, 0.5],
-      "sell_ceiling": [0.5, 1.0]
+      "sell_ceiling": [0.5, 1.0],
+      "maturity_multiplier": [0.5, 1.5]
     }
   },
   "SOLDaI": {
     "bunny": {
       "buy_cooldown": [1, 200],
-      "sell_cooldown": [1, 200],
       "min_roi": [0.1, 1.0],
       "buy_floor": [0.1, 0.5],
-      "sell_ceiling": [0.5, 1.0]
+      "sell_ceiling": [0.5, 1.0],
+      "maturity_multiplier": [0.5, 1.5]
     }
   }
 }

--- a/settings/settings.json
+++ b/settings/settings.json
@@ -10,11 +10,11 @@
         "dog": {
           "window_size": "7d",
           "buy_cooldown": 108,
-          "sell_cooldown": 80,
           "min_roi": 0.625321491513477,
           "investment_fraction": 0.1,
           "buy_floor": 0.251297141853029,
           "sell_ceiling": 0.539091086750003,
+          "maturity_multiplier": 1.0,
           "max_open_notes": 100
         }
       }
@@ -29,12 +29,12 @@
         "bunny": {
           "window_size": "7d",
           "buy_cooldown": 2,
-            "sell_cooldown": 148,
-            "min_roi": 0.543280801644922,
-            "investment_fraction": 0.1,
-            "buy_floor": 0.490153492110162,
-            "sell_ceiling": 0.642255110294084,
-            "max_open_notes": 100
+          "min_roi": 0.543280801644922,
+          "investment_fraction": 0.1,
+          "buy_floor": 0.490153492110162,
+          "sell_ceiling": 0.642255110294084,
+          "maturity_multiplier": 1.0,
+          "max_open_notes": 100
         }
       }
     }

--- a/systems/scripts/evaluate_sell.py
+++ b/systems/scripts/evaluate_sell.py
@@ -6,6 +6,7 @@ from typing import Dict, List, Tuple
 
 from systems.scripts.ledger import Ledger
 from systems.scripts.window_position_tools import get_trade_params
+from systems.utils.addlog import addlog
 
 
 def evaluate_sell(
@@ -34,9 +35,15 @@ def evaluate_sell(
             price, wave["ceiling"], wave["floor"], cfg, entry_price=note["entry_price"]
         )
         maturity_roi = trade["maturity_roi"]
-        if maturity_roi is not None and gain_pct < maturity_roi:
-            roi_skipped += 1
-            continue
+        if maturity_roi is not None:
+            addlog(
+                f"[DEBUG][SELL] gain_pct={gain_pct:.2%} maturity_roi={maturity_roi:.2%}",
+                verbose_int=3,
+                verbose_state=verbose,
+            )
+            if gain_pct < maturity_roi:
+                roi_skipped += 1
+                continue
         gain = (price - note["entry_price"]) * note["entry_amount"]
         note["exit_tick"] = tick
         note["exit_price"] = price

--- a/systems/sim_engine.py
+++ b/systems/sim_engine.py
@@ -44,17 +44,13 @@ def run_simulation(tag: str, verbose: int = 0) -> None:
     min_note_usdt = settings.get("general_settings", {}).get("minimum_note_size", 0)
 
     last_buy_tick = {name: float("-inf") for name in windows}
-    last_sell_tick = {name: float("-inf") for name in windows}
     buy_cooldown_skips = {name: 0 for name in windows}
-    sell_cooldown_skips = {name: 0 for name in windows}
     min_roi_gate_hits = 0
 
     state = {
         "capital": sim_capital,
         "last_buy_tick": last_buy_tick,
-        "last_sell_tick": last_sell_tick,
         "buy_cooldown_skips": buy_cooldown_skips,
-        "sell_cooldown_skips": sell_cooldown_skips,
         "min_roi_gate_hits": min_roi_gate_hits,
     }
 
@@ -129,11 +125,6 @@ def run_simulation(tag: str, verbose: int = 0) -> None:
     if verbose:
         addlog(
             f"Buy cooldown skips: {state['buy_cooldown_skips']}",
-            verbose_int=2,
-            verbose_state=verbose,
-        )
-        addlog(
-            f"Sell cooldown skips: {state['sell_cooldown_skips']}",
             verbose_int=2,
             verbose_state=verbose,
         )


### PR DESCRIPTION
## Summary
- compute sell triggers using position-based maturity ROI for both sim and live modes
- drop sell cooldown tracking in engines and configs
- add configurable `maturity_multiplier` with default 1.0

## Testing
- `python -m py_compile systems/scripts/evaluate_sell.py systems/scripts/handle_top_of_hour.py systems/sim_engine.py`
- `python -m json.tool settings/settings.json`
- `python -m json.tool settings/knobs.json`


------
https://chatgpt.com/codex/tasks/task_e_689175fdeb44832692a8698d8b7b845c