### PR TITLE
refactor: use tag-based raw filenames

### DIFF
--- a/systems/fetch.py
+++ b/systems/fetch.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import argparse
+import csv
+from typing import List, Tuple
+
+import ccxt
+
+from systems.utils.pairs import resolve_by_tag, raw_path
+from systems.utils.time import parse_relative_time
+
+COLUMNS = ["timestamp", "open", "high", "low", "close", "volume"]
+
+
+def _fetch(exchange: ccxt.Exchange, symbol: str, start_ms: int, end_ms: int) -> List[Tuple[int, float, float, float, float, float]]:
+    """Fetch OHLCV data between ``start_ms`` and ``end_ms`` (inclusive)."""
+    ohlcv = exchange.fetch_ohlcv(symbol, timeframe="1h", since=start_ms, limit=1000)
+    rows: List[Tuple[int, float, float, float, float, float]] = []
+    for ts, o, h, l, c, v in ohlcv:
+        if ts > end_ms:
+            break
+        rows.append((ts // 1000, o, h, l, c, v))
+    return rows
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="Fetch raw candles by tag")
+    parser.add_argument("--tag", required=True, help="Coin tag, e.g. SOL")
+    parser.add_argument(
+        "--time",
+        default="48h",
+        help="Relative time window to fetch (e.g. 48h)",
+    )
+    args = parser.parse_args(argv)
+
+    tag = args.tag.upper()
+    start_ts, end_ts = parse_relative_time(args.time)
+    start_ms = int(start_ts * 1000)
+    end_ms = int(end_ts * 1000)
+
+    pair = resolve_by_tag(tag)
+    bn_symbol = pair.get("binance_symbol")
+    kr_symbol = pair.get("kraken_symbol")
+
+    frames: List[Tuple[int, float, float, float, float, float]] = []
+    if kr_symbol:
+        try:
+            kr = ccxt.kraken({"enableRateLimit": True})
+            frames.extend(_fetch(kr, kr_symbol, start_ms, end_ms))
+        except Exception as exc:  # pragma: no cover - network
+            print(f"[fetch] kraken error: {exc}")
+    if bn_symbol:
+        try:
+            bn = ccxt.binance({"enableRateLimit": True})
+            frames.extend(_fetch(bn, bn_symbol, start_ms, end_ms))
+        except Exception as exc:  # pragma: no cover - network
+            print(f"[fetch] binance error: {exc}")
+
+    dedup = {ts: (ts, o, h, l, c, v) for ts, o, h, l, c, v in frames}
+    ordered = [dedup[k] for k in sorted(dedup)]
+
+    path = raw_path(tag)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", newline="", encoding="utf-8") as f:
+        writer = csv.writer(f)
+        writer.writerow(COLUMNS)
+        writer.writerows(ordered)
+
+    print(f"[fetch] wrote {len(ordered)} rows to {path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/systems/sim_engine.py
+++ b/systems/sim_engine.py
@@ -7,7 +7,7 @@ from typing import List, Tuple, Dict
 from systems.scripts.ledger_manager import LedgerManager
 from systems.scripts.evaluate_buy import evaluate_buy
 from systems.scripts.evaluate_sell import evaluate_sell
-from systems.utils.pairs import resolve_by_tag
+from systems.utils.pairs import resolve_by_tag, raw_path
 
 # ts, open, high, low, close
 Candle = Tuple[int, float, float, float, float]
@@ -20,8 +20,8 @@ DEAD_ZONE_MAX = 0.55
 
 
 
-def load_candles(symbol: str) -> List[Candle]:
-    path = Path("data/raw") / f"{symbol}.csv"
+def load_candles(tag: str) -> List[Candle]:
+    path = raw_path(tag)
     candles: List[Candle] = []
     with path.open() as f:
         reader = csv.DictReader(f)
@@ -54,7 +54,7 @@ def clip(x: float, lo: float, hi: float) -> float:
     return lo if x < lo else hi if x > hi else x
 
 
-def run(binance_symbol: str, base: str) -> None:
+def run(tag: str, base: str) -> None:
     cfg = CFG
 
     investment_size = float(cfg["investment_size"])
@@ -89,7 +89,7 @@ def run(binance_symbol: str, base: str) -> None:
     BASE_UNIT = investment_size
     ODDS_LOOKBACK = snapback_lookback
 
-    candles = load_candles(binance_symbol)
+    candles = load_candles(tag)
     if len(candles) < WINDOW:
         print("Not enough data to simulate.")
         return
@@ -273,12 +273,10 @@ def main() -> None:
         )
 
     pair = resolve_by_tag(tag)
-    binance_symbol = pair["binance_symbol"]
-    kraken_symbol = pair["kraken_symbol"]
 
     global CFG
     CFG = cfg
-    run(binance_symbol, pair["binance_base"])
+    run(tag, pair["binance_base"])
 
 
 if __name__ == "__main__":

--- a/systems/utils/pairs.py
+++ b/systems/utils/pairs.py
@@ -13,6 +13,11 @@ def load_cache(path: str | Path = CACHE_PATH) -> dict:
         return json.load(f)
 
 
+def raw_path(tag: str, base_dir: str | Path = "data/raw") -> Path:
+    """Return canonical raw data path for ``tag``."""
+    return Path(base_dir) / f"{tag.upper()}.csv"
+
+
 def resolve_by_tag(tag: str, cache: dict | None = None) -> dict:
     """
     Returns a dict of canonical symbols/codes for the logical tag.


### PR DESCRIPTION
## Summary
- load raw candles strictly by tag
- add fetch script that saves data/raw/{TAG}.csv
- centralize raw path computation in `pairs.raw_path`

## Testing
- `python -m systems.sim_engine --ledger travis`
- `python -m systems.fetch --tag sol --time 1h` *(fails: kraken GET https://api.kraken.com/0/public/Assets)*

------
https://chatgpt.com/codex/tasks/task_e_689736d5e54c8326b286e0314d223629