### PR TITLE
refactor: centralize config and load sim settings

### DIFF
--- a/settings/global.yaml
+++ b/settings/global.yaml
@@ -1,0 +1,20 @@
+strategy_defaults:
+  snapback_odds:
+    weights:
+      divergence: 0.45
+      wick: 0.35
+      depth: 0.20
+  topbottom:
+    alpha_wick: 0.12
+    smooth_ema: 0.25
+    momentum_bars: 8
+    momentum_eps: 0.0015
+    dead_zone_pct: null
+    dead_zone_min: 0.44
+    dead_zone_max: 0.56
+  odds_lookback: 8
+engine_defaults:
+  window_alg:
+    window: 300
+    step: 5
+  base_unit: 1.0

--- a/settings/knobs.json
+++ b/settings/knobs.json
@@ -1,0 +1,35 @@
+{
+  "DOGEUSD": {
+    "dog": {
+      "buy_cooldown": [1, 150],
+      "sell_cooldown": [0, 1508],
+      "maturity_multiplier": [0.5, 5.0],
+      "buy_cooldown_multiplier_scale": [0.5, 5.0],
+      "sell_cooldown_multiplier_scale": [0.5, 5.0],
+      "dead_zone_pct": [0.0, 0.1],
+      "max_open_notes": [999, 999]
+    }
+  },
+  "SOLUSDC": {
+    "bunny": {
+      "buy_cooldown": [1, 48],
+      "sell_cooldown": [0, 48],
+      "maturity_multiplier": [0.5, 5.0],
+      "buy_cooldown_multiplier_scale": [0.5, 2.0],
+      "sell_cooldown_multiplier_scale": [0.5, 2.0],
+      "dead_zone_pct": [0.0, 0.1],
+      "max_open_notes": [10, 100]
+    }
+  },
+  "SOLUSD": {
+    "goat": {
+      "buy_cooldown": [1, 48],
+      "sell_cooldown": [0, 48],
+      "maturity_multiplier": [0.5, 5.0],
+      "buy_cooldown_multiplier_scale": [0.5, 2.0],
+      "sell_cooldown_multiplier_scale": [0.5, 2.0],
+      "dead_zone_pct": [0.0, 0.1],
+      "max_open_notes": [10, 100]
+    }
+  }
+}

--- a/settings/ledger.json
+++ b/settings/ledger.json
@@ -1,0 +1,108 @@
+{
+  "ledger_settings": {
+    "Kris_Ledger": {
+      "tag": "DOGEUSD",
+      "asset": "DOGE",
+      "wallet_code": "XXDG",
+      "kraken_name": "DOGE/USD",
+      "kraken_pair": "XXDGZUSD",
+      "binance_name": "DOGEUSDT",
+      "window_settings": {
+        "dog": {
+          "window_size": "3d",
+          "buy_cooldown": 11,
+          "sell_cooldown": 5,
+          "investment_fraction": 0.02,
+          "maturity_multiplier": 0.853105598271046,
+          "buy_multiplier_scale": 3.429,
+          "buy_cooldown_multiplier_scale": 0.902421258277746,
+          "sell_cooldown_multiplier_scale": 1.56339541767712,
+          "dead_zone_pct": 0.0225026538433316,
+          "max_open_notes": 71,
+          "window_alg": { "window": 300, "step": 5 },
+          "topbottom": {
+            "alpha_wick": 0.12,
+            "smooth_ema": 0.25,
+            "momentum_bars": 8,
+            "momentum_eps": 0.0015,
+            "dead_zone_pct": 0.0225026538433316,
+            "dead_zone_min": 0.44,
+            "dead_zone_max": 0.56
+          },
+          "snapback_odds": { "lookback": 8 }
+        }
+      }
+    },
+    "Travis_Ledger": {
+      "tag": "SOLUSDC",
+      "asset": "SOL",
+      "wallet_code": "SOL.F",
+      "kraken_name": "SOL/USDC",
+      "kraken_pair": "SOLUSDC",
+      "binance_name": "SOLUSDC",
+      "window_settings": {
+        "bunny": {
+          "window_size": "7d",
+          "buy_cooldown": 3,
+          "sell_cooldown": 0,
+          "investment_fraction": 0.07,
+          "maturity_multiplier": 4.66765213004084,
+          "buy_multiplier_scale": 4.6,
+          "buy_cooldown_multiplier_scale": 1.95196594757427,
+          "sell_cooldown_multiplier_scale": 1.78927890073705,
+          "dead_zone_pct": 0.010929080263379,
+          "max_open_notes": 93,
+          "window_alg": { "window": 300, "step": 5 },
+          "topbottom": {
+            "alpha_wick": 0.12,
+            "smooth_ema": 0.25,
+            "momentum_bars": 8,
+            "momentum_eps": 0.0015,
+            "dead_zone_pct": 0.010929080263379,
+            "dead_zone_min": 0.44,
+            "dead_zone_max": 0.56
+          },
+          "snapback_odds": { "lookback": 8 }
+        }
+      }
+    },
+    "Goat Ledger": {
+      "tag": "SOLUSD",
+      "asset": "SOL",
+      "wallet_code": "SOL.F",
+      "kraken_name": "SOL/USD",
+      "kraken_pair": "SOLUSD",
+      "binance_name": "SOLUSDT",
+      "window_settings": {
+        "goat": {
+          "window_size": "1m",
+          "buy_cooldown": 3,
+          "sell_cooldown": 1,
+          "investment_fraction": 0.06,
+          "maturity_multiplier": 0.7,
+          "buy_multiplier_scale": 1.8,
+          "buy_cooldown_multiplier_scale": 1.0,
+          "sell_cooldown_multiplier_scale": 1.2,
+          "dead_zone_pct": 0.025,
+          "max_open_notes": 25,
+          "window_alg": { "window": 300, "step": 5 },
+          "topbottom": {
+            "alpha_wick": 0.12,
+            "smooth_ema": 0.25,
+            "momentum_bars": 8,
+            "momentum_eps": 0.0015,
+            "dead_zone_pct": 0.025,
+            "dead_zone_min": 0.44,
+            "dead_zone_max": 0.56
+          },
+          "snapback_odds": { "lookback": 8 }
+        }
+      }
+    }
+  },
+  "general_settings": {
+    "max_note_usdt": 1000.0,
+    "minimum_note_size": 10
+  },
+  "simulation_capital": 1000
+}

