### PR TITLE
Add walk-forward regime adaptation pipeline

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import argparse
+
+from systems.walk_regime import run as run_regimes
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--mode', required=True)
+    parser.add_argument('--tag')
+    parser.add_argument('--train')
+    parser.add_argument('--test')
+    parser.add_argument('--step')
+    parser.add_argument('--clusters', type=int, default=4)
+    parser.add_argument('--microtrials', type=int, default=0)
+    parser.add_argument('--fees', type=float, default=0.0)
+    parser.add_argument('--slip', type=float, default=0.0)
+    parser.add_argument('--hysteresis', type=int, default=0)
+    parser.add_argument('--blend', default='none')
+    args = parser.parse_args(argv)
+
+    if args.mode == 'regimes':
+        if not all([args.tag, args.train, args.test, args.step]):
+            parser.error('tag, train, test and step are required for regimes mode')
+        run_regimes(
+            tag=args.tag,
+            train=args.train,
+            test=args.test,
+            step=args.step,
+            clusters=args.clusters,
+            microtrials=args.microtrials,
+            fees=args.fees,
+            slip=args.slip,
+            hysteresis=args.hysteresis,
+            blend=args.blend,
+        )
+    else:
+        parser.error('--mode must be regimes')
+
+
+if __name__ == '__main__':
+    main()

--- a/regimes/seed_knobs.json
+++ b/regimes/seed_knobs.json
@@ -1,0 +1,18 @@
+{
+  "R0": {
+    "buy_settings": {"buy_fraction": 0.5},
+    "sell_settings": {"maturity_gain_target": 0.05}
+  },
+  "R1": {
+    "buy_settings": {"buy_fraction": 0.3},
+    "sell_settings": {"maturity_gain_target": 0.02}
+  },
+  "R2": {
+    "buy_settings": {"buy_fraction": 0.2},
+    "sell_settings": {"maturity_gain_target": 0.01}
+  },
+  "R3": {
+    "buy_settings": {"buy_fraction": 0.4},
+    "sell_settings": {"maturity_gain_target": 0.03}
+  }
+}

--- a/settings.json
+++ b/settings.json
@@ -1,0 +1,21 @@
+{
+  "simulation_capital": 1000,
+  "regime_settings": {
+    "feature_window": "30d",
+    "clusters": 4,
+    "blend": "top2",
+    "blend_alpha": 3.0,
+    "hysteresis": 3,
+    "micro_tune": {
+      "enabled": true,
+      "trials": 25,
+      "envelope_pct": 0.25,
+      "tunable_keys": [
+        "buy_settings.buy_fraction",
+        "sell_settings.maturity_gain_target",
+        "sell_settings.min_hold_time",
+        "sell_settings.trailing_stop_pct"
+      ]
+    }
+  }
+}

--- a/systems/data_loader.py
+++ b/systems/data_loader.py
@@ -1,0 +1,44 @@
+import numpy as np
+from pathlib import Path
+import csv
+from datetime import datetime, timedelta
+
+DATA_DIR = Path(__file__).resolve().parent.parent / 'legacy' / 'data' / 'raw'
+
+
+def load_prices(tag: str) -> np.ndarray:
+    """Load close prices for a given symbol tag.
+
+    Prices are expected to be stored as CSV files under ``legacy/data/raw``
+    where the filename matches the asset tag (e.g. ``SOL.csv``).
+    Only the ``close`` column is used and returned as a numpy ``float`` array.
+    """
+    path_csv = DATA_DIR / f"{tag.split('US')[0]}.csv"
+    if not path_csv.exists():
+        raise FileNotFoundError(f"price data not found for {tag}: {path_csv}")
+    closes: list[float] = []
+    with path_csv.open() as fh:
+        reader = csv.DictReader(fh)
+        for row in reader:
+            closes.append(float(row['close']))
+    return np.array(closes, dtype=float)
+
+
+def slice_prices(prices: np.ndarray, start: int, end: int) -> np.ndarray:
+    """Return a slice of ``prices`` between ``start`` and ``end`` indices."""
+    return prices[start:end]
+
+
+def parse_window(window: str, candles_per_day: int = 1) -> int:
+    """Convert a duration like ``'30d'`` or ``'4w'`` into a candle count."""
+    if window.isdigit():
+        return int(window)
+    qty = int(window[:-1])
+    unit = window[-1].lower()
+    if unit == 'd':
+        return qty * candles_per_day
+    if unit == 'w':
+        return qty * candles_per_day * 7
+    if unit == 'm':
+        return qty * candles_per_day * 30
+    raise ValueError(f"unrecognised window spec: {window}")

