### PR TITLE
Add bottom-likelihood scoring and ground-truth backtest

### DIFF
--- a/systems/sim_engine.py
+++ b/systems/sim_engine.py
@@ -1,11 +1,84 @@
 from __future__ import annotations
-import argparse, csv
+import argparse, csv, math
 from pathlib import Path
-from typing import List, Tuple
+from typing import List, Tuple, Optional
 
 # ts, open, high, low, close
 Candle = Tuple[int, float, float, float, float]
 LOG_PATH = Path("data/tmp/snapshots.log")
+
+# Tunable constants
+WINDOW = 132
+STEP = 24
+K = 12
+H = 48
+UP_TAKE = 0.03
+DOWN_FAIL = -0.015
+W_NEAR = 0.45
+W_MOMO = 0.25
+W_WICK = 0.20
+W_HL = 0.10
+
+
+def clip(x: float, a: float, b: float) -> float:
+    return max(a, min(b, x))
+
+
+def sigmoid(x: float) -> float:
+    return 1.0 / (1.0 + math.exp(-x))
+
+
+def compute_bottom_prob(window: List[Candle], pos_now: float) -> Tuple[float, float, float, float, float]:
+    closes = [x[4] for x in window]
+    lows = [x[3] for x in window]
+    opens = [x[1] for x in window]
+    highs = [x[2] for x in window]
+
+    f_near = 1 - pos_now
+
+    ma_short = sum(closes[-8:]) / max(1e-9, len(closes[-8:]))
+    ma_long = sum(closes[-24:]) / max(1e-9, len(closes[-24:]))
+    momo_raw = (ma_short - ma_long) / max(1e-9, ma_long)
+    f_momo = sigmoid(momo_raw * 10)
+
+    open_, high, low, close = opens[-1], highs[-1], lows[-1], closes[-1]
+    lower_wick = min(open_, close) - low
+    range_ = high - low
+    f_wick = clip(lower_wick / max(1e-9, range_), 0.0, 1.0)
+
+    k_lows = lows[-K:]
+    if len(k_lows) < 2:
+        f_hl = 0.0
+    else:
+        prior_min = min(k_lows[:-1])
+        f_hl = 1.0 if k_lows[-1] > prior_min * (1 + 0.001) else 0.0
+
+    bottom_prob = clip(
+        W_NEAR * f_near + W_MOMO * f_momo + W_WICK * f_wick + W_HL * f_hl,
+        0.0,
+        1.0,
+    )
+
+    return bottom_prob, f_near, f_momo, f_wick, f_hl
+
+
+def compute_ground_truth(candles: List[Candle], idx: int) -> Optional[int]:
+    if idx + H >= len(candles):
+        return None
+
+    t0_close = candles[idx - 1][4]
+    t0_low = candles[idx - 1][3]
+    up_target = t0_close * (1 + UP_TAKE)
+    down_target = t0_low * (1 + DOWN_FAIL)
+
+    for j in range(idx, idx + H):
+        high = candles[j][2]
+        low = candles[j][3]
+        if high >= up_target:
+            return 1
+        if low <= down_target:
+            return 0
+    return 0
 
 def load_candles(tag: str) -> List[Candle]:
     path = Path("data/raw") / f"{tag}.csv"
@@ -36,17 +109,14 @@ def log_snapshot(line: str, also_print: bool = True):
 
 def run(tag: str):
     candles = load_candles(tag)
-    if len(candles) < 721:
+    if len(candles) < WINDOW + H:
         print("Not enough data to simulate.")
         return
 
     init_snapshot_log()
 
-    WINDOW = 132   
-    STEP = 24  
-
-    zone_history = []
-    avgpos_history = []
+    bottom_probs: List[float] = []
+    gts: List[int] = []
 
     for i in range(WINDOW, len(candles), STEP):
         window = candles[i - WINDOW : i]
@@ -54,80 +124,59 @@ def run(tag: str):
         highs = [x[2] for x in window]
         closes = [x[4] for x in window]
 
-        low_30d = min(lows)
-        high_30d = max(highs)
-
-        positions = [
-            (c - low_30d) / (high_30d - low_30d) if high_30d != low_30d else 0.5
-            for c in closes
-        ]
-        avg_pos = sum(positions) / len(positions)
+        low_w = min(lows)
+        high_w = max(highs)
 
         current_close = closes[-1]
-        pos_now = (
-            (current_close - low_30d) / (high_30d - low_30d)
-            if high_30d != low_30d
-            else 0.5
-        )
+        denom = max(1e-9, high_w - low_w)
+        pos_now = 0.5 if high_w == low_w else (current_close - low_w) / denom
+        pos_now = clip(pos_now, 0.0, 1.0)
 
