### PR TITLE
refactor: remove legacy floor ceiling logic

### DIFF
--- a/systems/scripts/evaluate_buy.py
+++ b/systems/scripts/evaluate_buy.py
@@ -36,41 +36,34 @@ def evaluate_buy(
     if trade_params["in_dead_zone"]:
         return sim_capital, False
 
-    position = trade_params["pos_pct"]
     base_buy_cooldown = cfg.get("buy_cooldown", 0)
     adjusted_cooldown_ticks = int(
         base_buy_cooldown * trade_params["cooldown_multiplier"]
     )
     if tick - last_buy_tick.get(name, float("-inf")) < adjusted_cooldown_ticks:
         return sim_capital, True
-    if position <= cfg.get("buy_floor", 0):
-        open_for_window = [n for n in ledger.get_active_notes() if n["window"] == name]
-        if len(open_for_window) < cfg.get("max_open_notes", 0):
-            base_note_count = sim_capital * cfg.get("investment_fraction", 0)
-            adjusted_note_count = base_note_count * trade_params["buy_multiplier"]
-            invest = min(adjusted_note_count, max_note_usdt)
-            if invest >= min_note_usdt and invest <= sim_capital:
-                amount = invest / price
-                configured_mature = wave["floor"] + wave["range"] * cfg.get("sell_ceiling", 1)
-                configured_roi = (configured_mature - price) / price
-                min_roi = cfg.get("min_roi", 0)
-                target_roi = max(configured_roi, min_roi)
-                mature_price = price * (1 + target_roi)
-                note = {
-                    "window": name,
-                    "entry_tick": tick,
-                    "buy_tick": tick,
-                    "entry_price": price,
-                    "entry_amount": amount,
-                    "mature_price": mature_price,
-                    "status": "Open",
-                }
-                ledger.open_note(note)
-                sim_capital -= invest
-                last_buy_tick[name] = tick
-                addlog(
-                    f"[BUY] {name} tick {tick} price={price:.6f}",
-                    verbose_int=2,
-                    verbose_state=verbose,
-                )
+
+    open_for_window = [n for n in ledger.get_active_notes() if n["window"] == name]
+    if len(open_for_window) < cfg.get("max_open_notes", 0):
+        base_note_count = sim_capital * cfg.get("investment_fraction", 0)
+        adjusted_note_count = base_note_count * trade_params["buy_multiplier"]
+        invest = min(adjusted_note_count, max_note_usdt)
+        if invest >= min_note_usdt and invest <= sim_capital:
+            amount = invest / price
+            note = {
+                "window": name,
+                "entry_tick": tick,
+                "buy_tick": tick,
+                "entry_price": price,
+                "entry_amount": amount,
+                "status": "Open",
+            }
+            ledger.open_note(note)
+            sim_capital -= invest
+            last_buy_tick[name] = tick
+            addlog(
+                f"[BUY] {name} tick {tick} price={price:.6f}",
+                verbose_int=2,
+                verbose_state=verbose,
+            )
     return sim_capital, False

--- a/systems/scripts/evaluate_sell.py
+++ b/systems/scripts/evaluate_sell.py
@@ -45,9 +45,15 @@ def evaluate_sell(
                 verbose_int=3,
                 verbose_state=verbose,
             )
-            if gain_pct < maturity_roi:
-                roi_skipped += 1
-                continue
+        else:
+            addlog(
+                f"[DEBUG][SELL] gain_pct={gain_pct:.2%} maturity_roi=None",
+                verbose_int=3,
+                verbose_state=verbose,
+            )
+        if maturity_roi is None or maturity_roi <= 0 or gain_pct < maturity_roi:
+            roi_skipped += 1
+            continue
         gain = (price - note["entry_price"]) * note["entry_amount"]
         note["exit_tick"] = tick
         note["exit_price"] = price


### PR DESCRIPTION
## Summary
- remove legacy buy_floor, sell_ceiling, and min_roi gating
- rely on get_trade_params for buy cooldowns and note sizing
- enforce positive ROI before selling

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6891d1f0d8a88326b07843bf6842e32b