### PR TITLE
feat: split buy and sell cooldown multipliers

### DIFF
--- a/settings/settings.json
+++ b/settings/settings.json
@@ -14,7 +14,8 @@
           "investment_fraction": 0.1,
           "maturity_multiplier": 5,
           "buy_multiplier_scale": 5,
-          "cooldown_multiplier_scale": 1.0,
+          "buy_cooldown_multiplier_scale": 1.0,
+          "sell_cooldown_multiplier_scale": 1.0,
           "dead_zone_pct": 0.0,
           "max_open_notes": 100
         }
@@ -34,7 +35,8 @@
           "investment_fraction": 0.1,
           "maturity_multiplier": 1.0,
           "buy_multiplier_scale": 1.0,
-          "cooldown_multiplier_scale": 1.0,
+          "buy_cooldown_multiplier_scale": 1.0,
+          "sell_cooldown_multiplier_scale": 1.0,
           "dead_zone_pct": 0.0,
           "max_open_notes": 100
         }

--- a/systems/scripts/evaluate_buy.py
+++ b/systems/scripts/evaluate_buy.py
@@ -38,7 +38,7 @@ def evaluate_buy(
 
     base_buy_cooldown = cfg.get("buy_cooldown", 0)
     adjusted_cooldown_ticks = int(
-        base_buy_cooldown * trade_params["cooldown_multiplier"]
+        base_buy_cooldown / trade_params["buy_cooldown_multiplier"]
     )
     if tick - last_buy_tick.get(name, float("-inf")) < adjusted_cooldown_ticks:
         return sim_capital, True

--- a/systems/scripts/evaluate_sell.py
+++ b/systems/scripts/evaluate_sell.py
@@ -19,6 +19,7 @@ def evaluate_sell(
     cfg: Dict,
     sim_capital: float,
     verbose: int,
+    base_sell_cooldown: int,
     last_sell_tick: Dict[str, int],
 ) -> Tuple[float, List[Dict], int]:
     """Close notes that have reached their target price.
@@ -30,7 +31,6 @@ def evaluate_sell(
     if trade["in_dead_zone"]:
         return sim_capital, [], 0
 
-    base_sell_cooldown = cfg.get("sell_cooldown", 0)
     to_close: List[Dict] = []
     roi_skipped = 0
     notes = [n for n in ledger.get_active_notes() if n["window"] == name]
@@ -64,10 +64,10 @@ def evaluate_sell(
         ):
             roi_skipped += 1
             continue
-        adjusted_sell_cooldown = int(
-            base_sell_cooldown * trade_note["cooldown_multiplier"]
+        adjusted_sell_cd = int(
+            base_sell_cooldown / trade_note["sell_cooldown_multiplier"]
         )
-        if tick - last_sell_tick.get(name, float("-inf")) < adjusted_sell_cooldown:
+        if tick - last_sell_tick.get(name, float("-inf")) < adjusted_sell_cd:
             continue
         gain = (price - note["entry_price"]) * note["entry_amount"]
         note["exit_tick"] = tick

--- a/systems/scripts/handle_top_of_hour.py
+++ b/systems/scripts/handle_top_of_hour.py
@@ -142,7 +142,10 @@ def handle_top_of_hour(
                         continue
 
                     buy_cd_base = window_cfg.get("buy_cooldown", 0) * 3600
-                    buy_cd = buy_cd_base * trade["cooldown_multiplier"]
+                    buy_cd = int(
+                        buy_cd_base
+                        / trade["buy_cooldown_multiplier"]
+                    )
                     last_buy = last_buy_tick.get(window_name, float("-inf"))
                     if dry_run or current_ts - last_buy >= buy_cd:
                         open_for_window = [
@@ -242,7 +245,10 @@ def handle_top_of_hour(
                             or gain_pct < maturity_roi
                         ):
                             continue
-                        sell_cd = int(sell_cd_base * trade_note["cooldown_multiplier"])
+                        sell_cd = int(
+                            sell_cd_base
+                            / trade_note["sell_cooldown_multiplier"]
+                        )
                         if not dry_run and (
                             current_ts - last_sell_tick.get(window_name, float("-inf"))
                             < sell_cd
@@ -426,6 +432,7 @@ def handle_top_of_hour(
             cfg=cfg,
             sim_capital=sim_capital,
             verbose=verbose,
+            base_sell_cooldown=cfg.get("sell_cooldown", 0),
             last_sell_tick=last_sell_tick,
         )
         state["capital"] = sim_capital

--- a/systems/scripts/window_position_tools.py
+++ b/systems/scripts/window_position_tools.py
@@ -18,9 +18,9 @@ def get_trade_params(current_price, window_high, window_low, config, entry_price
     Returns
     -------
     dict
-        Dictionary containing ``pos_pct``, ``in_dead_zone``, buy and cooldown
-        multipliers, and ``maturity_roi`` (``None`` if ``entry_price`` is not
-        provided).
+        Dictionary containing ``pos_pct``, ``in_dead_zone``, buy multipliers,
+        buy/sell cooldown multipliers, and ``maturity_roi`` (``None`` if
+        ``entry_price`` is not provided).
     """
 
     window_range = window_high - window_low
@@ -34,9 +34,16 @@ def get_trade_params(current_price, window_high, window_low, config, entry_price
     in_dead_zone = abs(pos_pct) <= dead_zone_half if dead_zone_pct > 0 else False
 
     buy_scale = config.get("buy_multiplier_scale", 1.0)
-    cooldown_scale = config.get("cooldown_multiplier_scale", 1.0)
     buy_multiplier = 1.0 + (abs(pos_pct) * (buy_scale - 1.0))
-    cooldown_multiplier = 1.0 + (abs(pos_pct) * (cooldown_scale - 1.0))
+
+    buy_cd_multiplier = 1.0 + (
+        abs(pos_pct)
+        * (config.get("buy_cooldown_multiplier_scale", 1.0) - 1.0)
+    )
+    sell_cd_multiplier = 1.0 + (
+        abs(pos_pct)
+        * (config.get("sell_cooldown_multiplier_scale", 1.0) - 1.0)
+    )
 
     maturity_roi = None
     if entry_price is not None and window_range != 0:
@@ -49,6 +56,7 @@ def get_trade_params(current_price, window_high, window_low, config, entry_price
         "pos_pct": pos_pct,
         "in_dead_zone": in_dead_zone,
         "buy_multiplier": buy_multiplier,
-        "cooldown_multiplier": cooldown_multiplier,
+        "buy_cooldown_multiplier": buy_cd_multiplier,
+        "sell_cooldown_multiplier": sell_cd_multiplier,
         "maturity_roi": maturity_roi,
     }


### PR DESCRIPTION
## Summary
- allow separate buy and sell cooldown multiplier scales in settings
- compute independent buy/sell cooldown multipliers and apply them as divisors for faster or slower trading
- wire new cooldown logic through evaluate_buy/evaluate_sell and live trade loop

## Testing
- `pytest`
- `python -m py_compile systems/scripts/window_position_tools.py systems/scripts/evaluate_buy.py systems/scripts/evaluate_sell.py systems/scripts/handle_top_of_hour.py`


------
https://chatgpt.com/codex/tasks/task_e_6891dad47f748326926b9b05492fa4ef