### PR TITLE
Use ledger-config symbol mappings for candle fetch

### DIFF
--- a/systems/fetch.py
+++ b/systems/fetch.py
@@ -7,11 +7,10 @@ from pathlib import Path
 from typing import List
 import sys
 import pandas as pd
-from systems.utils.config import load_ledger_config, resolve_path
+from systems.utils.config import load_ledger_config, load_settings, resolve_path
 from systems.utils.cli import build_parser
 from systems.utils.symbols import (
     resolve_asset,
-    resolve_exchange_pairs,
     resolve_tag,
     raw_path,
 )
@@ -60,19 +59,25 @@ def main(argv: list[str] | None = None) -> None:
             verbose_state=True,
         )
     else:
-        ledger_cfg = load_ledger_config(args.ledger)
-        tag = resolve_tag(ledger_cfg)
+        settings = load_settings()
+        ledger_cfg = settings["ledger_settings"][args.ledger]
+        tag = ledger_cfg.get("tag", args.ledger).upper()
 
     asset = resolve_asset(ledger_cfg)
-    pairs = resolve_exchange_pairs(ledger_cfg)
-    kraken_symbol = pairs.get("kraken_pair") or tag
-    if pairs.get("kraken_pair") is None:
+    kraken_symbol = ledger_cfg.get("kraken_name")
+    if not kraken_symbol:
         addlog(
-            f"[WARN] Missing kraken_pair for {asset} ({tag})",
+            f"[WARN] Missing kraken_name for {asset} ({tag})",
             verbose_int=1,
             verbose_state=True,
         )
-    binance_symbol = pairs.get("binance_pair")
+    binance_symbol = ledger_cfg.get("binance_name")
+    if not binance_symbol:
+        addlog(
+            f"[WARN] Missing binance_name for {asset} ({tag})",
+            verbose_int=1,
+            verbose_state=True,
+        )
 
     start_ts, end_ts = parse_relative_time(time_window)
     out_path = raw_path(asset)
@@ -92,10 +97,11 @@ def main(argv: list[str] | None = None) -> None:
                 verbose_int=3,
                 verbose_state=verbose,
             )
-            df = fetch_range("kraken", kraken_symbol, gap_start, gap_end)
-            if not df.empty:
-                new_frames.append(df)
-                added_kraken += len(df)
+            if kraken_symbol:
+                df = fetch_range("kraken", kraken_symbol, gap_start, gap_end)
+                if not df.empty:
+                    new_frames.append(df)
+                    added_kraken += len(df)
         else:
             kraken_end = gap_start + 720 * 3600
             addlog(
@@ -103,20 +109,22 @@ def main(argv: list[str] | None = None) -> None:
                 verbose_int=3,
                 verbose_state=verbose,
             )
-            df_k = fetch_range("kraken", kraken_symbol, gap_start, kraken_end)
-            if not df_k.empty:
-                new_frames.append(df_k)
-                added_kraken += len(df_k)
-                kraken_limited = True
+            if kraken_symbol:
+                df_k = fetch_range("kraken", kraken_symbol, gap_start, kraken_end)
+                if not df_k.empty:
+                    new_frames.append(df_k)
+                    added_kraken += len(df_k)
+                    kraken_limited = True
             addlog(
                 f" Fetching from Binance: {datetime.utcfromtimestamp(kraken_end + 3600)} to {datetime.utcfromtimestamp(gap_end)}",
                 verbose_int=3,
                 verbose_state=verbose,
             )
-            df_b = fetch_range("binance", binance_symbol, kraken_end + 3600, gap_end)
-            if not df_b.empty:
-                new_frames.append(df_b)
-                added_binance += len(df_b)
+            if binance_symbol:
+                df_b = fetch_range("binance", binance_symbol, kraken_end + 3600, gap_end)
+                if not df_b.empty:
+                    new_frames.append(df_b)
+                    added_binance += len(df_b)
 
     total_rows = _merge_and_save(out_path, existing, new_frames)
 
