### PR TITLE
Add single-coin brain scoring with streaming debug

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -12,17 +12,24 @@ def main():
     brains_p = sub.add_parser("brains")
     brains_sub = brains_p.add_subparsers(dest="action")
     score_p = brains_sub.add_parser("score")
-    score_p.add_argument("--coins", required=True)
-    score_p.add_argument("--start", required=True)
-    score_p.add_argument("--end", required=True)
+    score_p.add_argument("--coin")
+    score_p.add_argument("--coins")
+    score_p.add_argument("--start")
+    score_p.add_argument("--end")
     score_p.add_argument("--horizons")
     score_p.add_argument("--out")
+    score_p.add_argument("--no_write", action="store_true")
     score_p.add_argument("--min_events", type=int)
     score_p.add_argument("-v", dest="verbose", action="count", default=0)
 
     args = parser.parse_args()
 
     if args.cmd == "brains" and args.action == "score":
+        if not args.coin and not args.coins:
+            score_p.print_help()
+            return
+        if args.coin:
+            args.coins = args.coin
         brain_score.main(args)
     else:
         parser.print_help()

--- a/readme..md
+++ b/readme..md
@@ -218,6 +218,17 @@ Because each brain outputs a \*\*boolean decision\*\* given price series context
 
 
 
+### Quick Brain Check (single coin, full history, no files)
+
+```powershell
+python bot.py brains score --coin SOLUSDT --no_write -vvv
+```
+
+--coin SOLUSDT → test one coin  
+--no_write → print-only (no CSVs)  
+-vvv → step-by-step debug; use -vv for periodic progress  
+Press Ctrl+C anytime — you’ll get a summary of Bear/Chop/Bull hit rates so far.
+
 \* Simulation harnesses to measure historical hit-rate.
 
 \* Live bots to gate trade execution.

--- a/systems/brain_score.py
+++ b/systems/brain_score.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import argparse
 import csv
 import json
 import math
@@ -21,7 +20,7 @@ def _parse_horizon(h: str) -> int:
     return int(h)
 
 
-def _load_series(tag: str) -> dict:
+def _load_series(tag: str, args) -> tuple[dict, datetime, datetime]:
     raw_dir = Path("data/raw")
     candidates = [raw_dir / f"{tag}.csv", raw_dir / f"{tag}.parquet", raw_dir / f"{tag.lower()}.csv"]
     if not any(p.exists() for p in candidates):
@@ -52,7 +51,10 @@ def _load_series(tag: str) -> dict:
             high.append(float(row["high"]))
             low.append(float(row["low"]))
             close.append(float(row["close"]))
-    return {"ts": ts, "open": open_, "high": high, "low": low, "close": close}
+    series = {"ts": ts, "open": open_, "high": high, "low": low, "close": close}
+    start = datetime.fromisoformat(args.start) if args.start else datetime.fromtimestamp(ts[0])
+    end = datetime.fromisoformat(args.end) if args.end else datetime.fromtimestamp(ts[-1])
+    return series, start, end
 
 
 def _baseline(close, horizon):
@@ -86,7 +88,7 @@ def _score_events(events, baseline):
     return events
 
 
-def score_coin(coin, series, cfg, start, end):
+def score_coin(coin, series, cfg, start, end, args):
     ts = series["ts"]
     close = series["close"]
     start_ts = int(start.timestamp())
@@ -95,9 +97,11 @@ def score_coin(coin, series, cfg, start, end):
     if not idx:
         return []
     max_w = max(cfg["bear"].get("L", 0), cfg["chop"].get("S", 0), cfg["bull"].get("M", 0))
-    horizon = max(_parse_horizon(cfg["bear"].get("horizons", ["24h"])[0]),
-                  _parse_horizon(cfg["chop"].get("horizons", ["24h"])[0]),
-                  _parse_horizon(cfg["bull"].get("horizons", ["24h"])[0]))
+    horizon = max(
+        _parse_horizon(cfg["bear"].get("horizons", ["24h"])[0]),
+        _parse_horizon(cfg["chop"].get("horizons", ["24h"])[0]),
+        _parse_horizon(cfg["bull"].get("horizons", ["24h"])[0]),
+    )
     start_i = max(0, idx[0] - max_w)
     end_i = min(len(ts), idx[-1] + horizon + 1)
     ts = ts[start_i:end_i]
