### PR TITLE
feat: add CLI argument helpers

### DIFF
--- a/systems/utils/cli_args.py
+++ b/systems/utils/cli_args.py
@@ -1,0 +1,21 @@
+from argparse import ArgumentParser
+
+
+def add_verbose(p: ArgumentParser):
+    p.add_argument("-v", "--verbose", action="count", default=0, help="Increase verbosity (-v, -vv, -vvv)")
+    return p
+
+
+def add_tag(p: ArgumentParser, required=True):
+    p.add_argument("--tag", type=str, required=required, help="Symbol tag, e.g., SOLUSDT")
+    return p
+
+
+def add_run_id(p: ArgumentParser, required=False, default=None):
+    p.add_argument("--run-id", type=str, required=required, default=default, help="Run identifier, e.g., regimes_fresh")
+    return p
+
+
+def add_action(p: ArgumentParser, choices):
+    p.add_argument("--action", type=str, choices=choices, required=True, help="Action to perform")
+    return p


### PR DESCRIPTION
## Summary
- factor out common CLI arg helpers for tag, run ID, action, and verbosity
- wire regimes subcommands to use new helper functions
- handle tune action directly and support -v/--verbose

## Testing
- `python bot.py regimes --help`
- `python bot.py regimes --action tune --tag SOLUSDT --run-id regimes_fresh --regime-id 0 --tau 0.70 --trials 3 -vv` *(fails: ImportError: cannot import name 'sim_engine')*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6898190545348326bc71deb844b88a05