### PR TITLE
refactor: split settings into buy and sell

### DIFF
--- a/knobs.json
+++ b/knobs.json
@@ -1,11 +1,15 @@
 {
-  "buy_frequency": [1, 50],
-  "min_hold_time": [1, 100],
-  "avg_window_all_time": [10, 200],
-  "buy_fraction": [0.005, 0.1],
-  "maturity_gain_target": [0.005, 0.1],
-  "max_concurrent_notes": [5, 100],
-  "dip_depth_entry": [0.0, 0.2],
-  "slope_filter": [-0.05, 0.05],
-  "volatility_filter": [0.0, 0.05]
+  "buy_settings.buy_frequency": [1, 50],
+  "buy_settings.buy_fraction": [0.005, 0.1],
+  "buy_settings.max_concurrent_notes": [5, 100],
+  "buy_settings.dip_depth_entry": [0.0, 0.2],
+  "buy_settings.slope_filter": [-0.05, 0.05],
+  "buy_settings.volatility_filter": [0.0, 0.05],
+
+  "sell_settings.min_hold_time": [1, 100],
+  "sell_settings.maturity_gain_target": [0.005, 0.1],
+  "sell_settings.max_hold_time": [20, 300],
+  "sell_settings.stop_loss_pct": [0.0, 0.2],
+  "sell_settings.trailing_stop_pct": [0.0, 0.1],
+  "sell_settings.trailing_start_gain": [0.0, 0.1]
 }

--- a/settings.json
+++ b/settings.json
@@ -1,12 +1,21 @@
 {
   "simulation_capital": 1000,
-  "buy_frequency": 5,
-  "min_hold_time": 10,
-  "avg_window_all_time": 50,
-  "buy_fraction": 0.02,
-  "maturity_gain_target": 0.02,
-  "max_concurrent_notes": 20,
-  "dip_depth_entry": 0.03,
-  "slope_filter": 0.01,
-  "volatility_filter": 0.005
+
+  "buy_settings": {
+    "buy_frequency": 5,
+    "buy_fraction": 0.02,
+    "max_concurrent_notes": 20,
+    "dip_depth_entry": 0.03,
+    "slope_filter": 0.01,
+    "volatility_filter": 0.005
+  },
+
+  "sell_settings": {
+    "min_hold_time": 10,
+    "maturity_gain_target": 0.02,
+    "max_hold_time": 150,
+    "stop_loss_pct": 0.06,
+    "trailing_stop_pct": 0.03,
+    "trailing_start_gain": 0.02
+  }
 }

--- a/sim_engine.py
+++ b/sim_engine.py
@@ -1,20 +1,34 @@
 from __future__ import annotations
 
-from collections import deque
 import csv
 from pathlib import Path
 from typing import Dict
 
-def run_sim(config: Dict[str, int | float]) -> Dict[str, float]:
+
+def run_sim(config: Dict[str, int | float | dict]) -> Dict[str, float]:
     """Run a minimal trading simulation and return metrics.
 
     The simulation loads historical candle data from ``data/raw/DOGEUSD.csv``
     and executes a simple strategy based on the provided configuration.
     """
+
     capital = float(config["simulation_capital"])
-    buy_frequency = int(config["buy_frequency"])
-    min_hold_time = int(config["min_hold_time"])
-    avg_window = int(config["avg_window_all_time"])
+    buy_cfg = config["buy_settings"]
+    sell_cfg = config["sell_settings"]
+
+    buy_frequency = int(buy_cfg["buy_frequency"])
+    buy_fraction = float(buy_cfg["buy_fraction"])
+    max_notes = int(buy_cfg["max_concurrent_notes"])
+    dip_depth_entry = float(buy_cfg["dip_depth_entry"])
+    slope_filter = float(buy_cfg["slope_filter"])
+    volatility_filter = float(buy_cfg["volatility_filter"])
+
+    min_hold_time = int(sell_cfg["min_hold_time"])
+    maturity_gain_target = float(sell_cfg["maturity_gain_target"])
+    max_hold_time = int(sell_cfg["max_hold_time"])
+    stop_loss_pct = float(sell_cfg["stop_loss_pct"])
+    trailing_stop_pct = float(sell_cfg["trailing_stop_pct"])
+    trailing_start_gain = float(sell_cfg["trailing_start_gain"])
 
     data_path = Path("data/raw/DOGEUSD.csv")
     prices: list[float] = []