--- a/systems/features.py
+++ b/systems/features.py
@@ -1,0 +1,77 @@
+import numpy as np
+
+
+def _drawdown(prices: np.ndarray) -> float:
+    peak = np.maximum.accumulate(prices)
+    drawdowns = (peak - prices) / peak
+    return float(drawdowns.max()) if drawdowns.size else 0.0
+
+
+def _slope(prices: np.ndarray) -> float:
+    x = np.arange(len(prices))
+    y = np.log(prices)
+    x_mean = x.mean()
+    y_mean = y.mean()
+    cov = ((x - x_mean) * (y - y_mean)).sum()
+    var = ((x - x_mean) ** 2).sum()
+    return float(cov / var) if var else 0.0
+
+
+def compute_window_features(prices: np.ndarray, win_len: int) -> np.ndarray:
+    """Compute rolling window statistical features on ``prices``.
+
+    Parameters
+    ----------
+    prices:
+        Array of close prices ordered chronologically.
+    win_len:
+        Size of the rolling window.
+    """
+    if win_len <= 1 or win_len > len(prices):
+        return np.empty((0, 8))
+    feats = []
+    for i in range(win_len, len(prices) + 1):
+        window = prices[i - win_len : i]
+        returns = np.diff(window) / window[:-1]
+        ret_mean = returns.mean()
+        ret_std = returns.std(ddof=1) if returns.size > 1 else 0.0
+        ac1 = (
+            np.corrcoef(returns[1:], returns[:-1])[0, 1]
+            if returns.size > 2 and ret_std > 0
+            else 0.0
+        )
+        center = returns - ret_mean
+        m3 = np.mean(center ** 3) if returns.size > 0 else 0.0
+        m4 = np.mean(center ** 4) if returns.size > 0 else 0.0
+        skew = m3 / (ret_std ** 3) if ret_std else 0.0
+        kurt = m4 / (ret_std ** 4) if ret_std else 0.0
+        dd = _drawdown(window)
+        sl = _slope(window)
+        # vol of vol: std of rolling std with subwindow 5
+        if returns.size >= 5:
+            sub = [returns[j : j + 5].std(ddof=1) for j in range(len(returns) - 4)]
+            vol_of_vol = np.std(sub, ddof=1) if len(sub) > 1 else 0.0
+        else:
+            vol_of_vol = 0.0
+        feats.append(
+            [ret_mean, ret_std, ac1, skew, kurt, dd, sl, vol_of_vol]
+        )
+    return np.array(feats, dtype=float)
+
+
+def zscore_features(X: np.ndarray, stats: dict | None = None) -> tuple[np.ndarray, dict]:
+    """Apply z-score normalization to ``X``.
+
+    If ``stats`` is ``None`` the mean and std are computed from ``X`` and
+    returned alongside the transformed array.
+    """
+    if stats is None:
+        mean = X.mean(axis=0)
+        std = X.std(axis=0)
+        stats = {"mean": mean.tolist(), "std": std.tolist()}
+    else:
+        mean = np.array(stats["mean"])
+        std = np.array(stats["std"])
+    std[std == 0] = 1
+    Xn = (X - mean) / std
+    return Xn, stats

--- a/systems/optimizer.py
+++ b/systems/optimizer.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from typing import Dict, Any
+import numpy as np
+
+
+def run(
+    *,
+    trials: int,
+    prices: np.ndarray,
+    base_policy: Dict[str, Any],
+) -> Dict[str, Any]:
+    """Placeholder micro-optimizer.
+
+    The function simply returns ``base_policy`` without modification when
+    ``trials`` is zero. When ``trials`` is positive a small random nudge is
+    applied to numeric fields within ±10% to mimic a tuning step.
+    """
+    if trials <= 0:
+        return base_policy
+    rng = np.random.default_rng(0)
+    tuned = {}
+    for k, v in base_policy.items():
+        if isinstance(v, dict):
+            tuned[k] = run(trials=trials, prices=prices, base_policy=v)
+        elif isinstance(v, (int, float)):
+            delta = v * 0.1 * (rng.random() - 0.5)
+            tuned[k] = v + delta
+        else:
+            tuned[k] = v
+    return tuned

