### PR TITLE
Add per-ledger window debug summary

### DIFF
--- a/systems/scripts/evaluate_buy.py
+++ b/systems/scripts/evaluate_buy.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from typing import Dict, Tuple
 
 from systems.scripts.ledger import Ledger
+from systems.scripts.get_window_data import get_window_data
+from systems.utils.addlog import addlog
 from systems.utils.trade_eval import evaluate_trade
 
 
@@ -16,6 +18,7 @@ def evaluate_buy(
     wave: Dict,
     tick: int,
     price: float,
+    symbol: str | None,
     sim_capital: float,
     last_buy_tick: Dict[str, int],
     max_note_usdt: float,
@@ -23,6 +26,21 @@ def evaluate_buy(
     verbose: int,
 ) -> Tuple[float, bool]:
     """Attempt to open a new note if buy conditions are met."""
+
+    if verbose >= 3:
+        summary = get_window_data(wave=wave, price=price)
+        tag = symbol or ledger.get_metadata().get("tag", "")
+        addlog(
+            (
+                f"[DEBUG] {tag} | {name} | "
+                f"Position: {summary['current_tunnel_position_avg']:.2f} | "
+                f"Loudness: {summary['loudness_avg']:.2f} | "
+                f"Slope: {summary['slope_direction_avg']:.2f} | "
+                f"ROI est: {summary['highest_spike_avg']:.2f}"
+            ),
+            verbose_int=3,
+            verbose_state=verbose,
+        )
 
     strategy_cfg = {
         "name": name,

--- a/systems/scripts/get_window_data.py
+++ b/systems/scripts/get_window_data.py
@@ -58,3 +58,39 @@ def get_wave_window_data_df(df, window: str, candle_offset: int = 0) -> dict | N
         "position_in_window": round(position, 4),
         "trend_direction_delta_window": trend_direction_delta_window
     }
+
+
+def get_window_data(*, wave: dict, price: float) -> dict:
+    """Return averaged tunnel metrics for logging purposes.
+
+    Parameters
+    ----------
+    wave:
+        Dictionary containing at least ``floor`` and ``ceiling`` keys.
+    price:
+        Current asset price.
+
+    Returns
+    -------
+    dict
+        Mapping with ``current_tunnel_position_avg``, ``loudness_avg``,
+        ``slope_direction_avg`` and ``highest_spike_avg``.
+    """
+
+    floor = wave.get("floor", 0.0)
+    ceiling = wave.get("ceiling", 0.0)
+    range_val = ceiling - floor
+
+    position = ((price - floor) / range_val * 2 - 1) if range_val else 0.0
+    loudness = (range_val / price) if price else 0.0
+    slope = wave.get("trend_direction_delta_window", 0.0)
+    highest_spike = (
+        max(abs(price - floor), abs(ceiling - price)) / price if price else 0.0
+    )
+
+    return {
+        "current_tunnel_position_avg": round(position, 2),
+        "loudness_avg": round(loudness, 2),
+        "slope_direction_avg": round(slope, 2),
+        "highest_spike_avg": round(highest_spike, 2),
+    }

--- a/systems/scripts/handle_top_of_hour.py
+++ b/systems/scripts/handle_top_of_hour.py
@@ -437,6 +437,7 @@ def handle_top_of_hour(
             wave=wave,
             tick=tick,
             price=price,
+            symbol=ledger_config.get("tag", ""),
             sim_capital=sim_capital,
             last_buy_tick=state.get("last_buy_tick", {}),
             max_note_usdt=max_note_usdt,


### PR DESCRIPTION
## Summary
- log per-ledger window metrics during buy evaluation when verbose level >= 3
- compute tunnel summary metrics via new `get_window_data` helper
- pass symbol into `evaluate_buy` so debug output includes trading pair

## Testing
- `python -m py_compile systems/scripts/evaluate_buy.py systems/scripts/get_window_data.py systems/scripts/handle_top_of_hour.py`


------
https://chatgpt.com/codex/tasks/task_e_6895231a57e4832693354f6be75704bf