### PR TITLE
feat: add tunnel debug logging

### DIFF
--- a/systems/scripts/logger.py
+++ b/systems/scripts/logger.py
@@ -1,4 +1,12 @@
 import logging
 
-# Shared logger for the WindowSurfer system
-logger = logging.getLogger()
+logger = logging.getLogger("WindowSurfer")
+
+if not logger.handlers:
+    handler = logging.StreamHandler()
+    handler.setFormatter(logging.Formatter("[%(levelname)s] %(message)s"))
+    logger.addHandler(handler)
+
+# Allow bot.py verbosity setup to override this
+logger.setLevel(logging.DEBUG)
+logger.propagate = False


### PR DESCRIPTION
## Summary
- configure dedicated WindowSurfer logger with stream handler and DEBUG level
- add verbose debug logs for tunnel buy and sell checks

## Testing
- `python -m py_compile systems/scripts/logger.py systems/scripts/tunnel.py`
- `python bot.py --mode sim --ledger GoatLedger --start 1y --range 6m -vvv` *(fails: FileNotFoundError: history not found for SOL)*

------
https://chatgpt.com/codex/tasks/task_e_6899457d415c83269759c7d714c0cf0c