### PR TITLE
Refactor CLI into task groups and add audit enhancements

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
+
 import argparse
 import json
 import logging
 from datetime import datetime
 from pathlib import Path
-from typing import List, Optional
+from typing import Dict, List, Optional
 
 import pandas as pd
 
@@ -23,7 +24,6 @@ logger = logging.getLogger("bot")
 
 
 def resolve_ccxt_symbols(tag: str) -> tuple[str, str]:
-    """Return (kraken_symbol, binance_symbol) for ``tag`` from settings.json."""
     path = Path("settings.json")
     settings = {}
     if path.exists():
@@ -33,7 +33,11 @@ def resolve_ccxt_symbols(tag: str) -> tuple[str, str]:
     return info.get("kraken_name", tag), info.get("binance_name", tag)
 
 
-def cmd_fetch_history(args: argparse.Namespace) -> None:
+# ---------------------------------------------------------------------------
+# Data commands
+# ---------------------------------------------------------------------------
+
+def cmd_data_fetch(args: argparse.Namespace) -> None:
     start, end = validate_dates(args.start, args.end)
     if not args.fetch_all and not (start and end):
         raise SystemExit("Provide --fetch-all or both --start and --end")
@@ -70,87 +74,35 @@ def cmd_fetch_history(args: argparse.Namespace) -> None:
         )
 
 
-def cmd_regimes(args: argparse.Namespace) -> None:
-    if args.cluster:
-        features_dir = Path("features")
-        feat_files = sorted(features_dir.glob(f"features_{args.tag}_*.parquet"))
-        if not feat_files:
-            raise SystemExit(f"No features found for {args.tag}; run with --features first")
-        latest_feat = feat_files[-1]
-        stamp = "_".join(latest_feat.stem.split("_")[2:])
-        meta_path = features_dir / f"features_meta_{args.tag}_{stamp}.json"
-        if not meta_path.exists():
-            raise SystemExit(f"Meta file missing for {latest_feat.name}")
-
-        features_df = pd.read_parquet(latest_feat)
-        with meta_path.open() as fh:
-            meta = json.load(fh)
-
-        settings = _load_settings()
-        k = settings.get("regime_settings", {}).get("cluster_count", 3)
-
-        from systems.regime_cluster import cluster_features
-
-        assignments, centroids, inertia = cluster_features(features_df, meta, k)
-
-        timestamp = datetime.utcnow().strftime("%Y%m%d_%H%M%S")
-        assign_path = features_dir / f"regime_assignments_{args.tag}_{timestamp}.csv"
-        assignments.to_csv(assign_path, index=False)
-        cent_path = features_dir / f"centroids_{args.tag}_{timestamp}.json"
-        with cent_path.open("w") as fh:
-            json.dump(centroids, fh, indent=2)
-
-        counts = assignments["regime_id"].value_counts().sort_index()
-        count_str = " | ".join(
-            f"Regime {i}: {c} blocks" for i, c in counts.items()
-        )
-        print(f"[CLUSTER] K={k} | Inertia={inertia:.2f}")
-        print(f"[CLUSTER] {count_str}")
-        return
-
-    if args.audit:
-        features_dir = Path("features")
-        feat_files = sorted(features_dir.glob(f"features_{args.tag}_*.parquet"))
-        meta_files = sorted(features_dir.glob(f"features_meta_{args.tag}_*.json"))
-        assign_files = sorted(features_dir.glob(f"regime_assignments_{args.tag}_*.csv"))
-        cent_files = sorted(features_dir.glob(f"centroids_{args.tag}_*.json"))
-        plan_files = sorted(Path("logs").glob(f"block_plan_{args.tag}_*.json"))
-
-        if not (feat_files and meta_files and assign_files and cent_files and plan_files):
-            raise SystemExit(
-                "Missing artifacts for audit; run with --features then --cluster first"
-            )
-
-        paths = {
-            "features": feat_files[-1],
-            "meta": meta_files[-1],
-            "assignments": assign_files[-1],
-            "centroids": cent_files[-1],
-            "block_plan": plan_files[-1],
-        }
-
-        from systems.regime_audit import run_audit
-
-        run_audit(args.tag, paths, args.verbosity)
-        return
-
-    if not (args.train and args.test and args.step):
-        raise SystemExit("Provide --train, --test and --step or use --cluster")
-
+def cmd_data_verify(args: argparse.Namespace) -> None:
     cache_path = CACHE_DIR / f"{args.tag}_1h.parquet"
     if not cache_path.exists():
