### PR TITLE
Add data loader and block planner

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+from datetime import datetime
+from pathlib import Path
+from typing import List
+
+import pandas as pd
+
+from systems.block_planner import parse_duration, plan_blocks
+from systems.data_loader import load_candles
+
+
+logger = logging.getLogger("bot")
+
+
+def main(argv: List[str] | None = None) -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--mode", default="regimes")
+    parser.add_argument("--tag", required=True, help="Asset tag to load")
+    parser.add_argument("--train", required=True, help="Training window (e.g. 3m)")
+    parser.add_argument("--test", required=True, help="Testing window (e.g. 1m)")
+    parser.add_argument("--step", required=True, help="Step size between blocks")
+    parser.add_argument("-v", action="count", default=0, dest="verbosity")
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(level=max(logging.WARNING - args.verbosity * 10, logging.DEBUG))
+
+    if args.mode != "regimes":
+        logger.error("Unsupported mode: %s", args.mode)
+        return
+
+    df = load_candles(args.tag)
+
+    train_len = parse_duration(args.train)
+    test_len = parse_duration(args.test)
+    step_len = parse_duration(args.step)
+
+    blocks = plan_blocks(df, train_len, test_len, step_len)
+
+    rows = []
+    for idx, b in enumerate(blocks, start=1):
+        row = {
+            "Block": idx,
+            "Train Start": pd.to_datetime(b["train_start"], unit="s"),
+            "Train End": pd.to_datetime(b["train_end"], unit="s"),
+            "Test Start": pd.to_datetime(b["test_start"], unit="s"),
+            "Test End": pd.to_datetime(b["test_end"], unit="s"),
+            "Train Candles": b["train_candles"],
+            "Test Candles": b["test_candles"],
+        }
+        if args.verbosity >= 2:
+            row["Train Idx"] = f"{b['train_index_start']}-{b['train_index_end']}"
+            row["Test Idx"] = f"{b['test_index_start']}-{b['test_index_end']}"
+        rows.append(row)
+
+    table = pd.DataFrame(rows)
+    if not table.empty:
+        print(table.to_string(index=False))
+    else:
+        logger.warning("No blocks generated")
+
+    # Save plan
+    logs_dir = Path("logs")
+    logs_dir.mkdir(exist_ok=True)
+    timestamp = datetime.utcnow().strftime("%Y%m%d_%H%M%S")
+    out_path = logs_dir / f"block_plan_{args.tag}_{timestamp}.json"
+    with out_path.open("w") as fh:
+        json.dump(blocks, fh, indent=2)
+    logger.info("Saved block plan to %s", out_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/systems/block_planner.py
+++ b/systems/block_planner.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List
+
+import pandas as pd
+
+
+DURATION_UNITS = {
+    "d": 24,               # days
+    "w": 7 * 24,           # weeks
+    "m": 30 * 24,          # months (30d)
+    "y": 365 * 24,         # years (365d)
+}
+
+
+def parse_duration(text: str) -> int:
+    """Convert a duration string (e.g. ``"3m"``) into a candle count."""
+    match = re.fullmatch(r"(\d+)([dwmy])", text.strip())
+    if not match:
+        raise ValueError(f"Invalid duration: {text}")
+
+    value = int(match.group(1))
+    unit = match.group(2)
+    candles = value * DURATION_UNITS[unit]
+    if candles < 1:
+        raise ValueError("Duration must be at least one candle")
+    return candles
+
+
+def plan_blocks(df: pd.DataFrame, train_len: int, test_len: int, step_len: int) -> List[Dict[str, int]]:
+    """Generate walk-forward blocks.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        Candle data sorted by timestamp.
+    train_len, test_len, step_len : int
+        Lengths in candles.
+    """
+    total = len(df)
+    blocks: List[Dict[str, int]] = []
+
+    start = 0
+    while start + train_len + test_len <= total:
+        train_start_idx = start
+        train_end_idx = start + train_len - 1
+        test_start_idx = train_end_idx + 1
+        test_end_idx = test_start_idx + test_len - 1
+
+        block = {
+            "train_start": int(df.loc[train_start_idx, "timestamp"]),
+            "train_end": int(df.loc[train_end_idx, "timestamp"]),
+            "test_start": int(df.loc[test_start_idx, "timestamp"]),
+            "test_end": int(df.loc[test_end_idx, "timestamp"]),
+            "train_candles": train_len,
+            "test_candles": test_len,
+            "train_index_start": train_start_idx,
+            "train_index_end": train_end_idx,
+            "test_index_start": test_start_idx,
+            "test_index_end": test_end_idx,
+        }
+        blocks.append(block)
+        start += step_len
+
+    return blocks

--- a/systems/data_loader.py
+++ b/systems/data_loader.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+import pandas as pd
+
+
+CACHE_DIR = Path("data/raw")
+
+
+def load_candles(tag: str, start_date: Optional[str] = None, end_date: Optional[str] = None) -> pd.DataFrame:
+    """Load cached 1h candles for *tag*.
+
+    Parameters
+    ----------
+    tag : str
+        Symbol or asset identifier. A CSV named ``<tag>.csv`` is expected
+        in the cache directory.
+    start_date, end_date : str | None, optional
+        ISO8601 timestamp strings (any ``pandas.Timestamp`` compatible format).
+        When provided, the resulting frame is filtered to the inclusive
+        range ``[start_date, end_date]``.
+
+    Returns
+    -------
+    pd.DataFrame
+        Dataframe with columns ``timestamp, open, high, low, close, volume``
+        sorted in ascending timestamp order with duplicate timestamps removed.
+    """
+
+    path = CACHE_DIR / f"{tag}.csv"
+    if not path.exists():
+        raise FileNotFoundError(f"No cached data for tag '{tag}' at {path}")
+
+    df = pd.read_csv(path, usecols=["timestamp", "open", "high", "low", "close", "volume"])
+
+    # Sort and deduplicate timestamps
+    df = df.sort_values("timestamp").drop_duplicates("timestamp", keep="last").reset_index(drop=True)
+
+    # Ensure strictly 1h interval candles
+    if not df.empty:
+        gaps = df["timestamp"].diff().dropna()
+        if not (gaps == 3600).all():
+            raise ValueError("Non 1h candle intervals detected in cached data")
+
+    # Optional time filtering
+    if start_date is not None:
+        start_ts = int(pd.Timestamp(start_date, tz="UTC").timestamp())
+        df = df[df["timestamp"] >= start_ts]
+    if end_date is not None:
+        end_ts = int(pd.Timestamp(end_date, tz="UTC").timestamp())
+        df = df[df["timestamp"] <= end_ts]
+
+    return df.reset_index(drop=True)


### PR DESCRIPTION
## Summary
- add `load_candles` utility to read cached 1h candle CSVs
- implement walk-forward block planner with duration parsing
- support regimes mode in `bot.py` to load data, plan blocks, and save plan

## Testing
- `pip install pandas` *(fails: Could not find a version that satisfies the requirement pandas)*
- `python bot.py --mode regimes --tag SOL --train 3m --test 1m --step 1m -vv` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6897dd0e47388326a83dab86d30feb38