### PR TITLE
Implement sell cooldown and profitability ordering

### DIFF
--- a/settings/knobs.json
+++ b/settings/knobs.json
@@ -2,6 +2,7 @@
   "DOGEUSD": {
     "dog": {
       "buy_cooldown": [1, 200],
+      "sell_cooldown": [0, 200],
       "min_roi": [0.1, 1.0],
       "buy_floor": [0.1, 0.5],
       "sell_ceiling": [0.5, 1.0],
@@ -11,6 +12,7 @@
   "SOLDaI": {
     "bunny": {
       "buy_cooldown": [1, 200],
+      "sell_cooldown": [0, 200],
       "min_roi": [0.1, 1.0],
       "buy_floor": [0.1, 0.5],
       "sell_ceiling": [0.5, 1.0],

--- a/settings/settings.json
+++ b/settings/settings.json
@@ -17,6 +17,7 @@
           "maturity_multiplier": 1.0,
           "buy_multiplier_scale": 1.0,
           "cooldown_multiplier_scale": 1.0,
+          "sell_cooldown": 0,
           "dead_zone_pct": 0.0,
           "max_open_notes": 100
         }


### PR DESCRIPTION
## Summary
- add per-window sell cooldown tracking and gain-based sorting to simulation sells
- prioritize profitable notes and enforce sell cooldown in live top-of-hour handler
- expose `sell_cooldown` in settings and tuning knobs for per-window adjustment

## Testing
- `pytest`
- `python -m py_compile systems/scripts/evaluate_sell.py systems/scripts/handle_top_of_hour.py`


------
https://chatgpt.com/codex/tasks/task_e_6891d513710083269dfa2c70a5fb2d43