### PR TITLE
Add dynamic policy blending for sim and live modes

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -358,6 +358,41 @@ def cmd_audit_full(args: argparse.Namespace) -> None:
 # ---------------------------------------------------------------------------
 
 def main(argv: Optional[List[str]] = None) -> None:
+    if argv is None:
+        argv = sys.argv[1:]
+    if "--mode" in argv:
+        idx = argv.index("--mode")
+        mode_val = argv[idx + 1] if idx + 1 < len(argv) else None
+        if mode_val == "blend":
+            p = argparse.ArgumentParser()
+            p.add_argument("--mode", choices=["blend"], required=True)
+            p.add_argument("--tag", required=True)
+            p.add_argument("--run-id")
+            p.add_argument("--alpha", type=float, default=0.7)
+            p.add_argument("--hyst-boost", type=float, default=0.1)
+            p.add_argument("--live", action="store_true")
+            p.add_argument("-v", "--verbose", action="count", default=0)
+            args = p.parse_args(argv)
+            if args.live:
+                from systems.live_engine import run_blend_live
+
+                run_blend_live(
+                    args.tag,
+                    alpha=args.alpha,
+                    boost=args.hyst_boost,
+                    verbosity=args.verbose,
+                )
+            else:
+                from systems.simulator import run_blend_sim
+
+                run_blend_sim(
+                    tag=args.tag,
+                    run_id=args.run_id or "blend",
+                    alpha=args.alpha,
+                    boost=args.hyst_boost,
+                    verbosity=args.verbose,
+                )
+            return
     parser = argparse.ArgumentParser()
     subparsers = parser.add_subparsers(dest="group", required=True)
 

--- a/systems/live_engine.py
+++ b/systems/live_engine.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict, Any, List
+
+import numpy as np
+
+from systems.data_loader import load_or_fetch
+from systems.brain import RegimeBrain
+from systems.features import extract_features, ALL_FEATURES
+from systems.policy_blender import (
+    load_seed_knobs,
+    classify_current,
+    predict_next,
+    apply_hysteresis,
+    blend_knobs,
+)
+
+try:  # pragma: no cover - scripts may be absent in tests
+    from systems.scripts.evaluate_buy import evaluate_buy  # type: ignore
+    from systems.scripts.evaluate_sell import evaluate_sell  # type: ignore
+except Exception:  # pragma: no cover
+    def evaluate_buy(*args, **kwargs):
+        return False
+
+    def evaluate_sell(*args, **kwargs):
+        return False
+
+
+def run_blend_live(
+    tag: str,
+    *,
+    alpha: float = 0.7,
+    boost: float = 0.1,
+    verbosity: int = 0,
+) -> Dict[str, Any]:
+    """Live-style engine that mirrors simulation blending."""
+    candles = load_or_fetch(tag)
+    candles = candles.tail(200).reset_index(drop=True)
+
+    brain = RegimeBrain.from_file(Path("data/brains") / f"brain_{tag}.json")
+    feat_order = brain._b.get("features", [])
+    idx = [ALL_FEATURES.index(f) for f in feat_order]
+
+    seed_knobs = load_seed_knobs().get(tag, {})
+    if not seed_knobs:
+        raise ValueError(f"No seed knobs for tag {tag}")
+
+    history: List[int] = []
+    last_top: int | None = None
+    win = 50
+    for i in range(win, len(candles)):
+        window = candles.iloc[i - win : i]
+        feats = extract_features(window)
+        window_feats = feats[idx]
+
+        weights_now = classify_current(window_feats, brain)
+        weights_next = predict_next(weights_now, history, alpha)
+        weights_final = apply_hysteresis(weights_next, last_top, boost)
+        blended_knobs = blend_knobs(weights_final, seed_knobs)
+
+        if verbosity >= 3:
+            print(
+                f"[BLEND] now={weights_now.round(3).tolist()} "
+                f"next={weights_next.round(3).tolist()} "
+                f"final={weights_final.round(3).tolist()} "
+                f"knobs={blended_knobs}"
+            )
+
+        price = float(window.iloc[-1]["close"])
+        evaluate_buy(price=price, knobs=blended_knobs)
+        evaluate_sell(price=price, knobs=blended_knobs)
+
+        top = int(np.argmax(weights_final))
+        history.append(top)
+        if len(history) > 50:
+            history.pop(0)
+        last_top = top
+
+    return {"ticks": len(candles) - win}
+
+
+__all__ = ["run_blend_live"]

