### PR TITLE
Add debug sell gating modes for simulator

### DIFF
--- a/settings/ledgers.json
+++ b/settings/ledgers.json
@@ -27,6 +27,10 @@
       "fiat_start": 1000.0,
       "min_order_usd": 10.0,
       "allow_partial_buys": true
-    }
+    },
+    "debug_sell_mode": "A",
+    "debug_min_profit_pct": 0.005,
+    "debug_min_maturity_candles": 24,
+    "debug_log_skips": true
   }
 }

--- a/systems/sim_engine.py
+++ b/systems/sim_engine.py
@@ -60,6 +60,16 @@ def clip(x: float, lo: float, hi: float) -> float:
 def run(tag: str, base: str) -> None:
     cfg = CFG
 
+    mode = (cfg.get("debug_sell_mode") or "").strip().upper()
+    min_profit_pct = float(cfg.get("debug_min_profit_pct", 0.005))
+    min_maturity_c = int(cfg.get("debug_min_maturity_candles", 24))
+    log_skips = bool(cfg.get("debug_log_skips", True))
+    if mode in {"A", "B", "C"}:
+        print(
+            f"[SIM] Debug sell mode={mode} | min_profit_pct={min_profit_pct} | "
+            f"min_maturity_candles={min_maturity_c}"
+        )
+
     investment_size = float(cfg["investment_size"])
     buy_multiplier = float(cfg.get("buy_multiplier", 1.0))
     sell_multiplier = float(cfg.get("sell_multiplier", 1.0))
@@ -227,6 +237,25 @@ def run(tag: str, base: str) -> None:
         should_buy  = 2 * (should_buy - 0.5) / 0.5
         should_buy  = clip(should_buy, 0.0, 1.0)
 
+        # Compute candle duration (sec) from this and prev candle (handles ms timestamps)
+        dt = (candles[i][0] - candles[i - 1][0])
+        candle_seconds = int(dt / 1000) if dt > 10_000 else int(dt)
+
+        eligible_coin = None
+        if mode in {"A", "B", "C"}:
+            eligible_coin = 0.0
+            for n in ledger.get_open_notes():
+                ok = True
+                if mode == "A":  # Loss gate: require price >= entry
+                    ok = price >= n["entry_price"]
+                elif mode == "B":  # Maturity gate: require age >= N candles
+                    age_sec = max(0, ts - int(n["entry_ts"]))
+                    ok = age_sec >= (min_maturity_c * candle_seconds)
+                elif mode == "C":  # Profit buffer: require price >= entry*(1+X%)
+                    ok = price >= (n["entry_price"] * (1.0 + min_profit_pct))
+                if ok:
+                    eligible_coin += float(n.get("remaining", 0.0))
+
         ctx = {
             "topbottom": topbottom_smooth,
             "buy_var": buy_var,
@@ -245,11 +274,29 @@ def run(tag: str, base: str) -> None:
         sell_amt = evaluate_sell(ctx)
 
         action = None
+
+        # SELL path first (your existing order)
         if sell_amt > 0:
-            ledger.sell(sell_amt, ctx["price"], ctx["ts"])
-            action = f"SELLx{sell_amt:.2f}"
-        elif buy_amt > 0:
-            ledger.buy(buy_amt, ctx["price"], ctx["ts"])
+            if mode in {"A", "B", "C"}:
+                # cap to eligible inventory
+                capped = min(sell_amt, eligible_coin or 0.0)
+                if capped <= 0.0:
+                    if log_skips:
+                        log_snapshot(
+                            "[SKIP] sell: no eligible notes under debug mode " + mode,
+                            also_print=False,
+                        )
+                    # fall through to BUY check (so we can still buy same tick)
+                else:
+                    ledger.sell(capped, price, ts)
+                    action = f"SELLx{capped:.2f}"
+            else:
+                ledger.sell(sell_amt, price, ts)
+                action = f"SELLx{sell_amt:.2f}"
+
+        # BUY path
+        if action is None and buy_amt > 0:
+            ledger.buy(buy_amt, price, ts)
             action = f"BUYx{buy_amt:.2f}"
 
         # Single clean print


### PR DESCRIPTION
## Summary
- add configuration flags to simulate sell gating by loss, maturity, or profit buffer
- expose debug sell parameters in default ledger settings

## Testing
- `PYTHONPATH=. python systems/sim_engine.py --ledger kris` with debug_sell_mode=A
- `PYTHONPATH=. python systems/sim_engine.py --ledger kris` with debug_sell_mode=B
- `PYTHONPATH=. python systems/sim_engine.py --ledger kris` with debug_sell_mode=C

------
https://chatgpt.com/codex/tasks/task_e_68975c9286fc832691f63f2303e655ae