### PR TITLE
Ensure UTF-8 logging

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -58,9 +58,9 @@ def log_to_file(tag: str, run_id: str):
     ensure_dirs()
     path = log_file(tag, run_id)
     path.parent.mkdir(parents=True, exist_ok=True)
-    with open(path, "a") as fh, redirect_stdout(Tee(sys.stdout, fh)), redirect_stderr(
-        Tee(sys.stderr, fh)
-    ):
+    with open(path, "a", encoding="utf-8", newline="") as fh, redirect_stdout(
+        Tee(sys.stdout, fh)
+    ), redirect_stderr(Tee(sys.stderr, fh)):
         yield
 
 logger = logging.getLogger("bot")

--- a/systems/regime_tuner.py
+++ b/systems/regime_tuner.py
@@ -72,7 +72,7 @@ def _bootstrap_centroids_from_brain(tag: str, run_id: str, cent_path: Path) -> N
     cent_path.parent.mkdir(parents=True, exist_ok=True)
     with cent_path.open("w") as fh:
         json.dump(payload, fh, indent=2)
-    print(f"[TUNE] Bootstrapped centroids from brain → {cent_path}")
+    print(f"[TUNE] Bootstrapped centroids from brain -> {cent_path}")
     print(
         f"[AUDIT] centroids:k={k} seed={seed} features={len(feature_names)} path={cent_path} ok"
     )

--- a/systems/simulator.py
+++ b/systems/simulator.py
@@ -139,12 +139,13 @@ def run_sim_blocks(
     if run_id:
         path = Path(log_path) if log_path else log_file(tag, run_id)
         path.parent.mkdir(parents=True, exist_ok=True)
-        log_fh = path.open("a")
+        log_fh = path.open("a", encoding="utf-8", newline="")
 
-    def _log(msg: str) -> None:
-        print(msg)
+    def _log(msg: str, log_fh=log_fh) -> None:
+        safe = msg.encode("utf-8", "replace").decode("utf-8")
+        print(safe)
         if log_fh is not None:
-            log_fh.write(msg + "\n")
+            log_fh.write(safe + "\n")
             log_fh.flush()
 
     _log(f"[SIM] Using sim runner: {RUNNER_ID}")
@@ -192,7 +193,7 @@ def run_sim_blocks(
             start_dt = pd.to_datetime(block_df.iloc[0]["timestamp"], unit="s", utc=True)
             end_dt = pd.to_datetime(block_df.iloc[-1]["timestamp"], unit="s", utc=True)
             _log(
-                f"[BLOCK] k={k:02d} | {start_dt.date()} → {end_dt.date()} | candles={len(block_df)}"
+                f"[BLOCK] k={k:02d} | {start_dt.date()} -> {end_dt.date()} | candles={len(block_df)}"
             )
             _log(
                 f"[BLOCK] trades={res['trades']} pnl=${res['pnl']:.2f} maxdd={res['maxdd']:.2f}"


### PR DESCRIPTION
## Summary
- open simulator logs with UTF-8 encoding and safe newline handling
- ensure `_log` prints/writes safely, replacing invalid characters
- open bot log files as UTF-8 and drop Unicode arrows in tuner messages

## Testing
- `python -m py_compile systems/simulator.py systems/regime_tuner.py bot.py`
- `python bot.py regimes --action train purity --tag SOLUSDT --run-id sim_smoke --tau 0.60` *(fails: UnboundLocalError in compute_purity)*
- `python bot.py regimes --action tune --tag SOLUSDT --run-id sim_smoke --regime-id 0 --tau 0.60 --trials 1 -vvv` *(fails: ModuleNotFoundError: No module named 'optuna')*

------
https://chatgpt.com/codex/tasks/task_e_6898af8d05448326a6827c236eaf7d34