### PR TITLE
stabilize sim runner shim for regime tuning

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -388,6 +388,7 @@ def main(argv: Optional[List[str]] = None) -> None:
     sp_regimes.add_argument("--trials", type=int, default=50, help="Optuna trials")
     sp_regimes.add_argument("--metric", type=str, default="pnl_dd", help="Optimization metric")
     sp_regimes.add_argument("--seed", type=int, default=2, help="RNG seed")
+    sp_regimes.add_argument("--smoke", action="store_true", help=argparse.SUPPRESS)
 
     reg_sub = sp_regimes.add_subparsers(dest="command")
 
@@ -478,6 +479,7 @@ def main(argv: Optional[List[str]] = None) -> None:
                 metric=args.metric,
                 seed=args.seed,
                 verbose=args.verbose,
+                smoke=args.smoke,
             )
             return
         run_id = args.run_id or new_run_id("regimes")

--- a/systems/sim_engine.py
+++ b/systems/sim_engine.py
@@ -1,26 +1,129 @@
 from __future__ import annotations
-import importlib
 
-# Try preferred engines in order; fall back to simple_sim_engine
-_CANDIDATES = [
-    ("systems.engine", ["run_sim_blocks", "run_sim", "run_simulation"]),
-    ("systems.scripts.simple_sim_engine", ["run_sim_blocks"]),
-    ("engine.sim_engine", ["run_sim_blocks", "run_sim"]),
-    ("systems.simple_sim_engine", ["run_sim_blocks"]),  # our new fallback
+import importlib
+import inspect
+from typing import Any, Iterable
+
+# candidate modules to search for a sim runner
+_CANDIDATE_MODULES: list[str] = [
+    "systems.scripts.simple_sim_engine",
+    "systems.simple_sim_engine",
+    "systems.scripts.sim_engine",
+    "engine.simple_sim_engine",
+    "engine.sim_engine",
 ]
 
-def _load_runner():
-    last_err = None
-    for mod_name, fns in _CANDIDATES:
+# candidate function names within those modules
+_CANDIDATE_FUNCTIONS: list[str] = [
+    "run_sim_blocks",
+    "run_simulation_blocks",
+    "run_sim",
+    "run_simulation",
+]
+
+
+def _resolve_runner() -> tuple[Any, str, Any]:
+    """Return (module, fn_name, fn) for the first available runner."""
+    last_err: Exception | None = None
+    for mod_name in _CANDIDATE_MODULES:
         try:
             mod = importlib.import_module(mod_name)
-            for fn in fns:
-                if hasattr(mod, fn):
-                    return getattr(mod, fn)
-        except Exception as e:
+        except Exception as e:  # pragma: no cover - import errors are aggregated
             last_err = e
             continue
-    raise ImportError(f"[sim_shim] No sim runner found. Tried: {_CANDIDATES}\nLast error: {last_err}")
+        for fn_name in _CANDIDATE_FUNCTIONS:
+            if hasattr(mod, fn_name):
+                return mod, fn_name, getattr(mod, fn_name)
+    search = [(m, _CANDIDATE_FUNCTIONS) for m in _CANDIDATE_MODULES]
+    raise ImportError(
+        f"[sim_shim] No sim runner found. Tried: {search}\nLast error: {last_err}"
+    )
 
-# public API the rest of the code can call
-run_sim_blocks = _load_runner()
+
+_MOD, _FN_NAME, _RUNNER = _resolve_runner()
+RUNNER_ID = f"{_MOD.__name__}.{_FN_NAME}"
+
+
+def _call_runner_with_ranges(tag: str, ranges: Iterable, knobs: dict, verbose: int):
+    params = inspect.signature(_RUNNER).parameters
+    # handle low-level simple engines expecting candles+blocks
+    if "candles" in params and "blocks" in params:
+        from .data_loader import load_or_fetch  # lazy import
+        import numpy as np
+
+        candles = load_or_fetch(tag)
+        ts = candles["timestamp"].to_numpy()
+        blocks = []
+        for i, (start, end) in enumerate(ranges, 1):
+            if isinstance(start, (int, np.integer)) and isinstance(end, (int, np.integer)) and start <= end:
+                i0, i1 = int(start), int(end)
+            else:
+                i0 = int(np.searchsorted(ts, start, side="left"))
+                i1 = int(np.searchsorted(ts, end, side="right") - 1)
+            blocks.append({"test_index_start": i0, "test_index_end": i1, "block_id": i})
+        res = _RUNNER(candles, blocks, knobs)
+        if isinstance(res, dict):
+            return res
+        summary = getattr(res, "summary", None)
+        return summary if isinstance(summary, dict) else res
+
+    kwargs = {"tag": tag, "knobs": knobs, "verbose": verbose}
+    if "ranges" in params:
+        kwargs["ranges"] = ranges
+    elif "block_ranges" in params:
+        kwargs["block_ranges"] = ranges
+    elif "start_end_ranges" in params:
+        kwargs["start_end_ranges"] = ranges
+    else:  # assume positional (tag, ranges, knobs, verbose)
+        return _RUNNER(tag, ranges, knobs, verbose)
+    return _RUNNER(**kwargs)
+
+
+def run_sim_blocks(tag, ranges, knobs, verbose: int = 0):
+    """
+    ranges: list of (start_ts, end_ts) or list of candle-index tuples.
+    Must return dict with at least: {'pnl': float, 'maxdd': float, 'trades': int}
+    """
+    if _FN_NAME in ("run_sim_blocks", "run_simulation_blocks"):
+        return _call_runner_with_ranges(tag, ranges, knobs, verbose)
+
+    # runner handles a single block; aggregate over ranges
+    total_pnl = 0.0
+    total_trades = 0
+    equity = 0.0
+    peak = 0.0
+    maxdd = 0.0
+    for start, end in ranges:
+        params = inspect.signature(_RUNNER).parameters
+        kwargs = {"tag": tag, "knobs": knobs, "verbose": verbose}
+        if "resume" in params:
+            kwargs["resume"] = True
+        if "start" in params:
+            kwargs["start"] = start
+        elif "start_ts" in params:
+            kwargs["start_ts"] = start
+        elif "i0" in params:
+            kwargs["i0"] = start
+        if "end" in params:
+            kwargs["end"] = end
+        elif "end_ts" in params:
+            kwargs["end_ts"] = end
+        elif "i1" in params:
+            kwargs["i1"] = end
+        try:
+            res = _RUNNER(**kwargs)
+        except TypeError:
+            res = _RUNNER(tag, start, end, knobs, verbose)
+        pnl = float(res.get("pnl", 0.0))
+        total_pnl += pnl
+        total_trades += int(res.get("trades", 0))
+        equity += pnl
+        peak = max(peak, equity)
+        if peak > 0:
+            maxdd = max(maxdd, (peak - equity) / peak)
+        block_dd = float(res.get("maxdd", res.get("max_dd", 0.0)))
+        maxdd = max(maxdd, block_dd)
+    return {"pnl": float(total_pnl), "maxdd": float(maxdd), "trades": int(total_trades)}
+
+
+__all__ = ["run_sim_blocks", "RUNNER_ID"]


### PR DESCRIPTION
## Summary
- expand sim-engine shim to search multiple runner modules/functions and expose `RUNNER_ID`
- add uniform `run_sim_blocks` wrapper with aggregation for single-range runners
- update regime tuner to use shim, log runner, and support `--smoke` discovery mode
- add `systems/scripts` package initializer and CLI `--smoke` flag

## Testing
- `python -m py_compile systems/sim_engine.py systems/regime_tuner.py bot.py systems/scripts/__init__.py`
- `python - <<'PY'
import systems.sim_engine as se
print('runner', se.RUNNER_ID)
PY`


------
https://chatgpt.com/codex/tasks/task_e_68989508aea48326946f7f0862e7f7f2