--- a/systems/policy_blender.py
+++ b/systems/policy_blender.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Dict, List
+
+import numpy as np
+
+# knob ranges from tuner for safety
+RANGES: Dict[str, tuple[float, float]] = {
+    "position_pct": (0.02, 0.12),
+    "max_concurrent": (1, 3),
+    "buy_cooldown": (4, 18),
+    "volatility_gate": (0.6, 1.2),
+    "rsi_buy": (30, 45),
+    "take_profit": (0.008, 0.035),
+    "trailing_stop": (0.006, 0.03),
+    "stop_loss": (0.02, 0.08),
+    "sell_cooldown": (3, 16),
+}
+INT_FIELDS = {"buy_cooldown", "sell_cooldown", "max_concurrent", "rsi_buy"}
+
+
+def load_seed_knobs() -> Dict[str, Dict[str, Dict[str, float]]]:
+    """Load seed knobs from disk."""
+    path = Path("regimes/seed_knobs.json")
+    with path.open() as fh:
+        return json.load(fh)
+
+
+def classify_current(window_features: np.ndarray, brain) -> np.ndarray:
+    """Convert distances to weights based on brain centroids."""
+    b = brain._b if hasattr(brain, "_b") else brain
+    scaler = b["scaler"]
+    mean = np.asarray(scaler["mean"], dtype=float)
+    std = np.maximum(np.asarray(scaler["std"], dtype=float), float(scaler.get("std_floor", 1e-6)))
+    x = (np.asarray(window_features, dtype=float) - mean) / std
+    centroids = np.asarray(b["centroids"], dtype=float)
+    dists = np.linalg.norm(centroids - x[None, :], axis=1)
+    inv = 1.0 / np.maximum(dists, 1e-9)
+    weights = inv / inv.sum() if inv.sum() else np.ones_like(inv) / len(inv)
+    return weights
+
+
+def predict_next(weights: np.ndarray, history: List[int], alpha: float = 0.7) -> np.ndarray:
+    k = len(weights)
+    trans = np.ones((k, k), float)
+    for a, b in zip(history[:-1], history[1:]):
+        if 0 <= a < k and 0 <= b < k:
+            trans[a, b] += 1.0
+    trans = (trans.T / trans.sum(axis=1)).T
+    pred = weights @ trans
+    blended = alpha * weights + (1 - alpha) * pred
+    return blended / blended.sum() if blended.sum() else weights
+
+
+def apply_hysteresis(weights: np.ndarray, last_top: int | None, boost: float = 0.1) -> np.ndarray:
+    w = weights.copy()
+    if last_top is not None and int(np.argmax(w)) == last_top:
+        w[last_top] += boost
+    return w / w.sum() if w.sum() else w
+
+
+def _clamp(v: float, lo: float, hi: float) -> float:
+    return max(lo, min(hi, v))
+
+
+def blend_knobs(weights: np.ndarray, knobs_by_regime: Dict[str, Dict[str, float]]) -> Dict[str, float]:
+    regimes = sorted(knobs_by_regime.keys())
+    k = min(len(regimes), len(weights))
+    w = np.asarray(weights[:k], dtype=float)
+    keys = set().union(*(knobs_by_regime[r].keys() for r in regimes))
+    out: Dict[str, float] = {}
+    for key in keys:
+        vals = [knobs_by_regime[r].get(key, 0.0) for r in regimes[:k]]
+        val = float(np.dot(w, vals))
+        if key in INT_FIELDS:
+            val = int(round(val))
+        lo, hi = RANGES.get(key, (None, None))
+        if lo is not None and hi is not None:
+            val = _clamp(val, lo, hi)
+        out[key] = val
+    return out
+
+
+__all__ = [
+    "load_seed_knobs",
+    "classify_current",
+    "predict_next",
+    "apply_hysteresis",
+    "blend_knobs",
+]


### PR DESCRIPTION
## Summary
- implement `policy_blender` with regime classification, transition prediction, hysteresis, and knob blending
- add `run_blend_sim` and `run_blend_live` engines using dynamic knob blending
- extend `bot.py` with `--mode blend` to drive simulator or live engine

## Testing
- `python bot.py --mode blend --tag SOLUSDT --run-id sim_blend --alpha 0.7 --hyst-boost 0.1 -vvv`

------
https://chatgpt.com/codex/tasks/task_e_6898bbc7d9408326bc461670faa4f13f