### PR TITLE
Rate-limit top-of-hour report to midnight UTC

### DIFF
--- a/systems/scripts/handle_top_of_hour.py
+++ b/systems/scripts/handle_top_of_hour.py
@@ -372,13 +372,15 @@ def handle_top_of_hour(
                 note_counts,
             )
             addlog(report, verbose_int=1, verbose_state=True)
-
-            send_top_hour_report(
-                ledger_name=ledger_name,
-                tag=tag,
-                strategy_summary=strategy_summary,
-                verbose=general_cfg.get("verbose", 0),
-            )
+            # Send top-of-hour portfolio report only at 12AM UTC
+            now_utc = datetime.utcnow()
+            if now_utc.hour == 0:
+                send_top_hour_report(
+                    ledger_name=ledger_name,
+                    tag=tag,
+                    strategy_summary=strategy_summary,
+                    verbose=general_cfg.get("verbose", 0),
+                )
 
             if not dry_run:
                 cooldowns[ledger_name] = {


### PR DESCRIPTION
## Summary
- send top-of-hour portfolio report only once per day at 12AM UTC

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68934407b9cc8326b4c9f3f2df95668c