### PR TITLE
Use ledger balance for coin holdings

### DIFF
--- a/systems/scripts/handle_top_of_hour.py
+++ b/systems/scripts/handle_top_of_hour.py
@@ -341,9 +341,16 @@ def handle_top_of_hour(
             ledger.set_metadata(metadata)
             save_ledger(ledger_cfg["tag"], ledger)
 
+            # USD fiat balance from Kraken
             usd_balance = float(balance.get(quote, 0.0))
-            coin_balance = float(balance.get(wallet_code, 0.0))
-            coin_balance_usd = coin_balance * price
+
+            # Crypto balance from local ledger, not Kraken
+            open_notes_all = ledger.get_open_notes()
+            coin_total_amount = sum(
+                note.get("entry_amount", 0.0) for note in open_notes_all
+            )
+            coin_balance_usd = coin_total_amount * price
+
             total_liquid_value = usd_balance + coin_balance_usd
             note_counts = {}
             for win in window_settings.keys():


### PR DESCRIPTION
## Summary
- derive crypto holdings from the ledger instead of Kraken snapshot in hourly report

## Testing
- `python -m py_compile systems/scripts/handle_top_of_hour.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689342e876c0832685aff4189c7d6274