### PR TITLE
Log total cost for live buy telegram notifications

### DIFF
--- a/systems/scripts/handle_top_of_hour.py
+++ b/systems/scripts/handle_top_of_hour.py
@@ -194,10 +194,15 @@ def handle_top_of_hour(
                                     if not dry_run:
                                         last_buy_tick[window_name] = current_ts
                                     buy_count += 1
+                                    total_cost = (
+                                        result["filled_amount"]
+                                        * result["avg_price"]
+                                    )
                                     msg = (
                                         f"[LIVE][BUY] {ledger_name} | {tag} | "
                                         f"{result['filled_amount']:.4f} {wallet_code} @ "
-                                        f"${result['avg_price']:.3f}"
+                                        f"${result['avg_price']:.3f} = "
+                                        f"${total_cost:.2f}"
                                     )
                                     addlog(msg)
                                     send_telegram_message(msg)


### PR DESCRIPTION
## Summary
- include total dollar cost in live buy log/telegram message

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68938e70d2d08326b4497919dc2c60dd