-        raise SystemExit(
-            f"Cache missing for {args.tag}; run fetch-history --fetch-all first"
-        )
+        raise SystemExit(f"Cache missing for {args.tag}; run data fetch-history first")
+    df = pd.read_parquet(cache_path)
+    ts = pd.to_datetime(df["timestamp"], unit="s", utc=True)
+    diffs = ts.diff().dropna().dt.total_seconds()
+    gaps = int((diffs != 3600).sum())
+    first = ts.iloc[0] if not df.empty else None
+    last = ts.iloc[-1] if not df.empty else None
+    print(f"[VERIFY] TAG={args.tag} | Range={first} -> {last} | gaps={gaps}")
 
-    df = load_or_fetch(args.tag)
+
+# ---------------------------------------------------------------------------
+# Regime utilities
+# ---------------------------------------------------------------------------
+
+def regimes_plan(tag: str, train: str, test: str, step: str, verbosity: int = 0) -> None:
+    cache_path = CACHE_DIR / f"{tag}_1h.parquet"
+    if not cache_path.exists():
+        raise SystemExit(f"Cache missing for {tag}; run data fetch-history first")
+    df = load_or_fetch(tag)
     diffs = df["timestamp"].diff().dropna()
     assert diffs.empty or (diffs == 3600).all(), "Candles must be 1h spaced"
 
     total = len(df)
-    train_c = parse_duration_1h(args.train)
-    test_c = parse_duration_1h(args.test)
-    step_c = parse_duration_1h(args.step)
+    train_c = parse_duration_1h(train)
+    test_c = parse_duration_1h(test)
+    step_c = parse_duration_1h(step)
 
     blocks = plan_blocks(df, train_c, test_c, step_c)
 
@@ -159,7 +111,7 @@ def cmd_regimes(args: argparse.Namespace) -> None:
         f"Step={step_c} | Blocks={len(blocks)}"
     )
 