@@ -112,54 +116,102 @@ def score_coin(coin, series, cfg, start, end):
     idx = [i for i, t in enumerate(ts) if start_ts <= t <= end_ts]
     summaries = []
     brains = {
-        "BEAR": (bear.parked, cfg["bear"]),
-        "CHOP": (chop.edge_long, cfg["chop"]),
-        "BULL": (bull.momo_long, cfg["bull"]),
+        "BEAR": (bear.parked, bear.explain, cfg["bear"]),
+        "CHOP": (chop.edge_long, chop.explain, cfg["chop"]),
+        "BULL": (bull.momo_long, bull.explain, cfg["bull"]),
     }
-    for name, (func, bcfg) in brains.items():
+    min_events = args.min_events if args.min_events is not None else cfg["scoring"].get("min_events", 100)
+    for name, (func, expl, bcfg) in brains.items():
         horizon = _parse_horizon(bcfg.get("horizons", ["24h"])[0])
         baseline = _baseline(close, horizon)
         events = []
-        for i in idx:
-            if i + horizon >= len(close):
-                break
-            dec = func(i, series, bcfg)
-            if not dec:
-                continue
-            if name == "BEAR":
-                hit, _ = first_hits(close, i, bcfg.get("up_pct", 0.02), bcfg.get("down_pct", -0.02), horizon)
-                outcome = int(close[i + horizon] < close[i] or hit == "down")
-            elif name == "CHOP":
-                hit, _ = first_hits(close, i, bcfg.get("tp_up", 0.04), bcfg.get("sl_dn", -0.03), horizon)
-                outcome = int(hit == "up")
-            else:
-                hit, _ = first_hits(close, i, bcfg.get("tp_up", 0.06), bcfg.get("sl_dn", -0.04), horizon)
-                outcome = int(hit == "up")
-            events.append({"ts": ts[i], "outcome": outcome})
+        hits = 0
+        total = idx[-1] if idx else 0
+        if args.verbose >= 1:
+            print(f"[{coin}] {name} horizon={horizon}h baseline={baseline*100:.1f}% (events so far: 0)")
+        interrupted = False
+        try:
+            for step, i in enumerate(idx):
+                if i + horizon >= len(close):
+                    break
+                if args.verbose >= 2 and step % 1000 == 0:
+                    p = hits / len(events) if events else 0.0
+                    print(f"[{name}] i={i}/{total} events={len(events)} hits={hits} p={p*100:.1f}% lift={(p-baseline)*100:+.1f}%")
+                if args.verbose >= 3:
+                    res = expl(i, series, bcfg)
+                    dec = res.get("decision")
+                    reasons = res.get("reasons", {})
+                else:
+                    dec = func(i, series, bcfg)
+                if not dec:
+                    continue
+                if name == "BEAR":
+                    hit, _ = first_hits(close, i, bcfg.get("up_pct", 0.02), bcfg.get("down_pct", -0.02), horizon)
+                    outcome = int(close[i + horizon] < close[i] or hit == "down")
+                elif name == "CHOP":
+                    hit, _ = first_hits(close, i, bcfg.get("tp_up", 0.04), bcfg.get("sl_dn", -0.03), horizon)
+                    outcome = int(hit == "up")
+                else:
+                    hit, _ = first_hits(close, i, bcfg.get("tp_up", 0.06), bcfg.get("sl_dn", -0.04), horizon)
+                    outcome = int(hit == "up")
+                hits += outcome
+                events.append({"ts": ts[i], "outcome": outcome})
+                if args.verbose >= 2:
+                    p = hits / len(events)
+                    print(f"[{name}] i={i}/{total} events={len(events)} hits={hits} p={p*100:.1f}% lift={(p-baseline)*100:+.1f}%")
+                if args.verbose >= 3:
+                    t = datetime.fromtimestamp(ts[i]).isoformat(timespec="minutes")
+                    parts = []
+                    for k, v in reasons.items():
+                        if isinstance(v, bool):
+                            parts.append(f"{k}={'+' if v else '-'}")
+                        elif isinstance(v, float):
+                            parts.append(f"{k}={v:+.1f}")
+                        else:
+                            parts.append(f"{k}={v}")
+                    reason_str = " ".join(parts)
+                    print(f"[{name}] t={t} {reason_str} OK -> OUTCOME={'up' if outcome else 'down'}")
+        except KeyboardInterrupt:
+            interrupted = True
         events = _score_events(events, baseline)
