### PR TITLE
feat: limit portfolio reports to midnight UTC

### DIFF
--- a/systems/scripts/handle_top_of_hour.py
+++ b/systems/scripts/handle_top_of_hour.py
@@ -372,9 +372,10 @@ def handle_top_of_hour(
                 note_counts,
             )
             addlog(report, verbose_int=1, verbose_state=True)
-            # Send top-of-hour portfolio report only at 12AM UTC
+
             now_utc = datetime.utcnow()
-            if now_utc.hour == 0:
+            # Always send in dry mode, else only at midnight UTC
+            if dry_run or now_utc.hour == 0:
                 send_top_hour_report(
                     ledger_name=ledger_name,
                     tag=tag,


### PR DESCRIPTION
## Summary
- only send top-of-hour portfolio report at midnight UTC in live mode
- always send report each hour when running in dry mode

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68934623b8b08326900538bc128e5814