### PR TITLE
Add buy ladder sizing and profit-aware tiered selling

### DIFF
--- a/settings/ledgers.json
+++ b/settings/ledgers.json
@@ -23,6 +23,18 @@
       "lookback": 10,
       "weights": { "divergence": 0.45, "wick": 0.35, "depth": 0.20 }
     },
+    "buy_rules": {
+      "ladder_tb":  [0.35, 0.25, 0.15],
+      "ladder_mult":[1.0,  2.0,  3.0],
+      "gate_momentum": true,
+      "gate_wick_bias": true
+    },
+    "sell_rules": {
+      "allow_loss": false,
+      "min_profit_pct": 0.003,
+      "tiers_tb":   [0.80, 0.90, 0.95],
+      "tiers_frac": [0.25, 0.50, 1.00]
+    },
     "sim_settings": {
       "fiat_start": 1000.0,
       "min_order_usd": 10.0,

--- a/systems/scripts/evaluate_buy.py
+++ b/systems/scripts/evaluate_buy.py
@@ -1,11 +1,32 @@
 from __future__ import annotations
 
-"""Buy amount evaluator — parity with original SIM engine trigger & sizing."""
-
 def evaluate_buy(ctx: dict) -> float:
     score = float(ctx["should_buy"])
     if score < 0.5:
         return 0.0
+
     base = float(ctx["base_unit"])
     mult = float(ctx.get("buy_multiplier", 1.0))
-    return base * mult
+
+    # Optional ladder sizing (clean + defaults)
+    rules = ctx.get("buy_rules", {}) or {}
+    ladder_tb   = list((rules.get("ladder_tb") or []))
+    ladder_mult = list((rules.get("ladder_mult") or []))
+
+    # Gates (optional)
+    gate_mom  = bool(rules.get("gate_momentum", False))
+    gate_wick = bool(rules.get("gate_wick_bias", False))
+    if gate_mom and float(ctx.get("slope_micro", 0.0)) >= 0.0:
+        return 0.0  # momentum not down → skip buy
+    if gate_wick and float(ctx.get("lw_ratio", 0.0)) <= float(ctx.get("uw_ratio", 0.0)):
+        return 0.0  # no lower-wick dominance → skip buy
+
+    # Pick deepest matching ladder multiplier
+    tb = float(ctx.get("topbottom", 0.5))
+    ladder = 1.0
+    if ladder_tb and ladder_mult and len(ladder_tb) == len(ladder_mult):
+        for th, m in zip(ladder_tb, ladder_mult):
+            if tb <= float(th):
+                ladder = float(m)
+
+    return base * mult * ladder


### PR DESCRIPTION
## Summary
- support buy ladders and profit-aware tiered selling via new configuration rules
- implement optional ladder sizing with momentum and wick gates in buy evaluator
- cap sells to profitable inventory and tier fractions in the simulation engine

## Testing
- `pytest`
- `python -m systems.sim_engine --ledger default` (baseline w/out rules)
- `python -m systems.sim_engine --ledger default` (rules enabled)


------
https://chatgpt.com/codex/tasks/task_e_6897628b4880832694c97c1dec0876d8