### PR TITLE
Track PnL and summarize sim results

### DIFF
--- a/ledger_manager.py
+++ b/ledger_manager.py
@@ -13,6 +13,7 @@ class LedgerManager:
         self.open_notes: List[Dict] = []
         self.closed_notes: List[Dict] = []
         self._next_id = 1
+        self.realized_usd: float = 0.0
 
     def buy(self, coin_amount: float, price: float, ts: int) -> Dict:
         """Record a buy and return the created note."""
@@ -54,6 +55,8 @@ class LedgerManager:
             note.setdefault("fills", []).append(fill)
             fills.append(fill)
             coin_left -= take
+            pnl = (price - note["entry_price"]) * take
+            self.realized_usd += pnl
             if note["remaining"] <= 0:
                 self.open_notes.remove(note)
                 closed = dict(note)
@@ -74,6 +77,20 @@ class LedgerManager:
     def total_coin(self) -> float:
         return sum(n["remaining"] for n in self.open_notes)
 
+    def realized_gain_usd(self) -> float:
+        return self.realized_usd
+
+    def unrealized_gain_usd(self, price: float) -> float:
+        return sum(
+            (price - n["entry_price"]) * n["remaining"] for n in self.open_notes
+        )
+
+    def total_pnl_usd(self, price: float) -> float:
+        return self.realized_gain_usd() + self.unrealized_gain_usd(price)
+
+    def value_usd(self, price: float) -> float:
+        return self.total_coin() * price
+
     def summary(self) -> Dict:
         return {
             "open_notes": len(self.open_notes),
@@ -86,6 +103,20 @@ class LedgerManager:
         data = {
             "open_notes": self.get_open_notes(),
             "closed_notes": self.get_closed_notes(),
+        }
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("w", encoding="utf-8") as f:
+            json.dump(data, f, indent=2)
+
+    def save_summary(self, path: Path, final_price: float) -> None:
+        data = {
+            "final_price": final_price,
+            "realized_usd": self.realized_gain_usd(),
+            "unrealized_usd": self.unrealized_gain_usd(final_price),
+            "total_pnl_usd": self.total_pnl_usd(final_price),
+            "remaining_coin": self.total_coin(),
+            "open_notes": len(self.open_notes),
+            "closed_notes": len(self.closed_notes),
         }
         path.parent.mkdir(parents=True, exist_ok=True)
         with path.open("w", encoding="utf-8") as f:

--- a/systems/sim_engine.py
+++ b/systems/sim_engine.py
@@ -227,9 +227,20 @@ def run(tag: str) -> None:
         line += f" | OpenNotes:{len(ledger.get_open_notes())} Coin:{ledger.total_coin():.4f}"
         log_snapshot(line)
 
+    final_price = candles[-1][4]
+    realized = ledger.realized_gain_usd()
+    unrealized = ledger.unrealized_gain_usd(final_price)
+    total = realized + unrealized
+    coin = ledger.total_coin()
+    print(
+        f"[SIM] PnL | Realized:${realized:.2f} | Unrealized:${unrealized:.2f} | "
+        f"Total:${total:.2f} | Coin:{coin:.6f} @ ${final_price:.4f}"
+    )
+
     out_dir = Path("data/tmp")
     out_dir.mkdir(parents=True, exist_ok=True)
     ledger.save(out_dir / "ledger_simple.json")
+    ledger.save_summary(Path("data/tmp/ledger_simple_summary.json"), final_price)
 
 
 def main() -> None:


### PR DESCRIPTION
## Summary
- extend ledger manager to track realized gains, compute unrealized and total PnL, and persist a summary JSON
- emit end-of-run PnL summary in simulation engine and save ledger summary file

## Testing
- `python systems/sim_engine.py DOGE`


------
https://chatgpt.com/codex/tasks/task_e_6896ae757cf08326bf30a15dc853feb3