### PR TITLE
Add simple Optuna tuner with CSV logging

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -11,12 +11,20 @@ from systems.sim_engine import run_sim
 def main() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument("--mode", required=True)
+    parser.add_argument("--trials", type=int, default=10)
     args = parser.parse_args()
-    if args.mode.lower() != "sim":
-        parser.error("--mode sim is the only supported mode")
-    with open("settings/settings.json") as f:
-        settings = json.load(f)
-    run_sim(settings)
+
+    mode = args.mode.lower()
+    if mode == "sim":
+        with open("settings/settings.json") as f:
+            settings = json.load(f)
+        run_sim(settings)
+    elif mode == "tune":
+        from optimizer import run as run_optimizer
+
+        run_optimizer(args.trials)
+    else:
+        parser.error("--mode must be either 'sim' or 'tune'")
 
 
 if __name__ == "__main__":

--- a/knobs.json
+++ b/knobs.json
@@ -1,0 +1,5 @@
+{
+  "buy_frequency": [1, 50],
+  "min_hold_time": [1, 100],
+  "avg_window_all_time": [10, 200]
+}

--- a/optimizer.py
+++ b/optimizer.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import csv
+import json
+import os
+from collections import OrderedDict
+from pathlib import Path
+from typing import Any, Dict
+
+import optuna
+
+from sim_engine import run_sim
+
+
+def run(trials: int) -> None:
+    """Run an Optuna study for the provided number of ``trials``."""
+    with open("settings.json", "r", encoding="utf-8") as f:
+        base_cfg: Dict[str, Any] = json.load(f)
+    with open("knobs.json", "r", encoding="utf-8") as f:
+        knobs: Dict[str, list[int]] = json.load(f)
+
+    results_path = Path("tune_results.csv")
+
+    def objective(trial: optuna.trial.Trial) -> float:
+        cfg = base_cfg.copy()
+        params: Dict[str, int] = {}
+        for name, bounds in knobs.items():
+            low, high = bounds
+            value = trial.suggest_int(name, int(low), int(high))
+            cfg[name] = value
+            params[name] = value
+
+        metrics = run_sim(cfg)
+
+        row = OrderedDict([("trial", trial.number)])
+        row.update(params)
+        row.update(metrics)
+
+        file_exists = results_path.exists()
+        with results_path.open("a", newline="", encoding="utf-8") as f:
+            writer = csv.DictWriter(f, fieldnames=row.keys())
+            if not file_exists:
+                writer.writeheader()
+            writer.writerow(row)
+            f.flush()
+            os.fsync(f.fileno())
+
+        return float(metrics["pnl"])
+
+    optuna.logging.set_verbosity(optuna.logging.WARNING)
+    study = optuna.create_study(direction="maximize")
+    study.optimize(objective, n_trials=trials)

--- a/settings.json
+++ b/settings.json
@@ -1,0 +1,6 @@
+{
+  "simulation_capital": 1000,
+  "buy_frequency": 5,
+  "min_hold_time": 10,
+  "avg_window_all_time": 50
+}

--- a/sim_engine.py
+++ b/sim_engine.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from collections import deque
+import csv
+from pathlib import Path
+from typing import Dict
+
+def run_sim(config: Dict[str, int | float]) -> Dict[str, float]:
+    """Run a minimal trading simulation and return metrics.
+
+    The simulation loads historical candle data from ``data/raw/DOGEUSD.csv``
+    and executes a simple strategy based on the provided configuration.
+    """
+    capital = float(config["simulation_capital"])
+    buy_frequency = int(config["buy_frequency"])
+    min_hold_time = int(config["min_hold_time"])
+    avg_window = int(config["avg_window_all_time"])
+
+    data_path = Path("data/raw/DOGEUSD.csv")
+    prices: list[float] = []
+    with data_path.open("r", encoding="utf-8") as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            prices.append(float(row["close"]))
+
+    window: deque[float] = deque(maxlen=avg_window)
+    holding = False
+    entry_price = 0.0
+    entry_step = 0
+    coin_amount = 0.0
+
+    for step, price in enumerate(prices):
+        window.append(price)
+        if not holding:
+            if step % buy_frequency == 0 and len(window) == avg_window:
+                avg_price = sum(window) / avg_window
+                if price < avg_price and capital > 0:
+                    coin_amount = capital / price
+                    capital = 0.0
+                    holding = True
+                    entry_price = price
+                    entry_step = step
+        else:
+            if step - entry_step >= min_hold_time and price > entry_price:
+                capital = coin_amount * price
+                coin_amount = 0.0
+                holding = False
+
+    if holding and prices:
+        capital += coin_amount * prices[-1]
+
+    final_capital = capital
+    pnl = final_capital - float(config["simulation_capital"])
+    return {"final_capital": final_capital, "pnl": pnl}


### PR DESCRIPTION
## Summary
- add baseline `settings.json` and `knobs.json` for tuning parameters
- implement minimal `sim_engine` and `optimizer` using Optuna with CSV logging
- extend `bot.py` with `tune` mode and trial count option

## Testing
- `python bot.py --mode tune --trials 1`
- inspected generated `tune_results.csv`

------
https://chatgpt.com/codex/tasks/task_e_6897a3a65a9c8326a1148d169f099919