### PR TITLE
feat: enforce feature alignment and hashing

### DIFF
--- a/settings.json
+++ b/settings.json
@@ -1,0 +1,6 @@
+{
+  "cluster_settings": {
+    "drop_features": ["avg_volume"],
+    "replace_features": {}
+  }
+}


### PR DESCRIPTION
## Summary
- Add deterministic feature SHA helper and std-floor scaling metadata
- Embed feature hash in clustering, support feature drops/replacements, and realign centroids against meta
- Align audits with centroid metadata to unscale data consistently
- Introduce optional settings to drop unstable features

## Testing
- `python bot.py regimes plan --tag SOLUSDT --train 3w --test 1m --step 1m` *(failed: No module named 'ccxt')*
- `python bot.py regimes features --tag SOLUSDT` *(failed: No module named 'ccxt')*
- `python bot.py regimes cluster --tag SOLUSDT` *(failed: No module named 'ccxt')*
- `python bot.py audit full --tag SOLUSDT -vv` *(failed: No module named 'ccxt')*


------
https://chatgpt.com/codex/tasks/task_e_6897f6a8608483268685cd2bfd2ab357