-        # Zone classification
-        if pos_now <= 0.2:
-            zone = "Bottom zone"
-        elif pos_now >= 0.8:
-            zone = "Top zone"
-        else:
-            zone = "Mid zone"
+        bottom_prob, f_near, f_momo, f_wick, f_hl = compute_bottom_prob(window, pos_now)
 
-        # Days in zone
-        if zone_history and zone_history[-1] == zone:
-            days_in_zone = (len(zone_history) + 1) * (STEP / 24)
-        else:
-            days_in_zone = STEP / 24
-
-        zone_history.append(zone)
-        avgpos_history.append(avg_pos)
-
-        # Entry speed (% per day from opposite range)
-        if zone == "Top zone":
-            ref_price = low_30d
-        elif zone == "Bottom zone":
-            ref_price = high_30d
-        else:
-            ref_price = None
-
-        if ref_price and ref_price != 0:
-            pct_move = abs((current_close - ref_price) / ref_price) * 100
-            entry_speed = pct_move / days_in_zone
-        else:
-            entry_speed = 0
-
-        # AvgPos trend (last 3 snapshots)
-        if len(avgpos_history) >= 3:
-            trend_val = avgpos_history[-1] - avgpos_history[-3]
-            if trend_val > 0.02:
-                avgpos_trend = "rising"
-            elif trend_val < -0.02:
-                avgpos_trend = "falling"
-            else:
-                avgpos_trend = "flat"
-        else:
-            avgpos_trend = "flat"
-
-        # Scenario tag
-        if zone == "Bottom zone" and avgpos_trend == "rising" and entry_speed > 1:
-            scenario = "BUY probability high"
-        elif zone == "Top zone" and avgpos_trend == "falling" and entry_speed > 1:
-            scenario = "SELL probability high"
-        else:
-            scenario = "No strong bias"
+        gt = compute_ground_truth(candles, i)
+        if gt is not None:
+            bottom_probs.append(bottom_prob)
+            gts.append(gt)
 
         ts = window[-1][0]
+        gt_str = str(gt) if gt is not None else "NA"
+        debug_bits = (
+            f"near={f_near:.2f}, momo={f_momo:.2f}, "
+            f"wick={f_wick:.2f}, hl={int(f_hl)}"
+        )
         line = (
-            f"[SNAPSHOT] {ts} | AvgPos: {avg_pos:.2f} | PosNow: {pos_now:.2f} | "
-            f"DaysInZone: {days_in_zone:.1f} | EntrySpeed: {entry_speed:.2f}%/day | "
-            f"Bias: {avgpos_trend} | Zone: {zone} | {scenario}"
+            f"[SNAPSHOT] {ts} | PosNow:{pos_now:.2f} | BottomProb:{bottom_prob:.2f} "
+            f"| GT:{gt_str} | Notes:{debug_bits}"
         )
         log_snapshot(line)
+
+    # End-of-run summary
+    if gts:
+        gt1_probs = [p for p, g in zip(bottom_probs, gts) if g == 1]
+        gt0_probs = [p for p, g in zip(bottom_probs, gts) if g == 0]
+        avg_gt1 = sum(gt1_probs) / len(gt1_probs) if gt1_probs else 0.0
+        avg_gt0 = sum(gt0_probs) / len(gt0_probs) if gt0_probs else 0.0
+
+        high_cases = [(p, g) for p, g in zip(bottom_probs, gts) if p >= 0.7]
+        hits_high = sum(1 for p, g in high_cases if g == 1)
+        count_high = len(high_cases)
+        hit_rate_high = hits_high / count_high if count_high else 0.0
+
+        summary = (
+            f"[SUMMARY] AvgProb|GT=1:{avg_gt1:.3f} AvgProb|GT=0:{avg_gt0:.3f} "
+            f"HitRate>=0.7:{hit_rate_high:.3f}"
+        )
+        log_snapshot(summary)
+
+        bins = [0.0, 0.2, 0.4, 0.6, 0.8, 1.0]
+        for start, end in zip(bins[:-1], bins[1:]):
+            probs = [g for p, g in zip(bottom_probs, gts) if start <= p < end]
+            rate = sum(probs) / len(probs) if probs else 0.0
+            log_snapshot(
+                f"[CALIBRATION] {start:.1f}-{end:.1f}: {rate:.3f}",
+                also_print=False,
+            )
 
 def main():
     parser = argparse.ArgumentParser(description="Monthly wave snapshot with predictive tags.")


### PR DESCRIPTION
## Summary
- compute bottom-likelihood probability using blend of position, momentum, wick, and higher-low signals
- log realized bottom ground-truth over fixed horizon for quick calibration
- summarize average probabilities, hit rates, and calibration bins after simulation

## Testing
- `python systems/sim_engine.py DOGEUSD`


------
https://chatgpt.com/codex/tasks/task_e_68967de139848326a437d6561feed880