@@ -23,31 +37,65 @@ def run_sim(config: Dict[str, int | float]) -> Dict[str, float]:
         for row in reader:
             prices.append(float(row["close"]))
 
-    window: deque[float] = deque(maxlen=avg_window)
-    holding = False
-    entry_price = 0.0
-    entry_step = 0
-    coin_amount = 0.0
+    open_notes: list[dict] = []
+    prev_price = prices[0] if prices else 0.0
 
     for step, price in enumerate(prices):
-        window.append(price)
-        if not holding:
-            if step % buy_frequency == 0 and len(window) == avg_window:
-                avg_price = sum(window) / avg_window
-                if price < avg_price and capital > 0:
-                    coin_amount = capital / price
-                    capital = 0.0
-                    holding = True
-                    entry_price = price
-                    entry_step = step
-        else:
-            if step - entry_step >= min_hold_time and price > entry_price:
-                capital = coin_amount * price
-                coin_amount = 0.0
-                holding = False
+        slope = (price - prev_price) / prev_price if prev_price else 0.0
+        volatility = abs(price - prev_price) / prev_price if prev_price else 0.0
 
-    if holding and prices:
-        capital += coin_amount * prices[-1]
+        # update peak price for trailing stop
+        for note in open_notes:
+            if price > note["peak_price"]:
+                note["peak_price"] = price
+
+        # check sells
+        notes_to_close: list[dict] = []
+        for note in open_notes:
+            hold_time = step - note["entry_step"]
+            gain = (price - note["entry_price"]) / note["entry_price"]
+            peak_gain = (note["peak_price"] - note["entry_price"]) / note["entry_price"]
+            drop_from_peak = (note["peak_price"] - price) / note["peak_price"] if note["peak_price"] else 0.0
+
+            if (hold_time >= min_hold_time and gain >= maturity_gain_target) or hold_time >= max_hold_time:
+                notes_to_close.append(note)
+            elif gain <= -stop_loss_pct:
+                notes_to_close.append(note)
+            elif peak_gain >= trailing_start_gain and drop_from_peak >= trailing_stop_pct:
+                notes_to_close.append(note)
+
+        for note in notes_to_close:
+            capital += note["amount"] * price
+            open_notes.remove(note)
+
+        # check buys
+        if (
+            step % buy_frequency == 0
+            and len(open_notes) < max_notes
+            and capital > 0
+            and prev_price > 0
+            and (prev_price - price) / prev_price >= dip_depth_entry
+            and slope <= slope_filter
+            and volatility <= volatility_filter
+        ):
+            usd_to_spend = capital * buy_fraction
+            if usd_to_spend > 0:
+                amount = usd_to_spend / price
+                capital -= usd_to_spend
+                open_notes.append(
+                    {
+                        "entry_price": price,
+                        "amount": amount,
+                        "entry_step": step,
+                        "peak_price": price,
+                    }
+                )
+
+        prev_price = price
+
+    final_price = prices[-1] if prices else 0.0
+    for note in open_notes:
+        capital += note["amount"] * final_price
 
     final_capital = capital
     pnl = final_capital - float(config["simulation_capital"])


### PR DESCRIPTION
## Summary
- split settings.json into buy_settings and sell_settings
- allow dotted nested knob names and unflatten config for simulation
- expand simulation engine to use buy/sell config and new sell logic

## Testing
- `python bot.py --mode tune --trials 50`
- `head -n 5 tune_results.csv`
- `wc -l tune_results.csv`


------
https://chatgpt.com/codex/tasks/task_e_6897acf5dafc8326854661fc965fd16b