--- a/systems/policy_blender.py
+++ b/systems/policy_blender.py
@@ -1,0 +1,86 @@
+import json
+from pathlib import Path
+from typing import Dict, Any
+
+import numpy as np
+
+SEED_PATH = Path(__file__).resolve().parent.parent / 'regimes' / 'seed_knobs.json'
+
+
+def _load_seeds() -> Dict[str, Dict[str, Any]]:
+    with SEED_PATH.open() as fh:
+        return json.load(fh)
+
+
+def select_policy(regime_id: str) -> Dict[str, Any]:
+    seeds = _load_seeds()
+    return seeds.get(regime_id, {})
+
+
+def _merge(a: Dict[str, Any], b: Dict[str, Any], w: float) -> Dict[str, Any]:
+    out: Dict[str, Any] = {}
+    for k in a:
+        if isinstance(a[k], dict):
+            out[k] = _merge(a[k], b.get(k, {}), w)
+        else:
+            av = a[k]
+            bv = b.get(k, av)
+            out[k] = av * (1 - w) + bv * w
+    return out
+
+
+def blend_policy(distances: np.ndarray, mode: str, blend_alpha: float = 1.0) -> Dict[str, Any]:
+    """Blend seed policies based on cluster distances."""
+    seeds = _load_seeds()
+    ids = list(seeds.keys())
+    if mode == 'none' or len(ids) == 1:
+        return seeds.get(ids[int(distances.argmin())], {})
+    order = distances.argsort()
+    if mode == 'top2' and len(order) >= 2:
+        i1, i2 = order[:2]
+        d1, d2 = distances[i1], distances[i2]
+        w2 = 1.0 / (d2 + 1e-9)
+        w1 = 1.0 / (d1 + 1e-9)
+        w = w2 / (w1 + w2)
+        return _merge(seeds[ids[i1]], seeds[ids[i2]], w)
+    if mode == 'softmax':
+        weights = np.exp(-blend_alpha * distances)
+        weights /= weights.sum()
+        policy = None
+        for idx, w in enumerate(weights):
+            r_id = ids[idx]
+            if policy is None:
+                policy = {k: v for k, v in seeds[r_id].items()}
+                continue
+            policy = _merge(policy, seeds[r_id], w)
+        return policy or {}
+    return seeds.get(ids[int(order[0])], {})
+
+
+class HysteresisRegime:
+    """Track regime changes requiring persistence before switching."""
+
+    def __init__(self, hysteresis: int) -> None:
+        self.hysteresis = hysteresis
+        self.current: str | None = None
+        self.pending: str | None = None
+        self.count = 0
+
+    def update(self, regime: str) -> str:
+        if self.current is None:
+            self.current = regime
+            return regime
+        if regime == self.current:
+            self.pending = None
+            self.count = 0
+            return self.current
+        if regime == self.pending:
+            self.count += 1
+            if self.count >= self.hysteresis:
+                self.current = regime
+                self.pending = None
+                self.count = 0
+        else:
+            self.pending = regime
+            self.count = 1
+        return self.current

--- a/systems/regime_cluster.py
+++ b/systems/regime_cluster.py
@@ -1,0 +1,36 @@
+import json
+from pathlib import Path
+import numpy as np
+from .features import zscore_features
+
+REGIME_DIR = Path(__file__).resolve().parent.parent / 'data' / 'tmp' / 'regimes'
+REGIME_DIR.mkdir(parents=True, exist_ok=True)
+
+
+def fit_kmeans(X_train: np.ndarray, k: int) -> dict:
+    """Run a simple k-means clustering on ``X_train``."""
+    Xn, stats = zscore_features(X_train)
+    rng = np.random.default_rng(0)
+    centroids = Xn[rng.choice(len(Xn), size=k, replace=False)]
+    for _ in range(10):
+        dists = np.linalg.norm(Xn[:, None, :] - centroids[None, :, :], axis=2)
+        labels = dists.argmin(axis=1)
+        for i in range(k):
+            members = Xn[labels == i]
+            if len(members):
+                centroids[i] = members.mean(axis=0)
+    return {"centroids": centroids.tolist(), "scale": stats}
+
+
+def save_centroids(tag: str, k: int, model: dict) -> None:
+    path = REGIME_DIR / f"{tag}_k{k}.json"
+    with path.open('w') as fh:
+        json.dump(model, fh)
+
+
+def assign_regime(x: np.ndarray, model: dict) -> tuple[int, np.ndarray]:
+    centroids = np.array(model['centroids'])
+    x_scaled, _ = zscore_features(x[None, :], model['scale'])
+    dists = np.linalg.norm(centroids - x_scaled, axis=1)
+    idx = int(dists.argmin())
+    return idx, dists

--- a/systems/sim_engine.py
+++ b/systems/sim_engine.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from typing import Callable, Dict, Any
+
+import numpy as np
+
+
+def run_sim(
+    *,
+    prices: np.ndarray,
+    base_settings: Dict[str, Any],
+    policy_provider: Callable[[int], Dict[str, Any]],
+    start_idx: int,
+    end_idx: int,
+    fees_bps: float,
+    slip_bps: float,
+) -> Dict[str, Any]:
+    """Very small placeholder simulation.
+
+    The engine simply applies a buy-and-hold on the slice between ``start_idx``
+    and ``end_idx``. The ``policy_provider`` is invoked for the block start but
+    otherwise unused. Fees and slippage are subtracted from the theoretical
+    profit for demonstration purposes.
+    """
+    capital = float(base_settings.get('capital', 0))
+    if end_idx > len(prices):
+        end_idx = len(prices)
+    start_price = prices[start_idx]
+    end_price = prices[end_idx - 1]
+    gross = capital * (end_price / start_price - 1)
+    cost = capital * (fees_bps + slip_bps)
+    pnl = gross - cost
+    return {
+        'final_capital': capital + pnl,
+        'pnl': pnl,
+        'max_dd': 0.0,
+        'trades': 1,
+        'avg_hold': end_idx - start_idx,
+        'exposure_pct': 1.0,
+        'regime_id_used': policy_provider(start_idx).get('regime', '')
+    }

