### PR TITLE
Add dead-zone-aware trade parameter helper

### DIFF
--- a/systems/scripts/evaluate_buy.py
+++ b/systems/scripts/evaluate_buy.py
@@ -27,13 +27,16 @@ def evaluate_buy(
 
     Returns updated capital and whether the attempt was skipped due to cooldown.
     """
-    position = wave["position_in_window"]
     trade_params = get_trade_params(
         current_price=price,
         window_high=wave["ceiling"],
         window_low=wave["floor"],
         config=cfg,
     )
+    if trade_params["in_dead_zone"]:
+        return sim_capital, False
+
+    position = trade_params["pos_pct"]
     base_buy_cooldown = cfg.get("buy_cooldown", 0)
     adjusted_cooldown_ticks = int(
         base_buy_cooldown * trade_params["cooldown_multiplier"]

--- a/systems/scripts/evaluate_sell.py
+++ b/systems/scripts/evaluate_sell.py
@@ -25,16 +25,20 @@ def evaluate_sell(
     Returns updated capital, the list of notes closed at this tick, and the
     number of notes that failed the minimum ROI requirement.
     """
+    trade = get_trade_params(price, wave["ceiling"], wave["floor"], cfg)
+    if trade["in_dead_zone"]:
+        return sim_capital, [], 0
+
     to_close: List[Dict] = []
     roi_skipped = 0
     for note in ledger.get_active_notes():
         if note["window"] != name:
             continue
         gain_pct = (price - note["entry_price"]) / note["entry_price"]
-        trade = get_trade_params(
+        trade_note = get_trade_params(
             price, wave["ceiling"], wave["floor"], cfg, entry_price=note["entry_price"]
         )
-        maturity_roi = trade["maturity_roi"]
+        maturity_roi = trade_note["maturity_roi"]
         if maturity_roi is not None:
             addlog(
                 f"[DEBUG][SELL] gain_pct={gain_pct:.2%} maturity_roi={maturity_roi:.2%}",

--- a/systems/scripts/handle_top_of_hour.py
+++ b/systems/scripts/handle_top_of_hour.py
@@ -126,7 +126,21 @@ def handle_top_of_hour(
                 )
 
                 if wave:
-                    position = wave.get("position_in_window", 0)
+                    trade = get_trade_params(
+                        current_price=price,
+                        window_high=wave["ceiling"],
+                        window_low=wave["floor"],
+                        config=window_cfg,
+                    )
+                    if trade["in_dead_zone"]:
+                        addlog(
+                            f"[SKIP] {ledger_name} | {tag} | {window_name} → In dead zone",
+                            verbose_int=3,
+                            verbose_state=True,
+                        )
+                        continue
+
+                    position = trade["pos_pct"]
                     buy_cd = window_cfg.get("buy_cooldown", 0) * 3600
                     last_buy = last_buy_tick.get(window_name, float("-inf"))
                     if position <= window_cfg.get("buy_floor", 0) and (
@@ -199,14 +213,14 @@ def handle_top_of_hour(
                         if note.get("window") != window_name:
                             continue
                         gain_pct = (price - note["entry_price"]) / note["entry_price"]
-                        trade = get_trade_params(
+                        trade_note = get_trade_params(
                             current_price=price,
                             window_high=wave["ceiling"],
                             window_low=wave["floor"],
                             config=window_cfg,
                             entry_price=note["entry_price"],
                         )
-                        maturity_roi = trade["maturity_roi"]
+                        maturity_roi = trade_note["maturity_roi"]
                         addlog(
                             f"[DEBUG][LIVE SELL] gain_pct={gain_pct:.2%} maturity_roi={maturity_roi:.2%}",
                             verbose_int=3,


### PR DESCRIPTION
## Summary
- centralize window position logic with `get_trade_params` including dead-zone detection and maturity ROI
- skip buys and sells when price sits inside configured dead zone
- apply dead-zone gating and centralized position calculations across buy/sell evaluators and hourly handler

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6891cd2482608326bdbc5e39166f5e65