### PR TITLE
Finalize brain artifact and add audit CLI

### DIFF
--- a/systems/brain.py
+++ b/systems/brain.py
@@ -1,134 +1,90 @@
 from __future__ import annotations
 
-import json
 from pathlib import Path
-from typing import Dict, Optional
-
-import numpy as np
-import pandas as pd
-
-from .paths import (
-    BRAINS_DIR,
-    TEMP_DIR,
-    brain_json,
-    ensure_dirs,
-    temp_run_dir,
-)
+import json, shutil, numpy as np, pandas as pd
+from datetime import datetime
+from systems.paths import BRAINS_DIR, temp_cluster_dir, temp_audit_dir
+from systems.paths import load_settings
 
 
-def _latest_run_id(tag: str) -> str:
-    """Return most recent run id for a given tag."""
-    candidates = list(TEMP_DIR.glob(f"*/cluster/centroids_{tag}.json"))
-    if not candidates:
-        raise FileNotFoundError(
-            f"No clustering artifacts found for tag {tag}; run regimes cluster first"
-        )
-    latest = max(candidates, key=lambda p: p.stat().st_mtime)
-    return latest.parent.parent.name
+def _nowstamp():
+    return datetime.utcnow().strftime("%Y%m%d_%H%M%S")
 
 
-def finalize_brain(
-    tag: str,
-    run_id: str | None,
-    labels: Dict[int, str] | None,
-    alpha: float = 0.2,
-    switch_margin: float = 0.3,
-) -> Path:
-    """Assemble brain artifact from clustering outputs."""
-    ensure_dirs()
-    if run_id is None:
-        run_id = _latest_run_id(tag)
+def finalize_brain(tag: str, run_id: str, labels: dict[int, str] | None = None,
+                   alpha: float = 0.2, switch_margin: float = 0.3) -> Path:
+    # 1) Load aligned centroids payload (already includes features, mean, std, std_floor)
+    c_dir = temp_cluster_dir(run_id)
+    centroids_path = max(c_dir.glob("centroids_*.json"))  # newest
+    C = json.loads(Path(centroids_path).read_text())
+    feat = C["features"]; sha = C["feature_sha"]
+    mean = np.asarray(C["mean"], float).tolist()
+    std = np.asarray(C["std"], float).tolist()
+    std_floor = float(C.get("std_floor", 1e-6))
+    centroids = C["centroids"]; k = int(C["k"]); seed = int(C.get("seed", 42))
 
-    run_dir = temp_run_dir(run_id)
-    cluster_dir = run_dir / "cluster"
-    blocks_dir = run_dir / "blocks"
+    # 2) Build Markov P(next|current) from assignments_with_dates
+    a_dir = temp_audit_dir(run_id)
+    assign_path = max(a_dir.glob("assignments_with_dates_*.csv"))
+    df = pd.read_csv(assign_path).sort_values("block_id")
+    trans = np.ones((k, k), float)  # Laplace smoothing init
+    for (cur, nxt) in zip(df.regime_id.values[:-1], df.regime_id.values[1:]):
+        if 0 <= cur < k and 0 <= nxt < k:
+            trans[cur, nxt] += 1.0
+    trans = (trans.T / trans.sum(axis=1)).T  # row-stochastic
 
-    cent_path = cluster_dir / f"centroids_{tag}.json"
-    assign_path = cluster_dir / f"regime_assignments_{tag}.csv"
-    block_plan_path = blocks_dir / f"block_plan_{tag}.json"
+    # 3) Labels (optional)
+    label_map = {str(i): labels.get(i, f"Regime {i}") for i in range(k)} if labels else {}
 