-        events_path = brains_events_path(coin, name)
-        with open(events_path, "w", newline="") as f:
-            writer = csv.DictWriter(f, fieldnames=["ts", "decision", "outcome", "p_hat", "ci_low", "ci_high", "lift"])
-            writer.writeheader()
-            for e in events:
-                row = {"ts": e["ts"], "decision": 1, "outcome": e["outcome"], "p_hat": e["p_hat"],
-                       "ci_low": e["ci_low"], "ci_high": e["ci_high"], "lift": e["lift"]}
-                writer.writerow(row)
+        if not args.no_write and args.out:
+            events_path = brains_events_path(coin, name)
+            with open(events_path, "w", newline="") as f:
+                writer = csv.DictWriter(
+                    f,
+                    fieldnames=["ts", "decision", "outcome", "p_hat", "ci_low", "ci_high", "lift"],
+                )
+                writer.writeheader()
+                for e in events:
+                    row = {
+                        "ts": e["ts"],
+                        "decision": 1,
+                        "outcome": e["outcome"],
+                        "p_hat": e["p_hat"],
+                        "ci_low": e["ci_low"],
+                        "ci_high": e["ci_high"],
+                        "lift": e["lift"],
+                    }
+                    writer.writerow(row)
         p_hat = events[-1]["p_hat"] if events else 0.0
         ci_low, ci_high = _wilson(p_hat, len(events))
         lift = p_hat - baseline
-        summaries.append({
-            "coin": coin,
-            "brain": name,
-            "events": len(events),
-            "p_hat": p_hat,
-            "ci_low": ci_low,
-            "ci_high": ci_high,
-            "baseline": baseline,
-            "lift": lift,
-            "insufficient_sample": int(len(events) < cfg["scoring"].get("min_events", 100)),
-            "drift": 0,
-        })
+        summaries.append(
+            {
+                "coin": coin,
+                "brain": name,
+                "events": len(events),
+                "p_hat": p_hat,
+                "ci_low": ci_low,
+                "ci_high": ci_high,
+                "baseline": baseline,
+                "lift": lift,
+                "insufficient_sample": int(len(events) < min_events),
+                "drift": 0,
+            }
+        )
+        if interrupted:
+            break
     return summaries
 
 
@@ -167,17 +219,25 @@ def main(args):
     with open("settings.json") as f:
         cfg = json.load(f)["brains"]
     coins = [c.strip() for c in args.coins.split(",") if c.strip()]
-    start = datetime.fromisoformat(args.start)
-    end = datetime.fromisoformat(args.end)
     all_rows = []
     for coin in coins:
-        series = _load_series(coin)
-        all_rows.extend(score_coin(coin, series, cfg, start, end))
-    summary_path = brains_summary_path()
-    with open(summary_path, "w", newline="") as f:
-        writer = csv.DictWriter(f, fieldnames=["coin", "brain", "events", "p_hat", "ci_low", "ci_high", "baseline", "lift", "insufficient_sample", "drift"])
-        writer.writeheader()
+        series, start, end = _load_series(coin, args)
+        all_rows.extend(score_coin(coin, series, cfg, start, end, args))
+    if not args.no_write and args.out:
+        summary_path = brains_summary_path()
+        with open(summary_path, "w", newline="") as f:
+            writer = csv.DictWriter(
+                f,
+                fieldnames=["coin", "brain", "events", "p_hat", "ci_low", "ci_high", "baseline", "lift", "insufficient_sample", "drift"],
+            )
+            writer.writeheader()
+            for row in all_rows:
+                writer.writerow(row)
+    else:
+        print("coin brain events p_hat ci_low ci_high baseline lift")
         for row in all_rows:
-            writer.writerow(row)
-    if args.verbose:
-        print(all_rows)
+            print(
+                f"{row['coin']} {row['brain']} {row['events']} "
+                f"{row['p_hat']*100:.1f}% {row['ci_low']*100:.1f}% {row['ci_high']*100:.1f}% "
+                f"{row['baseline']*100:.1f}% {row['lift']*100:+.1f}%"
+            )

--- a/systems/brains/bear.py
+++ b/systems/brains/bear.py
@@ -21,3 +21,30 @@ def parked(candle_idx: int, series: dict, cfg: dict) -> bool:
     if math.isnan(sl) or math.isnan(z):
         return False
     return sl < 0 or z < z_off
