### PR TITLE
Fix missing project root helper

### DIFF
--- a/systems/scripts/fetch_core.py
+++ b/systems/scripts/fetch_core.py
@@ -6,9 +6,13 @@ from typing import List
 import pandas as pd
 import ccxt
 
-from systems.utils.config import resolve_path
-
 COLUMNS = ["timestamp", "open", "high", "low", "close", "volume"]
+
+
+def find_project_root() -> Path:
+    """Return the absolute path to the repository root."""
+
+    return Path(__file__).resolve().parents[2]
 
 
 def _fetch_kraken(symbol: str, start_ms: int, end_ms: int) -> List[List]:


### PR DESCRIPTION
## Summary
- add `find_project_root` utility to fetch_core to locate repository root

## Testing
- `python -m py_compile systems/scripts/fetch_core.py && python - <<'PY'
from systems.scripts.fetch_core import get_raw_path
print(get_raw_path('BTCUSD'))
PY`

------
https://chatgpt.com/codex/tasks/task_e_689481626d5883268c08295d69f6baad