-    with cent_path.open() as fh:
-        centroids = json.load(fh)
-
-    assignments = pd.read_csv(assign_path)
-    with block_plan_path.open() as fh:
-        block_plan = json.load(fh)
-    order_map = {idx + 1: idx for idx, _ in enumerate(block_plan)}
-    assignments["_order"] = assignments["block_id"].map(order_map)
-    assignments = assignments.sort_values("_order")
-    ids = assignments["regime_id"].to_numpy(dtype=int)
-
-    k = int(centroids.get("k", len(centroids["centroids"])))
-    counts = np.zeros((k, k), dtype=int)
-    for a, b in zip(ids[:-1], ids[1:]):
-        counts[a, b] += 1
-    transitions = (counts + 1) / (counts.sum(axis=1, keepdims=True) + k)
-
+    # 4) Brain payload
     brain = {
         "tag": tag,
-        "features": centroids["features"],
-        "feature_sha": centroids["feature_sha"],
-        "scaler": {
-            "mean": centroids["mean"],
-            "std": centroids["std"],
-            "std_floor": centroids.get("std_floor", 1e-6),
-        },
-        "centroids": centroids["centroids"],
         "k": k,
-        "seed": centroids.get("seed", 42),
-        "transitions": transitions.tolist(),
+        "seed": seed,
+        "features": feat,
+        "feature_sha": sha,
+        "scaler": {"mean": mean, "std": std, "std_floor": std_floor},
+        "centroids": centroids,       # scaled space
+        "labels": label_map,
+        "transitions": trans.tolist(),
         "hysteresis": {"ema_alpha": alpha, "switch_margin": switch_margin},
+        "meta": {"run_id": run_id, "created_utc": _nowstamp()}
     }
-    if labels:
-        brain["labels"] = {str(k): v for k, v in labels.items()}
 
-    path = brain_json(tag)
-    path.parent.mkdir(parents=True, exist_ok=True)
-    with path.open("w") as fh:
-        json.dump(brain, fh, indent=2)
-    return path
+    # 5) Save versioned brain file
+    out = BRAINS_DIR / f"brain_{tag}__k{k}_seed{seed}_{_nowstamp()}.json"
+    BRAINS_DIR.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(brain, indent=2))
+
+    # Latest copy for convenience
+    latest = BRAINS_DIR / f"brain_{tag}.json"
+    shutil.copyfile(out, latest)
+
+    return out
 
 
 class RegimeBrain:
-    """Lightweight inference helper for regime brains."""
+    @staticmethod
+    def from_file(path: str | Path) -> "RegimeBrain":
+        obj = json.loads(Path(path).read_text())
+        rb = RegimeBrain(); rb._b = obj; return rb
 
-    def __init__(
-        self,
-        tag: str,
-        features: list[str],
-        feature_sha: str,
-        scaler: Dict[str, list],
-        centroids: list[list[float]],
-        k: int,
-        seed: int,
-        transitions: list[list[float]],
-        hysteresis: Dict[str, float],
-        labels: Optional[Dict[str, str]] = None,
-    ) -> None:
-        self.tag = tag
-        self.features = features
-        self.feature_sha = feature_sha
-        self.scaler = scaler
-        self.centroids = np.asarray(centroids, dtype=float)
-        self.k = k
-        self.seed = seed
-        self.transitions = transitions
-        self.hysteresis = hysteresis
-        self.labels = labels or {}
+    def classify_now(self, x: np.ndarray) -> int:
+        s = self._b["scaler"]
+        mean = np.asarray(s["mean"])
+        std = np.asarray(s["std"])
+        std_floor = float(s.get("std_floor", 1e-6))
+        x_scaled = (np.asarray(x) - mean) / np.maximum(std, std_floor)
+        return self.classify_scaled(x_scaled)
 
-    @classmethod
-    def from_file(cls, path: Path | str) -> "RegimeBrain":
-        with open(path) as fh:
-            data = json.load(fh)
-        return cls(**data)
+    def classify_scaled(self, x_scaled: np.ndarray) -> int:
+        # x_scaled: shape (F,)
+        import numpy as np
+        C = np.asarray(self._b["centroids"])
+        d = ((C - x_scaled[None, :])**2).sum(axis=1)
+        return int(np.argmin(d))
 
-    def classify(self, features_scaled: np.ndarray) -> int:
-        dists = ((self.centroids - features_scaled) ** 2).sum(axis=1)
-        return int(dists.argmin())
-
-    def next_probs(self, current_id: int) -> np.ndarray:
-        return np.asarray(self.transitions[current_id])
-
-    def blend_knobs(self, p_current: np.ndarray, p_next: np.ndarray):
-        pass
+    def next_probs(self, current_id: int) -> list[float]:
+        P = np.asarray(self._b["transitions"])
+        return P[current_id].tolist()
 


### PR DESCRIPTION
## Summary
- implement brain finalization and lightweight runtime classifier
- add `audit brain` CLI command to build brain artifacts with labels and report transition row sums

## Testing
- `python -m py_compile systems/brain.py bot.py`


------
https://chatgpt.com/codex/tasks/task_e_689805de9bd8832684afd0c91f3c5d3a