### PR TITLE
Add final simulation summary of capital and realized gains

### DIFF
--- a/systems/sim_engine.py
+++ b/systems/sim_engine.py
@@ -216,5 +216,14 @@ def run_simulation(
         verbose_state=verbose,
     )
 
+    capital = settings.get("simulation_capital", 0.0)
+    addlog(
+        f"[SUMMARY] Simulated Capital: ${capital:.2f} | "
+        f"Realized Gain: ${summary['realized_gain']:.2f} | "
+        f"Final Value: ${capital + summary['realized_gain']:.2f}",
+        verbose_int=0,
+        verbose_state=0,
+    )
+
     # Simulation summary logged above; no extra counters in new pipeline.
 


### PR DESCRIPTION
## Summary
- always log starting capital, realized gain, and final value after simulations

## Testing
- `pytest`
- `python -m py_compile systems/sim_engine.py`


------
https://chatgpt.com/codex/tasks/task_e_6896456ef1bc8326ade318eb4881405a