### PR TITLE
refactor: drop window_alg for window_size + skip_candles

### DIFF
--- a/settings/ledgers.json
+++ b/settings/ledgers.json
@@ -5,10 +5,10 @@
   },
   "default": {
     "window_size": "1m",
+    "skip_candles": 5,
     "investment_size": 0.02,
     "buy_multiplier": 3,
     "sell_multiplier": 3,
-    "window_alg": { "window": "1m", "skip_candles": 5 },
     "tunnel_settings": {
       "alpha_wick": 0.12,
       "smooth_ema": 0.25,

--- a/systems/live_engine.py
+++ b/systems/live_engine.py
@@ -20,13 +20,10 @@ def run(args: argparse.Namespace) -> None:
     binance_symbol = pair["binance_symbol"]
 
     window_size = cfg["window_size"]
+    skip_candles = int(cfg["skip_candles"])
     investment_size = float(cfg["investment_size"])
     buy_multiplier = float(cfg["buy_multiplier"])
     sell_multiplier = float(cfg["sell_multiplier"])
-
-    wa = cfg["window_alg"]
-    window_alg_window = wa["window"]
-    window_alg_skip_candles = int(wa["skip_candles"])
 
     TUN = cfg["tunnel_settings"]
     alpha_wick = float(TUN["alpha_wick"])
@@ -40,7 +37,7 @@ def run(args: argparse.Namespace) -> None:
     snapback_lookback = int(cfg["snapback_odds"]["lookback"])
 
     print(
-        f"[LIVE] Loaded {ledger_name} | Kraken:{kraken_symbol} Binance:{binance_symbol} Window:{window_size}"
+        f"[LIVE] Loaded {ledger_name} | Kraken:{kraken_symbol} Binance:{binance_symbol} Window:{window_size} Skip:{skip_candles}"
     )
 
 

--- a/systems/utils/config.py
+++ b/systems/utils/config.py
@@ -1,5 +1,5 @@
 import json
-from pathlib import Path
+import warnings
 
 
 def load_ledgers(path: str = "settings/ledgers.json") -> dict:
@@ -12,4 +12,22 @@ def resolve_ledger_cfg(ledger_name: str, all_cfg: dict) -> dict:
     override = dict(all_cfg.get("ledgers", {}).get(ledger_name, {}))
     # Shallow merge is fine given current schema
     base.update(override)
+
+    # Backward compatibility for legacy window_alg structure
+    wa = base.pop("window_alg", None)
+    if wa is not None:
+        warnings.warn(
+            "'window_alg' is deprecated; use 'window_size' and 'skip_candles'",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        base.setdefault("window_size", wa.get("window"))
+        base.setdefault("skip_candles", int(wa.get("skip_candles", 5)))
+
+    # Ensure skip_candles exists with default of 5
+    if "skip_candles" not in base:
+        base["skip_candles"] = 5
+    else:
+        base["skip_candles"] = int(base["skip_candles"])
+
     return base


### PR DESCRIPTION
## Summary
- simplify ledger settings by removing `window_alg`
- read `window_size` and new `skip_candles` directly in engines
- add config fallback for legacy `window_alg`

## Testing
- `python -m py_compile systems/**/*.py`
- `python -m systems.sim_engine --ledger travis`
- `python -m systems.sim_engine --ledger kris` (with temporary `skip_candles` override)


------
https://chatgpt.com/codex/tasks/task_e_68973a22d35883268b435c6ec3864ff4