### PR TITLE
Add market data fetcher and loader utilities

### DIFF
--- a/fetch.py
+++ b/fetch.py
@@ -1,0 +1,48 @@
+import argparse
+import json
+from pathlib import Path
+
+from systems.scripts.fetch_core import build_wallet_cache, fetch_full_history, fetch_update_history
+
+
+def _load_ledger(name: str):
+    path = Path("data/ledgers") / f"{name}.json"
+    if not path.exists():
+        raise FileNotFoundError(f"ledger not found: {path}")
+    with open(path, "r", encoding="utf-8") as fh:
+        data = json.load(fh)
+    if isinstance(data, dict):
+        return list(data.items())
+    coins = []
+    for entry in data:
+        symbol = entry.get("symbol")
+        fiat = entry.get("fiat")
+        if symbol and fiat:
+            coins.append((symbol, fiat))
+    return coins
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Unified market data fetch commands")
+    parser.add_argument("--ledger", help="Ledger name for coin list")
+    parser.add_argument("--full", action="store_true", help="Fetch full Binance history")
+    parser.add_argument("--update", action="store_true", help="Append recent Kraken candles")
+    parser.add_argument("--wallet_cache", action="store_true", help="Update wallet cache files")
+    args = parser.parse_args()
+
+    if args.wallet_cache:
+        build_wallet_cache()
+
+    if args.full or args.update:
+        if not args.ledger:
+            parser.error("--ledger is required for full or update fetch")
+        coins = _load_ledger(args.ledger)
+        for symbol, fiat in coins:
+            if args.full:
+                fetch_full_history(symbol, fiat)
+            if args.update:
+                fetch_update_history(symbol, fiat)
+
+
+if __name__ == "__main__":
+    main()

--- a/systems/scripts/data_loader.py
+++ b/systems/scripts/data_loader.py
@@ -1,0 +1,54 @@
+import os
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pandas as pd
+
+DATA_RAW = Path("data/raw")
+
+_UNITS = {"d": 86400, "w": 604800, "m": 2592000, "y": 31536000}
+
+
+def _parse_timespan(expr: str) -> int:
+    """Return span in seconds from shorthand like '1d', '2w', '3m', '4y'."""
+    if expr is None:
+        return 0
+    m = re.fullmatch(r"(\d+)([dwmy])", expr.strip())
+    if not m:
+        raise ValueError(f"invalid timespan: {expr}")
+    value, unit = m.groups()
+    return int(value) * _UNITS[unit]
+
+
+def load_candle_history(symbol: str, start: str | None = None, range: str | None = None) -> pd.DataFrame:
+    """Load historical candles from Parquet and apply optional windowing."""
+    path = DATA_RAW / f"{symbol.upper()}.parquet"
+    if not path.exists():
+        raise FileNotFoundError(f"history not found for {symbol}")
+
+    df = pd.read_parquet(path)
+    if df.empty:
+        return df
+
+    df.sort_values("timestamp", inplace=True)
+    now = int(datetime.now(timezone.utc).timestamp())
+
+    start_ts = df["timestamp"].min()
+    if start:
+        start_ts = now - _parse_timespan(start)
+
+    end_ts = df["timestamp"].max()
+    if range:
+        end_ts = start_ts + _parse_timespan(range)
+
+    window = df[(df["timestamp"] >= start_ts) & (df["timestamp"] <= end_ts)]
+    return window.reset_index(drop=True)
+
+
+def merge_live_updates(df: pd.DataFrame, live_df: pd.DataFrame) -> pd.DataFrame:
+    """Append live candles to history, returning a sorted de-duplicated frame."""
+    combined = pd.concat([df, live_df], ignore_index=True)
+    combined.drop_duplicates(subset="timestamp", keep="last", inplace=True)
+    combined.sort_values("timestamp", inplace=True)
+    return combined.reset_index(drop=True)

