### PR TITLE
Add Goat ledger config and SOLUSD asset pair

### DIFF
--- a/data/snapshots/asset_pairs.json
+++ b/data/snapshots/asset_pairs.json
@@ -16,5 +16,14 @@
     "pair_decimals": 1,
     "lot_decimals": 8,
     "pair": "SOLUSDC"
+  },
+  "SOLUSD": {
+    "altname": "SOLUSD",
+    "wsname": "SOL/USD",
+    "base": "SOL",
+    "quote": "ZUSD",
+    "pair_decimals": 1,
+    "lot_decimals": 8,
+    "pair": "SOLUSD"
   }
 }

--- a/settings/settings.json
+++ b/settings/settings.json
@@ -41,6 +41,27 @@
           "max_open_notes": 100
         }
       }
+    },
+    "Goat ledger": {
+      "tag": "SOLUSD",
+      "wallet_code": "SOL.F",
+      "kraken_name": "SOL/USD",
+      "kraken_pair": "SOLUSD",
+      "binance_name": "SOLUSD",
+      "window_settings": {
+        "goat": {
+          "window_size": "7d",
+          "buy_cooldown": 2,
+          "sell_cooldown": 0,
+          "investment_fraction": 0.1,
+          "maturity_multiplier": 1.0,
+          "buy_multiplier_scale": 1.0,
+          "buy_cooldown_multiplier_scale": 1.0,
+          "sell_cooldown_multiplier_scale": 1.0,
+          "dead_zone_pct": 0.0,
+          "max_open_notes": 100
+        }
+      }
     }
   },
   "general_settings": {


### PR DESCRIPTION
## Summary
- add Goat ledger configuration for SOL/USD
- include SOLUSD in cached Kraken asset pairs

## Testing
- `python bot.py --mode sim --ledger "Goat ledger" -v`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68928317af248326b8f2196143c730b3