-    if args.verbosity >= 2:
+    if verbosity >= 2:
         for idx, b in enumerate(blocks, start=1):
             ts = lambda x: pd.to_datetime(x, unit="s", utc=True)
             print(
@@ -170,7 +122,7 @@ def cmd_regimes(args: argparse.Namespace) -> None:
     logs_dir = Path("logs")
     logs_dir.mkdir(exist_ok=True)
     timestamp = datetime.utcnow().strftime("%Y%m%d_%H%M%S")
-    plan_path = logs_dir / f"block_plan_{args.tag}_{timestamp}.json"
+    plan_path = logs_dir / f"block_plan_{tag}_{timestamp}.json"
     with plan_path.open("w") as fh:
         json.dump(blocks, fh, indent=2)
     csv_path = logs_dir / "regime_walk_results.csv"
@@ -178,74 +130,194 @@ def cmd_regimes(args: argparse.Namespace) -> None:
         fh.write("block,train_start,train_end,test_start,test_end\n")
     logger.info("Saved block plan to %s", plan_path)
 
-    if args.features:
-        from systems.features import FEATURE_NAMES, extract_all_features, save_features
 
-        feat_df = extract_all_features(df, blocks)
-        paths = save_features(feat_df, args.tag, timestamp)
-        print(
-            f"[FEATURES] Extracted {len(FEATURE_NAMES)} features for {len(blocks)} blocks "
-            f"-> saved to {Path(paths['raw']).name}"
+def regimes_features(tag: str, verbosity: int = 0) -> None:
+    cache_path = CACHE_DIR / f"{tag}_1h.parquet"
+    if not cache_path.exists():
+        raise SystemExit(f"Cache missing for {tag}; run data fetch-history first")
+    plan_files = sorted(Path("logs").glob(f"block_plan_{tag}_*.json"))
+    if not plan_files:
+        raise SystemExit(f"No block plan found for {tag}; run regimes plan first")
+    with plan_files[-1].open() as fh:
+        blocks = json.load(fh)
+    df = load_or_fetch(tag)
+    from systems.features import FEATURE_NAMES, extract_all_features, save_features
+
+    feat_df = extract_all_features(df, blocks)
+    timestamp = datetime.utcnow().strftime("%Y%m%d_%H%M%S")
+    paths = save_features(feat_df, tag, timestamp)
+    print(
+        f"[FEATURES] Extracted {len(FEATURE_NAMES)} features for {len(blocks)} blocks "
+        f"-> saved to {Path(paths['raw']).name}"
+    )
+
+
+def regimes_cluster(tag: str, verbosity: int = 0) -> None:
+    features_dir = Path("features")
+    feat_files = sorted(features_dir.glob(f"features_{tag}_*.parquet"))
+    if not feat_files:
+        raise SystemExit(f"No features found for {tag}; run regimes features first")
+    latest_feat = feat_files[-1]
+    stamp = "_".join(latest_feat.stem.split("_")[2:])
+    meta_path = features_dir / f"features_meta_{tag}_{stamp}.json"
+    if not meta_path.exists():
+        raise SystemExit(f"Meta file missing for {latest_feat.name}")
+
+    features_df = pd.read_parquet(latest_feat)
+    with meta_path.open() as fh:
+        meta = json.load(fh)
+
+    settings = _load_settings()
+    k = settings.get("regime_settings", {}).get("cluster_count", 3)
+
+    from systems.regime_cluster import cluster_features
+
+    assignments, centroids, inertia = cluster_features(features_df, meta, k)
+
+    timestamp = datetime.utcnow().strftime("%Y%m%d_%H%M%S")
+    assign_path = features_dir / f"regime_assignments_{tag}_{timestamp}.csv"
+    assignments.to_csv(assign_path, index=False)
+    cent_path = features_dir / f"centroids_{tag}_{timestamp}.json"
+    with cent_path.open("w") as fh:
+        json.dump(centroids, fh, indent=2)
+
+    counts = assignments["regime_id"].value_counts().sort_index()
+    count_str = " | ".join(f"Regime {i}: {c} blocks" for i, c in counts.items())
+    print(f"[CLUSTER] K={k} | Inertia={inertia:.2f}")
+    print(f"[CLUSTER] {count_str}")
+
+
+# ---------------------------------------------------------------------------
+# Audit utilities
+# ---------------------------------------------------------------------------
+
+def _resolve_latest_artifacts(tag: str) -> Dict[str, Path]:
+    features_dir = Path("features")
+    logs_dir = Path("logs")
+    feat_files = sorted(features_dir.glob(f"features_{tag}_*.parquet"))
+    meta_files = sorted(features_dir.glob(f"features_meta_{tag}_*.json"))
+    assign_files = sorted(features_dir.glob(f"regime_assignments_{tag}_*.csv"))
+    cent_files = sorted(features_dir.glob(f"centroids_{tag}_*.json"))
+    plan_files = sorted(logs_dir.glob(f"block_plan_{tag}_*.json"))
+    if not (feat_files and meta_files and assign_files and cent_files and plan_files):
+        raise SystemExit(
+            "Missing artifacts for audit; run regimes features and cluster first"
         )
+    return {
+        "features": feat_files[-1],
+        "meta": meta_files[-1],
+        "assignments": assign_files[-1],
+        "centroids": cent_files[-1],
+        "block_plan": plan_files[-1],
+    }
 
+
+def cmd_audit_summary(args: argparse.Namespace) -> None:
+    paths = _resolve_latest_artifacts(args.tag)
+    from systems.regime_audit import run_audit
+
+    run_audit(args.tag, paths, args.verbosity)
+
+
+def cmd_audit_full(args: argparse.Namespace) -> None:
+    features_dir = Path("features")
+    feat_files = sorted(features_dir.glob(f"features_{args.tag}_*.parquet"))
+    meta_files = sorted(features_dir.glob(f"features_meta_{args.tag}_*.json"))
+    if not (feat_files and meta_files):
+        regimes_features(args.tag, args.verbosity)
+    assign_files = sorted(features_dir.glob(f"regime_assignments_{args.tag}_*.csv"))
+    cent_files = sorted(features_dir.glob(f"centroids_{args.tag}_*.json"))
+    if not (assign_files and cent_files):
+        regimes_cluster(args.tag, args.verbosity)
+    paths = _resolve_latest_artifacts(args.tag)
+    from systems.regime_audit import run_audit
+    from systems.regime_audit_plus import run as run_plus
+
+    run_audit(args.tag, paths, args.verbosity)
+    run_plus(args.tag, args.verbosity)
+
+
+# ---------------------------------------------------------------------------
+# Main CLI
+# ---------------------------------------------------------------------------
 
 def main(argv: Optional[List[str]] = None) -> None:
     parser = argparse.ArgumentParser()
-    subparsers = parser.add_subparsers(dest="command")
-    parser.add_argument("--mode", choices=["fetch-history", "regimes"], help=argparse.SUPPRESS)
+    subparsers = parser.add_subparsers(dest="group", required=True)
 
-    sp_fetch = subparsers.add_parser(
-        "fetch-history", help="Fetch and cache 1h candles"
-    )
+    # Data group
+    sp_data = subparsers.add_parser("data", help="Data management")
+    data_sub = sp_data.add_subparsers(dest="command", required=True)
+
+    sp_fetch = data_sub.add_parser("fetch-history", help="Fetch and cache 1h candles")
     sp_fetch.add_argument("--tag", required=True, help="Asset tag")
     sp_fetch.add_argument("--fetch-all", action="store_true", help="Fetch full history")
     sp_fetch.add_argument("--start", help="Range start (YYYY-MM-DD)")
     sp_fetch.add_argument("--end", help="Range end (YYYY-MM-DD)")
+    add_verbosity(sp_fetch)
 
-    sp_regimes = subparsers.add_parser(
-        "regimes", help="Walk-forward: Step 1 (plan blocks)"
-    )
-    sp_regimes.add_argument("--tag", required=True, help="Asset tag")
-    sp_regimes.add_argument("--train", help="Training window")
-    sp_regimes.add_argument("--test", help="Testing window")
-    sp_regimes.add_argument("--step", help="Step size")
-    sp_regimes.add_argument(
-        "--features",
-        action="store_true",
-        help="Extract features for training windows",
-    )
-    sp_regimes.add_argument(
-        "--cluster",
-        action="store_true",
-        help="Run K-Means clustering on extracted features",
-    )
-    sp_regimes.add_argument(
-        "--audit",
-        action="store_true",
-        help="Audit latest clustering results",
-    )
-    add_verbosity(sp_regimes)
+    sp_verify = data_sub.add_parser("verify", help="Verify cached data continuity")
+    sp_verify.add_argument("--tag", required=True, help="Asset tag")
+    add_verbosity(sp_verify)
+
+    # Regimes group
+    sp_regimes = subparsers.add_parser("regimes", help="Regime workflows")
+    reg_sub = sp_regimes.add_subparsers(dest="command", required=True)
+
+    sp_plan = reg_sub.add_parser("plan", help="Plan walk-forward blocks")
+    sp_plan.add_argument("--tag", required=True, help="Asset tag")
+    sp_plan.add_argument("--train", required=True, help="Training window")
+    sp_plan.add_argument("--test", required=True, help="Testing window")
+    sp_plan.add_argument("--step", required=True, help="Step size")
+    add_verbosity(sp_plan)
+
+    sp_feat = reg_sub.add_parser("features", help="Extract features for blocks")
+    sp_feat.add_argument("--tag", required=True, help="Asset tag")
+    add_verbosity(sp_feat)
+
+    sp_clust = reg_sub.add_parser("cluster", help="Run K-Means clustering on features")
+    sp_clust.add_argument("--tag", required=True, help="Asset tag")
+    add_verbosity(sp_clust)
+
+    # Audit group
+    sp_audit = subparsers.add_parser("audit", help="Audit regimes")
+    audit_sub = sp_audit.add_subparsers(dest="command", required=True)
+
+    sp_sum = audit_sub.add_parser("summary", help="Run audit summary")
+    sp_sum.add_argument("--tag", required=True, help="Asset tag")
+    add_verbosity(sp_sum)
+
+    sp_full = audit_sub.add_parser("full", help="Run full audit pipeline")
+    sp_full.add_argument("--tag", required=True, help="Asset tag")
+    add_verbosity(sp_full)
 
     args = parser.parse_args(argv)
-
-    if getattr(args, "mode", None) and not args.command:
-        logger.warning("--mode is deprecated; use subcommands")
-        args.command = args.mode
-
-    if not getattr(args, "command", None):
-        parser.error("No command provided")
 
     logging.basicConfig(
         level=max(logging.WARNING - getattr(args, "verbosity", 0) * 10, logging.DEBUG)
     )
 
-    if args.command == "fetch-history":
-        cmd_fetch_history(args)
-    elif args.command == "regimes":
-        cmd_regimes(args)
+    if args.group == "data":
+        if args.command == "fetch-history":
+            cmd_data_fetch(args)
+        elif args.command == "verify":
+            cmd_data_verify(args)
+    elif args.group == "regimes":
+        if args.command == "plan":
+            regimes_plan(args.tag, args.train, args.test, args.step, args.verbosity)
+        elif args.command == "features":
+            regimes_features(args.tag, args.verbosity)
+        elif args.command == "cluster":
+            regimes_cluster(args.tag, args.verbosity)
+    elif args.group == "audit":
+        if args.command == "summary":
+            cmd_audit_summary(args)
+        elif args.command == "full":
+            cmd_audit_full(args)
     else:
-        parser.error(f"Unknown command: {args.command}")
+        parser.error("Unknown command")
 
 
 if __name__ == "__main__":
     main()
+

--- a/systems/regime_audit_plus.py
+++ b/systems/regime_audit_plus.py
@@ -1,0 +1,180 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import Dict
+
+import numpy as np
+import pandas as pd
+
+
+def _resolve_latest(tag: str) -> Dict[str, Path]:
+    features_dir = Path("features")
+    logs_dir = Path("logs")
+    feat_files = sorted(features_dir.glob(f"features_{tag}_*.parquet"))
+    meta_files = sorted(features_dir.glob(f"features_meta_{tag}_*.json"))
+    assign_files = sorted(features_dir.glob(f"regime_assignments_{tag}_*.csv"))
+    cent_files = sorted(features_dir.glob(f"centroids_{tag}_*.json"))
+    plan_files = sorted(logs_dir.glob(f"block_plan_{tag}_*.json"))
+    if not (feat_files and meta_files and assign_files and cent_files and plan_files):
+        raise FileNotFoundError(
+            "Missing artifacts for audit; run regimes features and cluster first"
+        )
+    return {
+        "features": feat_files[-1],
+        "meta": meta_files[-1],
+        "assignments": assign_files[-1],
+        "centroids": cent_files[-1],
+        "block_plan": plan_files[-1],
+    }
+
+
+def run(tag: str, verbose: int = 0) -> Dict[str, Path | float | dict]:
+    """Perform extended audit on latest regime artifacts for ``tag``."""
+    paths = _resolve_latest(tag)
+
+    features_df = pd.read_parquet(paths["features"])
+    with Path(paths["meta"]).open() as fh:
+        meta = json.load(fh)
+    assignments = pd.read_csv(paths["assignments"])
+    with Path(paths["centroids"]).open() as fh:
+        centroids = json.load(fh)
+    with Path(paths["block_plan"]).open() as fh:
+        block_plan = json.load(fh)
+
+    features = meta["features"]
+    mean = np.asarray(meta["mean"], dtype=float)
+    std = np.asarray(meta["std"], dtype=float)
+    cent_feat = centroids["features"]
+    assert features == cent_feat, "Feature order mismatch: meta vs centroids"
+
+    C_scaled = np.asarray(centroids["centroids"], dtype=float)
+    C_unscaled = C_scaled * std + mean
+
+    Xs = features_df[features].to_numpy(dtype=float)
+    Xu = np.nan_to_num(Xs * std + mean)
+    df_unscaled = pd.DataFrame(Xu, columns=features)
+    df_unscaled.insert(0, "block_id", features_df["block_id"].to_numpy())
+    merged = assignments.merge(df_unscaled, on="block_id")
+
+    reg_means_df = merged.groupby("regime_id")[features].mean().reindex(range(C_unscaled.shape[0]))
+    reg_means = np.nan_to_num(reg_means_df.to_numpy())
+    max_diff = float(np.max(np.abs(reg_means - C_unscaled)))
+
+    audit_dir = Path("audit")
+    audit_dir.mkdir(exist_ok=True)
+    ts = datetime.utcnow().strftime("%Y%m%d_%H%M%S")
+
+    cent_df = pd.DataFrame({"regime_id": range(C_unscaled.shape[0])})
+    for i, f in enumerate(features):
+        cent_df[f"centroid_{f}"] = C_unscaled[:, i]
+        cent_df[f"mean_{f}"] = reg_means[:, i]
+    cent_path = audit_dir / f"centroids_unscaled_{tag}_{ts}.csv"
+    cent_df.to_csv(cent_path, index=False)
+
+    global_mean = Xu.mean(axis=0)
+    cluster_ids = assignments["regime_id"].to_numpy()
+    K = C_unscaled.shape[0]
+    n_k = np.array([(cluster_ids == k).sum() for k in range(K)], dtype=float)
+
+    SSB = (n_k[:, None] * (reg_means - global_mean) ** 2).sum(axis=0)
+    SSW = np.zeros_like(global_mean)
+    for k in range(K):
+        Xk = Xu[cluster_ids == k]
+        if Xk.size:
+            diff = Xk - reg_means[k]
+            SSW += (diff**2).sum(axis=0)
+    F_scores = SSB / np.maximum(SSW, 1e-12)
+
+    fi_df = pd.DataFrame(
+        {
+            "feature": features,
+            "F_score": F_scores,
+            "global_mean": global_mean,
+        }
+    )
+    for k in range(K):
+        fi_df[f"cluster_{k}_mean"] = reg_means[k]
+    fi_path = audit_dir / f"feature_influence_{tag}_{ts}.csv"
+    fi_df.to_csv(fi_path, index=False)
+
+    top_records = []
+    for k in range(K):
+        deltas = reg_means[k] - global_mean
+        order = np.argsort(np.abs(deltas))[::-1]
+        for rank, idx in enumerate(order[:3], start=1):
+            top_records.append(
+                {
+                    "regime_id": k,
+                    "rank": rank,
+                    "feature": features[idx],
+                    "delta_unscaled": deltas[idx],
+                    "cluster_mean": reg_means[k, idx],
+                    "global_mean": global_mean[idx],
+                    "F_score": F_scores[idx],
+                }
+            )
+    top_df = pd.DataFrame(top_records)
+    top_path = audit_dir / f"top_drivers_{tag}_{ts}.csv"
+    top_df.to_csv(top_path, index=False)
+
+    bp_df = pd.DataFrame(block_plan)
+    bp_df.insert(0, "block_id", np.arange(1, len(bp_df) + 1))
+    assign_dates = assignments.merge(
+        bp_df[["block_id", "train_start", "train_end"]], on="block_id", how="left"
+    )
+    assign_path = audit_dir / f"assignments_with_dates_{tag}_{ts}.csv"
+    assign_dates.to_csv(assign_path, index=False)
+
+    spans = []
+    for rid, grp in assign_dates.sort_values("block_id").groupby("regime_id"):
+        blk_ids = grp["block_id"].to_numpy()
+        starts = grp["train_start"].to_numpy()
+        ends = grp["train_end"].to_numpy()
+        s = starts[0]
+        e = ends[0]
+        count = 1
+        for i in range(1, len(blk_ids)):
+            if blk_ids[i] == blk_ids[i - 1] + 1:
+                e = ends[i]
+                count += 1
+            else:
+                spans.append({"regime_id": rid, "start_date": s, "end_date": e, "num_blocks": count})
+                s = starts[i]
+                e = ends[i]
+                count = 1
+        spans.append({"regime_id": rid, "start_date": s, "end_date": e, "num_blocks": count})
+    span_df = pd.DataFrame(spans)
+    span_path = audit_dir / f"regime_spans_{tag}_{ts}.csv"
+    span_df.to_csv(span_path, index=False)
+
+    counts = assignments["regime_id"].value_counts().sort_index().to_dict()
+    top_global = fi_df.sort_values("F_score", ascending=False).head(3)["feature"].tolist()
+    print(f"[AUDIT++] K={K} | sizes: {counts}")
+    print(f"[AUDIT++] Max centroid diff (empirical vs model, unscaled): {max_diff:.6f}")
+    print(f"[AUDIT++] Top global drivers (F-score): {', '.join(top_global)}")
+    for k in range(K):
+        deltas = reg_means[k] - global_mean
+        order = np.argsort(np.abs(deltas))[::-1][:3]
+        parts = []
+        for idx in order:
+            sign = '+' if deltas[idx] >= 0 else '-'
+            parts.append(f"{sign}{features[idx]}")
+        print(f"[AUDIT++] R{k} top deltas: {', '.join(parts)}")
+    print(
+        "[AUDIT++] Files: centroids_unscaled.csv, feature_influence.csv, top_drivers.csv, "
+        "assignments_with_dates.csv, regime_spans.csv"
+    )
+
+    return {
+        "centroids_unscaled": cent_path,
+        "feature_influence": fi_path,
+        "top_drivers": top_path,
+        "assignments_with_dates": assign_path,
+        "regime_spans": span_path,
+        "max_centroid_diff": max_diff,
+        "sizes": counts,
+        "top_global_drivers": top_global,
+    }
+


### PR DESCRIPTION
## Summary
- Group CLI commands under data, regimes, and audit namespaces
- Add data verify check and full audit pipeline with automatic feature/cluster steps
- Implement regime_audit_plus for centroid unscale, feature influence, and date span exports

## Testing
- `python -m py_compile bot.py systems/regime_audit_plus.py`
- `python bot.py --help` *(fails: No module named 'ccxt')*
- `pip install ccxt` *(fails: Could not find a version that satisfies the requirement)*

------
https://chatgpt.com/codex/tasks/task_e_6897f4599b4c8326b51254fcbed138c7