@@ -173,15 +181,20 @@ def fetch_missing_candles(
     ledger_cfg = load_ledger_config(ledger)
     tag = resolve_tag(ledger_cfg)
     asset = resolve_asset(ledger_cfg)
-    pairs = resolve_exchange_pairs(ledger_cfg)
-    kraken_symbol = kraken_pair or pairs.get("kraken_pair") or tag
-    if pairs.get("kraken_pair") is None and kraken_pair is None:
+    kraken_symbol = kraken_pair or ledger_cfg.get("kraken_name")
+    if not kraken_symbol:
         addlog(
-            f"[WARN] Missing kraken_pair for {asset} ({tag})",
+            f"[WARN] Missing kraken_name for {asset} ({tag})",
             verbose_int=1,
             verbose_state=True,
         )
-    binance_symbol = pairs.get("binance_pair")
+    binance_symbol = ledger_cfg.get("binance_name")
+    if not binance_symbol:
+        addlog(
+            f"[WARN] Missing binance_name for {asset} ({tag})",
+            verbose_int=1,
+            verbose_state=True,
+        )
 
     start_ts, end_ts = parse_relative_time(relative_window)
     out_path = raw_path(asset)
@@ -195,41 +208,44 @@ def fetch_missing_candles(
     for gap_start, gap_end in gaps:
         diff_hours = int((gap_end - gap_start) // 3600) + 1
         if diff_hours <= 720:
-            try:
-                df = fetch_range("kraken", kraken_symbol, gap_start, gap_end)
-                if not df.empty:
-                    new_frames.append(df)
-                    added_kraken += len(df)
-            except Exception as e:
-                addlog(
-                    f"[WARN] Kraken fetch error: {e}",
-                    verbose_int=2,
-                    verbose_state=verbose,
-                )
+            if kraken_symbol:
+                try:
+                    df = fetch_range("kraken", kraken_symbol, gap_start, gap_end)
+                    if not df.empty:
+                        new_frames.append(df)
+                        added_kraken += len(df)
+                except Exception as e:
+                    addlog(
+                        f"[WARN] Kraken fetch error: {e}",
+                        verbose_int=2,
+                        verbose_state=verbose,
+                    )
         else:
             kraken_end = gap_start + 720 * 3600
-            try:
-                df_k = fetch_range("kraken", kraken_symbol, gap_start, kraken_end)
-                if not df_k.empty:
-                    new_frames.append(df_k)
-                    added_kraken += len(df_k)
-            except Exception as e:
-                addlog(
-                    f"[WARN] Kraken fetch error: {e}",
-                    verbose_int=2,
-                    verbose_state=verbose,
-                )
-            try:
-                df_b = fetch_range("binance", binance_symbol, kraken_end + 3600, gap_end)
-                if not df_b.empty:
-                    new_frames.append(df_b)
-                    added_binance += len(df_b)
-            except Exception as e:
-                addlog(
-                    f"[WARN] Binance fetch error: {e}",
-                    verbose_int=2,
-                    verbose_state=verbose,
-                )
+            if kraken_symbol:
+                try:
+                    df_k = fetch_range("kraken", kraken_symbol, gap_start, kraken_end)
+                    if not df_k.empty:
+                        new_frames.append(df_k)
+                        added_kraken += len(df_k)
+                except Exception as e:
+                    addlog(
+                        f"[WARN] Kraken fetch error: {e}",
+                        verbose_int=2,
+                        verbose_state=verbose,
+                    )
+            if binance_symbol:
+                try:
+                    df_b = fetch_range("binance", binance_symbol, kraken_end + 3600, gap_end)
+                    if not df_b.empty:
+                        new_frames.append(df_b)
+                        added_binance += len(df_b)
+                except Exception as e:
+                    addlog(
+                        f"[WARN] Binance fetch error: {e}",
+                        verbose_int=2,
+                        verbose_state=verbose,
+                    )
 
     _merge_and_save(out_path, existing, new_frames)
 

--- a/systems/scripts/fetch_core.py
+++ b/systems/scripts/fetch_core.py
@@ -15,10 +15,11 @@ def find_project_root() -> Path:
     return Path(__file__).resolve().parents[2]
 
 
-def _fetch_kraken(kraken_pair: str, start_ms: int, end_ms: int) -> List[List]:
+def _fetch_kraken(symbol: str, start_ms: int, end_ms: int) -> List[List]:
+    """Fetch Kraken candles for a fully-resolved symbol."""
     exchange = ccxt.kraken({"enableRateLimit": True})
     limit = min(720, int((end_ms - start_ms) // 3600000) + 1)
-    ohlcv = exchange.fetch_ohlcv(kraken_pair, timeframe="1h", since=start_ms, limit=limit)
+    ohlcv = exchange.fetch_ohlcv(symbol, timeframe="1h", since=start_ms, limit=limit)
     return [row for row in ohlcv if row and start_ms <= row[0] <= end_ms]
 
 


### PR DESCRIPTION
## Summary
- Use `kraken_name` and `binance_name` from `settings.json` to resolve symbols in `systems.fetch`
- Expect fully-resolved symbols in fetch core functions

## Testing
- `python -m systems.fetch --ledger "Goat Ledger" --time 3y` *(fails: NetworkError: kraken GET https://api.kraken.com/0/public/Assets)*

------
https://chatgpt.com/codex/tasks/task_e_689631a5944c8326a9242306fd5bb2aa