### PR TITLE
Refine bear brain and add single-brain test mode

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -2,20 +2,28 @@ from __future__ import annotations
 
 import argparse
 
-from systems import brain_score
-
-
 def main() -> None:
     parser = argparse.ArgumentParser()
-    parser.add_argument("--mode", choices=["test"], required=True)
-    parser.add_argument("--brain", choices=["bear", "chop", "bull"], required=True)
-    parser.add_argument("--tag", required=True)
+    parser.add_argument("--mode", choices=["test", "brains"], required=True)
+    parser.add_argument("--brain", choices=["bear", "chop", "bull"])
+    parser.add_argument("--tag")
     parser.add_argument("--out")
+    parser.add_argument("--coins")
+    parser.add_argument("--start")
+    parser.add_argument("--end")
+    parser.add_argument("--no_write", action="store_true")
+    parser.add_argument("--min_events", type=int)
     parser.add_argument("-v", dest="verbose", action="count", default=0)
     args = parser.parse_args()
 
     if args.mode == "test":
+        from systems import brain_score
         brain_score.run_single_brain(args)
+    elif args.mode == "brains":
+        from systems import brain_score
+        brain_score.main(args)
+    else:
+        parser.print_help()
 
 
 if __name__ == "__main__":

--- a/readme..md
+++ b/readme..md
@@ -218,16 +218,18 @@ Because each brain outputs a \*\*boolean decision\*\* given price series context
 
 
 
-### Quick Brain Check (single coin, full history, no files)
+### Quick Brain Test (single coin, full history)
 
 ```powershell
-python bot.py brains score --coin SOLUSDT --no_write -vvv
-```
+python bot.py --mode test --brain bear --tag SOLUSDT -vvv
+--brain = bear | chop | bull
 
---coin SOLUSDT → test one coin  
---no_write → print-only (no CSVs)  
--vvv → step-by-step debug; use -vv for periodic progress  
-Press Ctrl+C anytime — you’ll get a summary of Bear/Chop/Bull hit rates so far.
+--tag = coin symbol matching data\raw
+
+-vvv prints event reasons and outcomes.
+
+A progress bar stays on the bottom line. Press Ctrl+C anytime to see a partial summary.
+```
 
 \* Simulation harnesses to measure historical hit-rate.
 

--- a/settings.json
+++ b/settings.json
@@ -1,7 +1,7 @@
 {
   "brains": {
-    "bear": { "L": 50, "z_off": -1.0, "z_on_band": 0.5, "dwell": 3, "atr_cool_w": 50, "atr_cool_k": 1.0,
-               "horizons": ["24h", "72h"], "down_pct": -0.02, "up_pct": 0.02, "atr_stress": 1.2 },
+    "bear": { "L": 50, "M": 20, "z_off": -1.0, "z_on_band": 0.5, "dwell": 3, "atr_cool_w": 50, "atr_cool_k": 1.0,
+               "horizons": ["72h"], "down_pct": -0.02, "up_pct": 0.02, "atr_stress": 1.2 },
     "chop": { "S": 20, "z_buy": -1.0, "slope_w": 5, "horizons": ["7d"], "tp_up": 0.04, "sl_dn": -0.03 },
     "bull": { "M": 20, "hh_lookback": 5, "hh_min": 3, "horizons": ["10d"], "tp_up": 0.06, "sl_dn": -0.04 },
     "scoring": { "roll_N": 200, "min_events": 100, "ci": "wilson95", "pchart_target": 0.70, "pchart_z": 2,

--- a/systems/brains/bear.py
+++ b/systems/brains/bear.py
@@ -1,56 +1,59 @@
 from __future__ import annotations
 
 import math
-from typing import Dict, Tuple
+from typing import Dict
 
-from ._utils import slope, zscore
+from ._utils import slope, zscore, sma
 
 
-# track slope hysteresis per series id
+# track hysteresis per series id
 _slope_state: Dict[int, bool] = {}
 
 
-def parked(candle_idx: int, series: dict, cfg: dict) -> Tuple[bool, dict]:
-    """Determine if the bear brain should be parked.
+def parked_explain(i: int, series: dict, cfg: dict):
+    """Return bear decision and debug info without hysteresis state."""
 
-    Returns a tuple of decision and debug info including trigger reason.
-    """
+    L = int(cfg.get("L", 50))
+    M = int(cfg.get("M", 20))
     close = series["close"]
-    L = cfg.get("L", 50)
 
-    sl_arr = slope(close, L)
-    z_arr = zscore(close, L)
+    zL = zscore(close, L)[i]
+    slopeL = slope(close, L)[i]
+    slopeM = slope(close, M)[i]
+    smaM = sma(close, M)[i]
 
-    if candle_idx >= len(close):
-        return False, {"slopeL": math.nan, "zL": math.nan, "reason": None}
+    cond_z = zL <= -1.5
+    cond_trend = slopeM <= 0
+    cond_ma = close[i] < smaM
 
-    sl = sl_arr[candle_idx]
-    z = z_arr[candle_idx]
-    if math.isnan(sl) or math.isnan(z):
-        return False, {"slopeL": sl, "zL": z, "reason": None}
+    decision = bool(cond_z and cond_trend and cond_ma)
+    reason = "zscore+trend+ma" if decision else None
+    return decision, {
+        "zL": zL,
+        "slopeL": slopeL,
+        "slopeM": slopeM,
+        "above_M": int(close[i] >= smaM),
+        "reason": reason,
+    }
 
-    key = id(close)
-    slope_triggered = _slope_state.get(key, False)
-    reasons = []
 
-    z_hit = z <= -1.0
-    if z_hit:
-        reasons.append("zscore")
+def parked(i: int, series: dict, cfg: dict) -> bool:
+    """Return True when bear brain is parked using hysteresis."""
 
-    if sl <= -0.05 and not slope_triggered:
-        slope_triggered = True
-        reasons.append("slope")
-    elif slope_triggered and sl >= 0.05:
-        slope_triggered = False
-    _slope_state[key] = slope_triggered
-
-    if reasons:
-        reason = "both" if len(reasons) == 2 else reasons[0]
-        return True, {"slopeL": sl, "zL": z, "reason": reason}
-    return False, {"slopeL": sl, "zL": z, "reason": None}
+    dec, info = parked_explain(i, series, cfg)
+    key = id(series["close"])
+    if dec:
+        _slope_state[key] = True
+        return True
+    if _slope_state.get(key, False):
+        if info["slopeL"] >= 0.05 and abs(info["zL"]) <= 0.5:
+            _slope_state[key] = False
+            return False
+        return True
+    return False
 
 
 def explain(candle_idx: int, series: dict, cfg: dict) -> dict:
-    decision, info = parked(candle_idx, series, cfg)
-    return {"decision": decision, "reasons": info}
+    decision, reasons = parked_explain(candle_idx, series, cfg)
+    return {"decision": decision, "reasons": reasons}
 


### PR DESCRIPTION
## Summary
- Tighten bear brain with z-score, trend, and MA filters, plus hysteresis-based resume
- Adjust scoring to use bearish baseline and enforce event spacing
- Add sticky-progress single-brain test mode and streamlined CLI

## Testing
- `python bot.py --mode test --brain bear --tag SOLUSDT -vvv`
- `python bot.py --mode test --brain chop --tag SOLUSDT -vvv`
- `python bot.py --mode test --brain bull --tag SOLUSDT -vvv`
- `python bot.py --mode brains --coins SOLUSDT --start 2023-01-01 --end 2025-08-01 -vv`


------
https://chatgpt.com/codex/tasks/task_e_6898efad4f848326b964a10c46193288