+
+
+def explain(candle_idx: int, series: dict, cfg: dict) -> dict:
+    close = series["close"]
+    high = series["high"]
+    low = series["low"]
+    L = cfg.get("L", 50)
+    z_off = cfg.get("z_off", -1.0)
+    atr_cool = cfg.get("atr_cool", 0.02)
+
+    sma_L = sma(close, L)
+    z_L = zscore(close, L)
+    slope_L = slope(sma_L, L)
+    atr_L = atr(high, low, close, L)
+
+    if candle_idx >= len(close):
+        return {"decision": False, "reasons": {}}
+    sl = slope_L[candle_idx]
+    z = z_L[candle_idx]
+    atr_rel = atr_L[candle_idx] / close[candle_idx] if close[candle_idx] else math.nan
+    atr_ok = not math.isnan(atr_rel) and atr_rel < atr_cool
+    if math.isnan(sl) or math.isnan(z):
+        decision = False
+    else:
+        decision = sl < 0 or z < z_off
+    reasons = {"slopeL": sl, "zL": z, "atr_cool_ok": atr_ok}
+    return {"decision": decision, "reasons": reasons}

--- a/systems/brains/bull.py
+++ b/systems/brains/bull.py
@@ -35,3 +35,25 @@ def momo_long(candle_idx: int, series: dict, cfg: dict) -> bool:
         return False
     start = max(0, candle_idx - hh_lookback + 1)
     return _higher_highs(close[start:candle_idx + 1], hh_lookback, hh_min)
+
+
+def explain(candle_idx: int, series: dict, cfg: dict) -> dict:
+    close = series["close"]
+    M = cfg.get("M", 20)
+    hh_lookback = cfg.get("hh_lookback", 5)
+    hh_min = cfg.get("hh_min", 3)
+
+    sma_M = sma(close, M)
+    slope_M = slope(sma_M, M)
+
+    if candle_idx >= len(close):
+        return {"decision": False, "reasons": {}}
+    sl = slope_M[candle_idx]
+    ma = sma_M[candle_idx]
+    slope_ok = not math.isnan(sl) and sl > 0
+    above_ma = not math.isnan(ma) and close[candle_idx] > ma
+    start = max(0, candle_idx - hh_lookback + 1)
+    hh = _higher_highs(close[start:candle_idx + 1], hh_lookback, hh_min)
+    decision = slope_ok and above_ma and hh
+    reasons = {"slopeM_ok": slope_ok, "above_MA": above_ma, "higher_highs": hh}
+    return {"decision": decision, "reasons": reasons}

--- a/systems/brains/chop.py
+++ b/systems/brains/chop.py
@@ -21,3 +21,22 @@ def edge_long(candle_idx: int, series: dict, cfg: dict) -> bool:
     if math.isnan(z) or math.isnan(sl):
         return False
     return z <= z_buy and sl >= 0
+
+
+def explain(candle_idx: int, series: dict, cfg: dict) -> dict:
+    close = series["close"]
+    S = cfg.get("S", 20)
+    z_buy = cfg.get("z_buy", -1.0)
+    slope_w = cfg.get("slope_w", 5)
+
+    z_S = zscore(close, S)
+    sma_slope = slope(sma(close, slope_w), slope_w)
+
+    if candle_idx >= len(close):
+        return {"decision": False, "reasons": {}}
+    z = z_S[candle_idx]
+    sl = sma_slope[candle_idx]
+    slope_ok = not math.isnan(sl) and sl >= 0
+    decision = not math.isnan(z) and z <= z_buy and slope_ok
+    reasons = {"zS": z, "slope5_ok": slope_ok}
+    return {"decision": decision, "reasons": reasons}


### PR DESCRIPTION
## Summary
- support `--coin` and `--no_write` for quick single-coin scoring
- stream progress and decision explanations in `brain_score` with full-history defaults
- document quick brain check usage in README

## Testing
- `python -m py_compile bot.py systems/brain_score.py systems/brains/bear.py systems/brains/chop.py systems/brains/bull.py`
- `python bot.py brains score --coin SOLUSDT --no_write -vvv` *(interrupted with Ctrl+C)*

------
https://chatgpt.com/codex/tasks/task_e_6898e6928eec8326ad9ce5b48debec6c