### PR TITLE
Add verbose debug logging for tunnel buy/sell decisions

### DIFF
--- a/systems/scripts/tunnel_manager.py
+++ b/systems/scripts/tunnel_manager.py
@@ -29,10 +29,12 @@ class TunnelManager:
         """Process one tick of prices. Returns logs of actions."""
         actions: Dict[str, List[str]] = {sym: [] for sym in prices.keys()}
 
+        debug_mode = logger.isEnabledFor(logging.DEBUG)
+
         # Update windows first with optional summaries
         for symbol, price in prices.items():
             for tunnel_id, tunnel in self.tunnels.get(symbol, {}).items():
-                tunnel.update_window(price)
+                tunnel.update_window(price, debug=debug_mode)
                 if logger.isEnabledFor(logging.INFO):
                     pos = tunnel.current_position
                     pos_str = f"{pos:.3f}" if pos is not None else "nan"
@@ -40,8 +42,6 @@ class TunnelManager:
                         f"[TICK] {symbol}/{tunnel_id} pos={pos_str} buy_trig={tunnel.buy_trigger_position:.3f} "
                         f"maturity_mult={tunnel.sell_maturity_multiplier:.3f} can_buy={tunnel.can_buy}"
                     )
-
-        debug_mode = logger.isEnabledFor(logging.DEBUG)
 
         # Handle sells first to free capital
         for symbol, price in prices.items():


### PR DESCRIPTION
## Summary
- Add granular -vvv debug logs in tunnel buy and sell checks, including position, triggers, ROI, WTF multiplier, and skip reasons
- Log cooldown unlock events and forward debug flag through TunnelManager

## Testing
- `python bot.py --mode sim --ledger GoatLedger --start 1y --range 6m -vvv` *(fails: history not found for SOL)*
- `python bot.py --mode sim --ledger GoatLedger --start 1y --range 6m -v` *(fails: history not found for SOL)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689942fdc3748326afdcf84c3851b915