--- a/systems/scripts/fetch_core.py
+++ b/systems/scripts/fetch_core.py
@@ -1,0 +1,102 @@
+import json
+import os
+import time
+from pathlib import Path
+from typing import Dict
+
+import ccxt
+import pandas as pd
+
+DATA_RAW = Path("data/raw")
+DATA_META = Path("data/meta")
+
+
+def _load_market_cache(name: str) -> Dict[str, dict]:
+    """Load cached market info for an exchange."""
+    path = DATA_META / f"{name}_pairs.json"
+    if not path.exists():
+        raise FileNotFoundError(f"wallet cache missing: {path}")
+    with open(path, "r", encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def _resolve_pair(cache: Dict[str, dict], symbol: str, fiat: str) -> str:
+    """Return exchange pair for symbol/fiat from cached markets."""
+    symbol = symbol.upper()
+    fiat = fiat.upper()
+    for pair in cache.keys():
+        try:
+            base, quote = pair.split("/")
+        except ValueError:
+            continue
+        if base == symbol and quote == fiat:
+            return pair
+    raise ValueError(f"pair for {symbol}/{fiat} not found in wallet cache")
+
+
+def fetch_full_history(symbol: str, fiat: str) -> None:
+    """Fetch full 1h candle history from Binance and store to Parquet."""
+    markets = _load_market_cache("binance")
+    pair = _resolve_pair(markets, symbol, fiat)
+    exchange = ccxt.binance({"enableRateLimit": True})
+
+    since = None
+    all_candles = []
+    while True:
+        candles = exchange.fetch_ohlcv(pair, timeframe="1h", since=since, limit=1000)
+        if not candles:
+            break
+        all_candles.extend(candles)
+        since = candles[-1][0] + 3600_000
+        time.sleep(exchange.rateLimit / 1000)
+
+    df = pd.DataFrame(all_candles, columns=["timestamp", "open", "high", "low", "close", "volume"])
+    df["timestamp"] = df["timestamp"] // 1000
+    df.sort_values("timestamp", inplace=True)
+
+    DATA_RAW.mkdir(parents=True, exist_ok=True)
+    df.to_parquet(DATA_RAW / f"{symbol.upper()}.parquet", index=False)
+
+
+def fetch_update_history(symbol: str, fiat: str) -> None:
+    """Append recent 1h candles from Kraken to existing history."""
+    path = DATA_RAW / f"{symbol.upper()}.parquet"
+    if not path.exists():
+        fetch_full_history(symbol, fiat)
+        return
+
+    existing = pd.read_parquet(path)
+    last_ts = int(existing["timestamp"].max()) if not existing.empty else 0
+
+    markets = _load_market_cache("kraken")
+    pair = _resolve_pair(markets, symbol, fiat)
+    exchange = ccxt.kraken({"enableRateLimit": True})
+    candles = exchange.fetch_ohlcv(pair, timeframe="1h", limit=120)
+    update = pd.DataFrame(candles, columns=["timestamp", "open", "high", "low", "close", "volume"])
+    update["timestamp"] = update["timestamp"] // 1000
+
+    if last_ts and update["timestamp"].min() - last_ts > 120 * 3600:
+        fetch_full_history(symbol, fiat)
+        return
+
+    combined = pd.concat([existing, update], ignore_index=True)
+    combined.drop_duplicates(subset="timestamp", keep="last", inplace=True)
+    combined.sort_values("timestamp", inplace=True)
+    combined.to_parquet(path, index=False)
+
+
+def build_wallet_cache() -> None:
+    """Fetch market metadata from Binance and Kraken and cache locally."""
+    DATA_META.mkdir(parents=True, exist_ok=True)
+
+    binance = ccxt.binance({"enableRateLimit": True})
+    kraken = ccxt.kraken({"enableRateLimit": True})
+
+    binance_markets = binance.load_markets()
+    kraken_markets = kraken.load_markets()
+
+    with open(DATA_META / "binance_pairs.json", "w", encoding="utf-8") as fh:
+        json.dump(binance_markets, fh, indent=2)
+
+    with open(DATA_META / "kraken_pairs.json", "w", encoding="utf-8") as fh:
+        json.dump(kraken_markets, fh, indent=2)


### PR DESCRIPTION
## Summary
- add core functions to pull full or incremental candle history and build wallet cache
- introduce unified CLI for fetching market data and caching exchange metadata
- provide data loader helpers to slice history and merge live updates

## Testing
- `python fetch.py --ledger GoatLedger --full` *(fails: No module named 'ccxt')*
- `python fetch.py --ledger GoatLedger --update` *(fails: No module named 'ccxt')*
- `python fetch.py --wallet_cache` *(fails: No module named 'ccxt')*
- `python -c "from systems.scripts.data_loader import load_candle_history; print(load_candle_history('SOL', start='1y', range='3m'))"` *(fails: No module named 'pandas')*


------
https://chatgpt.com/codex/tasks/task_e_68992d2a14348326b16ee501fe9a6e10