### PR TITLE
Enable snapback odds weighting

### DIFF
--- a/settings/ledgers.json
+++ b/settings/ledgers.json
@@ -19,6 +19,9 @@
       "dead_zone_min": 0.44,
       "dead_zone_max": 0.56
     },
-    "snapback_odds": { "lookback": 20 }
+    "snapback_odds": {
+      "lookback": 10,
+      "weights": { "divergence": 0.45, "wick": 0.35, "depth": 0.20 }
+    }
   }
 }

--- a/systems/sim_engine.py
+++ b/systems/sim_engine.py
@@ -79,11 +79,16 @@ def run(tag: str, base: str) -> None:
     dead_zone_max = 0.5 + dz_pct / 2 if dz_pct is not None else DEAD_ZONE_MAX
 
     snapback = cfg.get("snapback_odds", {})
-    snapback_lookback = int(snapback.get("lookback", 0))
-    weights = snapback.get("weights", {})
-    W_DIVERGENCE = weights.get("divergence", 0)
-    W_WICK = weights.get("wick", 0)
-    W_DEPTH = weights.get("depth", 0)
+    snapback_lookback = int(snapback.get("lookback", 8))
+    weights = snapback.get("weights", {}) or {}
+    W_DIVERGENCE = float(weights.get("divergence", 0.45))
+    W_WICK       = float(weights.get("wick",       0.35))
+    W_DEPTH      = float(weights.get("depth",      0.20))
+
+    print(
+        f"[SIM] snapback lookback={snapback_lookback} "
+        f"weights(div={W_DIVERGENCE:.2f}, wick={W_WICK:.2f}, depth={W_DEPTH:.2f})"
+    )
 
     WINDOW = 300
     STEP = skip_candles


### PR DESCRIPTION
## Summary
- add non-zero snapback weighting defaults in ledger config
- load snapback odds with sane fallbacks and emit debug print

## Testing
- `python -m py_compile systems/sim_engine.py`
- `python -m json.tool settings/ledgers.json`
- `PYTHONPATH=. python systems/sim_engine.py --ledger kris` *(fails: FileNotFoundError: No such file or directory: 'data/raw/SOL.csv')*

------
https://chatgpt.com/codex/tasks/task_e_689751bd0b6083269767ac19aa4aa2e2