--- a/systems/utils/config.py
+++ b/systems/utils/config.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+"""Configuration loading and resolution helpers."""
+
+from pathlib import Path
+import json
+import yaml
+from typing import Any, Dict
+import copy
+
+ROOT = Path(__file__).resolve().parents[2]
+
+DEFAULT_CFG: Dict[str, Any] = {
+    "window_alg": {"window": 300, "step": 5},
+    "base_unit": 1.0,
+    "topbottom": {
+        "alpha_wick": 0.12,
+        "smooth_ema": 0.25,
+        "momentum_bars": 8,
+        "momentum_eps": 0.0015,
+        "dead_zone_min": 0.44,
+        "dead_zone_max": 0.56,
+        "dead_zone_pct": None,
+    },
+    "snapback_odds": {
+        "lookback": 8,
+        "weights": {
+            "divergence": 0.45,
+            "wick": 0.35,
+            "depth": 0.20,
+        },
+    },
+}
+
+
+def _read_json(path: Path) -> Dict[str, Any]:
+    with path.open("r", encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def _read_yaml(path: Path) -> Dict[str, Any]:
+    with path.open("r", encoding="utf-8") as fh:
+        data = yaml.safe_load(fh)
+        return {} if data is None else data
+
+
+def load_ledger(path: str = "settings/ledger.json") -> Dict[str, Any]:
+    """Load the project ledger configuration."""
+    return _read_json(ROOT / path)
+
+
+def load_global(path: str = "settings/global.yaml") -> Dict[str, Any]:
+    """Load global defaults."""
+    return _read_yaml(ROOT / path)
+
+
+def load_knobs(path: str = "settings/knobs.json") -> Dict[str, Any]:
+    """Load knob ranges for search."""
+    return _read_json(ROOT / path)
+
+
+def _deep_update(base: Dict[str, Any], overrides: Dict[str, Any]) -> Dict[str, Any]:
+    for key, val in overrides.items():
+        if isinstance(val, dict) and isinstance(base.get(key), dict):
+            base[key] = _deep_update(base.get(key, {}), val)
+        else:
+            base[key] = val
+    return base
+
+
+def resolve_window_cfg(
+    ledger_name: str,
+    window_key: str,
+    tag: str,
+    *,
+    ledger: Dict[str, Any],
+    global_cfg: Dict[str, Any],
+) -> Dict[str, Any]:
+    """Resolve configuration for a specific ledger/window pair."""
+
+    ledgers = ledger.get("ledger_settings")
+    if not ledgers:
+        raise ValueError("ledger_settings missing in ledger config")
+    if ledger_name not in ledgers:
+        raise ValueError(f"ledger '{ledger_name}' not found")
+    ledger_cfg = ledgers[ledger_name]
+    windows = ledger_cfg.get("window_settings") or {}
+    if window_key not in windows:
+        raise ValueError(
+            f"window '{window_key}' not found for ledger '{ledger_name}'"
+        )
+    window_cfg = windows[window_key]
+
+    cfg = copy.deepcopy(DEFAULT_CFG)
+
+    # Global defaults
+    _deep_update(cfg, global_cfg.get("engine_defaults", {}))
+    strat = global_cfg.get("strategy_defaults", {})
+    if strat.get("topbottom"):
+        _deep_update(cfg["topbottom"], strat["topbottom"])
+    weights = (strat.get("snapback_odds") or {}).get("weights")
+    if weights:
+        _deep_update(cfg["snapback_odds"]["weights"], weights)
+    if (strat.get("snapback_odds") or {}).get("lookback") is not None:
+        cfg["snapback_odds"]["lookback"] = strat["snapback_odds"]["lookback"]
+    if strat.get("odds_lookback") is not None:
+        cfg["snapback_odds"]["lookback"] = strat["odds_lookback"]
+
+    # Ledger level overrides
+    ledger_overlay = {
+        k: ledger_cfg[k]
+        for k in ("window_alg", "base_unit", "topbottom", "snapback_odds")
+        if k in ledger_cfg
+    }
+    _deep_update(cfg, ledger_overlay)
+
+    # Window level overrides
+    win_overlay = {
+        k: window_cfg[k]
+        for k in ("window_alg", "base_unit", "topbottom", "snapback_odds")
+        if k in window_cfg
+    }
+    _deep_update(cfg, win_overlay)
+
+    # Legacy support for dead_zone_pct at root
+    if "dead_zone_pct" in window_cfg:
+        cfg["topbottom"]["dead_zone_pct"] = window_cfg["dead_zone_pct"]
+
+    return cfg


### PR DESCRIPTION
## Summary
- move ledger and knobs settings into new `settings/` dir and add `global.yaml`
- add `systems.utils.config` helpers to load and merge settings
- refactor `sim_engine` to read configuration via resolver instead of hardcoded constants

## Testing
- `python -m py_compile systems/sim_engine.py systems/utils/config.py`
- `python -m systems.sim_engine SOLUSD --ledger 'Goat Ledger' --window goat`

------
https://chatgpt.com/codex/tasks/task_e_6896b6b615948326bc257ca7be42d050