### PR TITLE
Fix top-of-hour open note summary crash

### DIFF
--- a/systems/scripts/handle_top_of_hour.py
+++ b/systems/scripts/handle_top_of_hour.py
@@ -360,8 +360,12 @@ def handle_top_of_hour(
             total_liquid_value = usd_balance + coin_balance_usd
             note_counts: dict[str, tuple[int, int]] = {}
             for win in window_settings.keys():
-                open_n = sum(1 for n in open_notes if n.get("window") == win)
-                closed_n = sum(1 for n in closed_notes if n.get("window") == win)
+                open_n = sum(
+                    1 for n in open_notes_all if n.get("window") == win
+                )
+                closed_n = sum(
+                    1 for n in ledger.get_closed_notes() if n.get("window") == win
+                )
                 note_counts[win.title()] = (open_n, closed_n)
             report = format_top_of_hour_report(
                 tag,


### PR DESCRIPTION
## Summary
- Prevent NameError in live top-of-hour reporting by using `open_notes_all`
- Count closed notes directly from ledger

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6894801d07c8832692125eb461c114e0