### PR TITLE
Add blend-window option for blend mode

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -372,6 +372,15 @@ def main(argv: Optional[List[str]] = None) -> None:
             p.add_argument("--hyst-boost", type=float, default=0.1)
             p.add_argument("--live", action="store_true")
             p.add_argument("-v", "--verbose", action="count", default=0)
+            p.add_argument(
+                "--blend-window",
+                type=int,
+                default=None,
+                help=(
+                    "Number of most recent candles to use for blend mode "
+                    "(default: full history)"
+                ),
+            )
             args = p.parse_args(argv)
             if args.live:
                 from systems.live_engine import run_live
@@ -382,6 +391,7 @@ def main(argv: Optional[List[str]] = None) -> None:
                     alpha=args.alpha,
                     hyst_boost=args.hyst_boost,
                     verbosity=args.verbose,
+                    blend_window=args.blend_window,
                 )
             else:
                 from systems.simulator import run_sim_blocks
@@ -404,6 +414,7 @@ def main(argv: Optional[List[str]] = None) -> None:
                     blend_enabled=True,
                     alpha=args.alpha,
                     hyst_boost=args.hyst_boost,
+                    blend_window=args.blend_window,
                 )
             return
     parser = argparse.ArgumentParser()

--- a/systems/live_engine.py
+++ b/systems/live_engine.py
@@ -35,9 +35,13 @@ def run_live(
     alpha: float = 0.7,
     hyst_boost: float = 0.1,
     verbosity: int = 0,
+    blend_window: int | None = None,
 ) -> Dict[str, Any]:
     """Simplified live engine with optional knob blending."""
     candles = _clean_prices(load_or_fetch(tag))
+    if blend_enabled and blend_window:
+        candles = candles.iloc[-blend_window:].copy()
+        print(f"[BLEND] Using last {blend_window} candles for test")
 
     brain = None
     seed_knobs: Dict[str, Dict[str, Any]] | None = None

--- a/systems/simulator.py
+++ b/systems/simulator.py
@@ -294,6 +294,7 @@ def run_sim_blocks(
     blend_enabled: bool = False,
     alpha: float = 0.7,
     hyst_boost: float = 0.1,
+    blend_window: int | None = None,
 ) -> Dict[str, Any]:
     """Execute simulation over blocks."""
 
@@ -323,6 +324,9 @@ def run_sim_blocks(
         sim_dir.mkdir(parents=True, exist_ok=True)
 
     candles = load_or_fetch(tag)
+    if blend_enabled and blend_window:
+        candles = candles.iloc[-blend_window:].copy()
+        _log(f"[BLEND] Using last {blend_window} candles for test")
     # Ensure timestamps are int64 seconds
     candles = candles.copy()
     candles["timestamp"] = pd.to_numeric(candles["timestamp"], errors="coerce").astype("Int64")


### PR DESCRIPTION
## Summary
- allow specifying a `--blend-window` to limit candle history during blend mode runs
- support candle history slicing in simulator and live engine when blend mode is enabled

## Testing
- `python bot.py --mode blend --tag SOLUSDT --run-id sim_blend_short --blend-window 500 -vvv`
- `python bot.py --mode blend --tag SOLUSDT --run-id sim_blend_long -vvv`


------
https://chatgpt.com/codex/tasks/task_e_6898c39934888326b061b987d8df8fa9