### PR TITLE
refactor: resolve exchange pairs at runtime

### DIFF
--- a/settings/ledgers.json
+++ b/settings/ledgers.json
@@ -1,12 +1,9 @@
 {
   "ledgers": {
-    "kris": {},
-    "travis": {}
+    "kris": { "tag": "DOGE" },
+    "travis": { "tag": "SOL" }
   },
   "default": {
-    "wallet_code": "XXDG",
-    "kraken_name": "DOGE/USD",
-    "binance_name": "DOGEUSDT",
     "window_size": "1m",
     "investment_size": 0.02,
     "buy_multiplier": 3,

--- a/systems/live_engine.py
+++ b/systems/live_engine.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import argparse
 
 from systems.utils.config import load_ledgers, resolve_ledger_cfg
+from systems.utils.pairs import resolve_by_tag
 
 
 def run(args: argparse.Namespace) -> None:
@@ -10,9 +11,13 @@ def run(args: argparse.Namespace) -> None:
     ledger_name = args.ledger or next(iter(all_cfg.get("ledgers", {})))
     cfg = resolve_ledger_cfg(ledger_name, all_cfg)
 
-    wallet_code = cfg["wallet_code"]
-    kraken_name = cfg["kraken_name"]
-    binance_name = cfg["binance_name"]
+    if "tag" not in cfg:
+        raise SystemExit(f"[error] Ledger '{ledger_name}' missing 'tag' in settings/ledgers.json")
+
+    pair = resolve_by_tag(cfg["tag"])
+    kraken_wallet_code = pair.get("kraken_wallet_code")
+    kraken_symbol = pair["kraken_symbol"]
+    binance_symbol = pair["binance_symbol"]
 
     window_size = cfg["window_size"]
     investment_size = float(cfg["investment_size"])
@@ -35,13 +40,14 @@ def run(args: argparse.Namespace) -> None:
     snapback_lookback = int(cfg["snapback_odds"]["lookback"])
 
     print(
-        f"[LIVE] Loaded {ledger_name} | Kraken:{kraken_name} Binance:{binance_name} Window:{window_size}"
+        f"[LIVE] Loaded {ledger_name} | Kraken:{kraken_symbol} Binance:{binance_symbol} Window:{window_size}"
     )
 
 
 def main() -> None:
     parser = argparse.ArgumentParser(description="Live trading engine stub.")
     parser.add_argument("--ledger", dest="ledger", help="Ledger name to use")
+    parser.add_argument("--dry", action="store_true", help="Dry run")
     args = parser.parse_args()
     run(args)
 

--- a/systems/scripts/resolve_ccxt_symbols.py
+++ b/systems/scripts/resolve_ccxt_symbols.py
@@ -1,5 +1,10 @@
+from systems.utils.pairs import resolve_by_tag
+
+
 def resolve_ccxt_symbols(ledger_cfg: dict) -> dict:
+    # ledger_cfg MUST have 'tag'
+    info = resolve_by_tag(ledger_cfg["tag"])
     return {
-        "kraken": ledger_cfg["kraken_name"],
-        "binance": ledger_cfg["binance_name"],
+        "kraken": info["kraken_symbol"],
+        "binance": info["binance_symbol"],
     }

--- a/systems/utils/pairs.py
+++ b/systems/utils/pairs.py
@@ -1,0 +1,60 @@
+import json
+from pathlib import Path
+
+CACHE_PATH = Path("data/tmp/pair_cache.json")
+
+
+class PairNotFound(Exception):
+    pass
+
+
+def load_cache(path: str | Path = CACHE_PATH) -> dict:
+    with open(path, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def resolve_by_tag(tag: str, cache: dict | None = None) -> dict:
+    """
+    Returns a dict of canonical symbols/codes for the logical tag.
+    Expected cache structure: cache[tag] exists.
+    Output (minimum):
+      {
+        "binance_symbol": "DOGEUSDT",
+        "kraken_symbol": "DOGE/USD",
+        "kraken_wallet_code": "XXDG",   # if present in cache.wallet_codes
+        "binance_base": "DOGE",         # convenience
+      }
+    Selection rules:
+      - Choose the first Binance market for this base with a quote in priority [USD, USDT, USDC];
+        fallback to any if none match.
+      - Choose the first Kraken market similarly; fallback to any if none match.
+    """
+    cache = cache or load_cache()
+    entry = cache.get(tag.upper())
+    if not entry:
+        raise PairNotFound(f"No pair info for tag '{tag}' in {CACHE_PATH}")
+    # Binance pick
+    b_list = entry.get("binance") or []
+    b_pick = _pick_by_quotes(b_list, ("USD", "USDT", "USDC"), "symbol")
+    # Kraken pick
+    k_list = entry.get("kraken") or []
+    k_pick = _pick_by_quotes(k_list, ("USD", "USDT", "USDC"), "symbol")
+    # Wallet codes if present
+    wc = (entry.get("wallet_codes") or {})
+    return {
+        "binance_symbol": (b_pick or {}).get("symbol"),
+        "kraken_symbol": (k_pick or {}).get("symbol"),
+        "kraken_wallet_code": wc.get("kraken_asset"),
+        "binance_base": (b_pick or {}).get("base")
+        or wc.get("binance_asset")
+        or tag.upper(),
+    }
+
+
+def _pick_by_quotes(markets: list[dict], priority: tuple[str, ...], symbol_key: str) -> dict | None:
+    # markets contain unified keys from ccxt: 'symbol', 'base', 'quote'
+    by_quote = {m.get("quote"): m for m in markets if m.get(symbol_key)}
+    for q in priority:
+        if q in by_quote:
+            return by_quote[q]
+    return markets[0] if markets else None


### PR DESCRIPTION
## Summary
- simplify ledger settings to keep only per-ledger tag
- add utility to resolve Binance/Kraken symbols from `pair_cache.json`
- update engines and symbol resolver to derive symbols from tag

## Testing
- `python -m systems.sim_engine --ledger kris`
- `python -m systems.live_engine --ledger kris --dry`
- `git grep -n -w "kraken_name\|binance_name\|wallet_code"`


------
https://chatgpt.com/codex/tasks/task_e_6897342089b88326b0ad02b00aa3b318