### PR TITLE
Add tuning knobs and CSV header for tuning

### DIFF
--- a/knobs.json
+++ b/knobs.json
@@ -1,5 +1,11 @@
 {
   "buy_frequency": [1, 50],
   "min_hold_time": [1, 100],
-  "avg_window_all_time": [10, 200]
+  "avg_window_all_time": [10, 200],
+  "buy_fraction": [0.005, 0.1],
+  "maturity_gain_target": [0.005, 0.1],
+  "max_concurrent_notes": [5, 100],
+  "dip_depth_entry": [0.0, 0.2],
+  "slope_filter": [-0.05, 0.05],
+  "volatility_filter": [0.0, 0.05]
 }

--- a/settings.json
+++ b/settings.json
@@ -2,5 +2,11 @@
   "simulation_capital": 1000,
   "buy_frequency": 5,
   "min_hold_time": 10,
-  "avg_window_all_time": 50
+  "avg_window_all_time": 50,
+  "buy_fraction": 0.02,
+  "maturity_gain_target": 0.02,
+  "max_concurrent_notes": 20,
+  "dip_depth_entry": 0.03,
+  "slope_filter": 0.01,
+  "volatility_filter": 0.005
 }

--- a/tune_results.csv
+++ b/tune_results.csv
@@ -1,0 +1,1 @@
+trial,buy_frequency,min_hold_time,avg_window_all_time,buy_fraction,maturity_gain_target,max_concurrent_notes,dip_depth_entry,slope_filter,volatility_filter,final_capital,pnl


### PR DESCRIPTION
## Summary
- Expand default settings with new trading knobs and default values
- Allow optimizer to tune integer and float knobs and manage CSV headers
- Provide tuning ranges for new knobs and initialize results CSV with header

## Testing
- `python bot.py --mode tune --trials 1`


------
https://chatgpt.com/codex/tasks/task_e_6897a661ada4832682d2352e7cd4643f