### PR TITLE
Load candle data by base coin symbol

### DIFF
--- a/systems/scripts/fetch_canles.py
+++ b/systems/scripts/fetch_canles.py
@@ -7,10 +7,30 @@ import pandas as pd
 from systems.utils.config import resolve_path
 
 
+def _extract_coin(tag: str) -> str:
+    """Return the base coin symbol from a market ``tag``.
+
+    Tags often include a quote currency (e.g. ``SOLUSDC`` or ``DOGEUSD``).
+    Candle files are stored using just the base coin name, so this function
+    strips any stablecoin suffixes and returns the resulting coin symbol.
+    """
+
+    tag = tag.upper()
+    suffixes = ("USDC", "USD", "DAI")
+    for suffix in suffixes:
+        if tag.endswith(suffix):
+            return tag[: -len(suffix)]
+    return tag
+
+
 def fetch_candles(tag: str) -> pd.DataFrame:
-    """Load historical candles for ``tag`` from ``data/raw``."""
+    """Load historical candles for ``tag`` from ``data/raw``.
+
+    Only the base coin portion of ``tag`` is used to determine the file name.
+    """
     root = resolve_path("")
-    path = root / "data" / "raw" / f"{tag.upper()}.csv"
+    coin = _extract_coin(tag)
+    path = root / "data" / "raw" / f"{coin}.csv"
     if not path.exists():  # pragma: no cover - file presence check
         raise FileNotFoundError(f"Candle file not found: {path}")
     return pd.read_csv(path)


### PR DESCRIPTION
## Summary
- derive coin symbol from tag before loading candle file

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_6893dbeee6cc832686bd2e51d892be8c