### PR TITLE
Integrate regime-based knob blending into sim and live engines

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -374,23 +374,36 @@ def main(argv: Optional[List[str]] = None) -> None:
             p.add_argument("-v", "--verbose", action="count", default=0)
             args = p.parse_args(argv)
             if args.live:
-                from systems.live_engine import run_blend_live
+                from systems.live_engine import run_live
 
-                run_blend_live(
+                run_live(
                     args.tag,
+                    blend_enabled=True,
                     alpha=args.alpha,
-                    boost=args.hyst_boost,
+                    hyst_boost=args.hyst_boost,
                     verbosity=args.verbose,
                 )
             else:
-                from systems.simulator import run_blend_sim
+                from systems.simulator import run_sim_blocks
+                from systems.policy_blender import load_seed_knobs
+                from systems.paths import load_settings
 
-                run_blend_sim(
+                seed_all = load_seed_knobs().get(args.tag, {})
+                if not seed_all:
+                    raise SystemExit(f"No seed knobs for tag {args.tag}")
+                base_knobs = next(iter(seed_all.values()))
+                settings = load_settings()
+
+                run_sim_blocks(
+                    blocks=[{}],
                     tag=args.tag,
-                    run_id=args.run_id or "blend",
-                    alpha=args.alpha,
-                    boost=args.hyst_boost,
+                    knobs=base_knobs,
+                    settings=settings,
                     verbosity=args.verbose,
+                    run_id=args.run_id or "blend",
+                    blend_enabled=True,
+                    alpha=args.alpha,
+                    hyst_boost=args.hyst_boost,
                 )
             return
     parser = argparse.ArgumentParser()

--- a/systems/live_engine.py
+++ b/systems/live_engine.py
@@ -8,6 +8,7 @@ import numpy as np
 from systems.data_loader import load_or_fetch
 from systems.brain import RegimeBrain
 from systems.features import extract_features, ALL_FEATURES
+from systems.simulator import _clean_prices
 from systems.policy_blender import (
     load_seed_knobs,
     classify_current,
@@ -27,57 +28,64 @@ except Exception:  # pragma: no cover
         return False
 
 
-def run_blend_live(
+def run_live(
     tag: str,
     *,
+    blend_enabled: bool = False,
     alpha: float = 0.7,
-    boost: float = 0.1,
+    hyst_boost: float = 0.1,
     verbosity: int = 0,
 ) -> Dict[str, Any]:
-    """Live-style engine that mirrors simulation blending."""
-    candles = load_or_fetch(tag)
-    candles = candles.tail(200).reset_index(drop=True)
+    """Simplified live engine with optional knob blending."""
+    candles = _clean_prices(load_or_fetch(tag))
 
-    brain = RegimeBrain.from_file(Path("data/brains") / f"brain_{tag}.json")
-    feat_order = brain._b.get("features", [])
-    idx = [ALL_FEATURES.index(f) for f in feat_order]
-
-    seed_knobs = load_seed_knobs().get(tag, {})
-    if not seed_knobs:
-        raise ValueError(f"No seed knobs for tag {tag}")
+    brain = None
+    seed_knobs: Dict[str, Dict[str, Any]] | None = None
+    feat_idx: List[int] | None = None
+    default_knobs: Dict[str, Any] = {}
+    if blend_enabled:
+        brain = RegimeBrain.from_file(Path("data/brains") / f"brain_{tag}.json")
+        feat_order = brain._b.get("features", [])
+        feat_idx = [ALL_FEATURES.index(f) for f in feat_order]
+        seed_knobs = load_seed_knobs().get(tag, {})
+        if not seed_knobs:
+            raise ValueError(f"No seed knobs for tag {tag}")
+        default_knobs = next(iter(seed_knobs.values()))
+    else:
+        seed_all = load_seed_knobs().get(tag, {})
+        default_knobs = next(iter(seed_all.values()), {})
 
     history: List[int] = []
     last_top: int | None = None
     win = 50
-    for i in range(win, len(candles)):
-        window = candles.iloc[i - win : i]
-        feats = extract_features(window)
-        window_feats = feats[idx]
+    for i in range(len(candles)):
+        knobs_now = default_knobs
+        if blend_enabled and brain is not None and seed_knobs is not None and i >= win:
+            window = candles.iloc[i - win : i]
+            feats = extract_features(window)
+            window_feats = feats[feat_idx] if feat_idx is not None else feats
+            w_now = classify_current(window_feats, brain)
+            w_next = predict_next(w_now, history, alpha)
+            w_final = apply_hysteresis(w_next, last_top, hyst_boost)
+            knobs_now = blend_knobs(w_final, seed_knobs)
+            if verbosity >= 3:
+                print(
+                    f"[BLEND] now={w_now.round(3).tolist()} "
+                    f"next={w_next.round(3).tolist()} "
+                    f"final={w_final.round(3).tolist()} "
+                    f"knobs={knobs_now}"
+                )
+            top = int(np.argmax(w_final))
+            history.append(top)
+            if len(history) > 50:
+                history.pop(0)
+            last_top = top
 
-        weights_now = classify_current(window_feats, brain)
-        weights_next = predict_next(weights_now, history, alpha)
-        weights_final = apply_hysteresis(weights_next, last_top, boost)
-        blended_knobs = blend_knobs(weights_final, seed_knobs)
+        price = float(candles.iloc[i]["close"])
+        evaluate_buy(price=price, knobs=knobs_now)
+        evaluate_sell(price=price, knobs=knobs_now)
 
-        if verbosity >= 3:
-            print(
-                f"[BLEND] now={weights_now.round(3).tolist()} "
-                f"next={weights_next.round(3).tolist()} "
-                f"final={weights_final.round(3).tolist()} "
-                f"knobs={blended_knobs}"
-            )
-
-        price = float(window.iloc[-1]["close"])
-        evaluate_buy(price=price, knobs=blended_knobs)
-        evaluate_sell(price=price, knobs=blended_knobs)
-
-        top = int(np.argmax(weights_final))
-        history.append(top)
-        if len(history) > 50:
-            history.pop(0)
-        last_top = top
-
-    return {"ticks": len(candles) - win}
+    return {"ticks": len(candles)}
 
 
-__all__ = ["run_blend_live"]
+__all__ = ["run_live"]


### PR DESCRIPTION
## Summary
- replace demo blend loop with per-tick blending in `_run_block`
- add blend controls to `run_sim_blocks` and new `run_live`
- wire `--mode blend` to simulation and live paths

## Testing
- `python bot.py --mode blend --tag SOLUSDT --run-id sim_blend --alpha 0.7 --hyst-boost 0.1 -vvv`
- `python bot.py --mode blend --tag SOLUSDT --alpha 0.7 --hyst-boost 0.1 --live -vvv`

------
https://chatgpt.com/codex/tasks/task_e_6898bf5d03b8832686fe316c5dd30521