--- a/systems/walk_regime.py
+++ b/systems/walk_regime.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import csv
+import json
+from pathlib import Path
+from typing import Callable, Dict, Any
+
+import numpy as np
+
+from . import data_loader, features, regime_cluster, policy_blender, sim_engine, optimizer
+
+SETTINGS_PATH = Path(__file__).resolve().parent.parent / 'settings.json'
+RESULTS_PATH = Path('regime_walk_results.csv')
+
+
+def _load_settings() -> dict:
+    with SETTINGS_PATH.open() as fh:
+        return json.load(fh)
+
+
+def run(
+    *,
+    tag: str,
+    train: str,
+    test: str,
+    step: str,
+    clusters: int,
+    microtrials: int,
+    fees: float,
+    slip: float,
+    hysteresis: int,
+    blend: str,
+) -> None:
+    settings = _load_settings()
+    prices = data_loader.load_prices(tag)
+    train_len = data_loader.parse_window(train)
+    test_len = data_loader.parse_window(test)
+    step_len = data_loader.parse_window(step)
+    feat_win = data_loader.parse_window(
+        settings.get('regime_settings', {}).get('feature_window', '30d')
+    )
+    hyst = policy_blender.HysteresisRegime(hysteresis)
+    blend_alpha = settings.get('regime_settings', {}).get('blend_alpha', 1.0)
+    sim_cap = settings.get('simulation_capital', 1000)
+    seeds_mode = 'blend' if blend != 'none' else 'seeds'
+
+    rows = []
+    cursor = 0
+    while cursor + train_len + test_len <= len(prices):
+        train_slice = data_loader.slice_prices(prices, cursor, cursor + train_len)
+        X_train = features.compute_window_features(train_slice, feat_win)
+        model = regime_cluster.fit_kmeans(X_train, clusters)
+        regime_cluster.save_centroids(tag, clusters, model)
+
+        block_start = cursor + train_len
+        assign_window = data_loader.slice_prices(prices, block_start - feat_win, block_start)
+        X_block = features.compute_window_features(assign_window, feat_win)
+        x_feat = X_block[-1]
+        idx, dists = regime_cluster.assign_regime(x_feat, model)
+        regime_id = f"R{idx}"
+        effective = hyst.update(regime_id)
+        policy = policy_blender.blend_policy(dists, blend, blend_alpha)
+        policy_source = seeds_mode
+        if microtrials > 0:
+            policy = optimizer.run(
+                trials=microtrials,
+                prices=data_loader.slice_prices(prices, block_start - test_len, block_start),
+                base_policy=policy,
+            )
+            policy_source = 'micro'
+
+        def provider(_: int) -> Dict[str, Any]:
+            return policy
+
+        metrics = sim_engine.run_sim(
+            prices=prices,
+            base_settings={'capital': sim_cap},
+            policy_provider=provider,
+            start_idx=block_start,
+            end_idx=block_start + test_len,
+            fees_bps=fees,
+            slip_bps=slip,
+        )
+        rows.append(
+            {
+                'start_idx': block_start,
+                'end_idx': block_start + test_len,
+                'regime_id': effective,
+                'policy_source': policy_source,
+                'pnl': metrics.get('pnl', 0.0),
+                'max_dd': metrics.get('max_dd', 0.0),
+                'trades': metrics.get('trades', 0),
+                'avg_hold': metrics.get('avg_hold', 0.0),
+                'exposure': metrics.get('exposure_pct', 0.0),
+                'knobs_json': json.dumps(policy),
+            }
+        )
+        cursor += step_len
+
+    with RESULTS_PATH.open('w', newline='') as fh:
+        writer = csv.DictWriter(
+            fh,
+            fieldnames=[
+                'start_idx','end_idx','regime_id','policy_source','pnl','max_dd','trades','avg_hold','exposure','knobs_json'
+            ],
+        )
+        writer.writeheader()
+        writer.writerows(rows)


### PR DESCRIPTION
## Summary
- add CLI mode `regimes` and walk-forward driver for regime clustering and trading
- implement numpy-based feature extraction, k-means clustering, policy blending with hysteresis, and placeholder optimizer
- include simplified simulation engine and seed knob configuration

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_6897b44d363083268c163da1c195a396