### PR TITLE
Tag window context in trade evaluation

### DIFF
--- a/systems/live_engine.py
+++ b/systems/live_engine.py
@@ -10,8 +10,8 @@ from tqdm import tqdm
 
 from systems.scripts.fetch_canles import fetch_candles
 from systems.scripts.ledger import Ledger, save_ledger
-from systems.scripts.evaluate_buy import evaluate_buy_signal
-from systems.scripts.evaluate_sell import evaluate_sell_actions
+from systems.scripts.evaluate_buy import evaluate_buy
+from systems.scripts.evaluate_sell import evaluate_sell
 from systems.utils.addlog import addlog
 from systems.utils.config import load_settings
 
@@ -19,7 +19,7 @@ from systems.utils.config import load_settings
 def _run_iteration(settings, runtime_states, *, dry: bool, verbose: int) -> None:
     for name, ledger_cfg in settings.get("ledger_settings", {}).items():
         tag = ledger_cfg.get("tag", "").upper()
-        cfg = next(iter(ledger_cfg.get("window_settings", {}).values()))
+        window_settings = ledger_cfg.get("window_settings", {})
         try:
             df = fetch_candles(tag)
         except FileNotFoundError:
@@ -37,45 +37,67 @@ def _run_iteration(settings, runtime_states, *, dry: bool, verbose: int) -> None
             name,
             {
                 "capital": float(settings.get("simulation_capital", 0.0)),
-                "buy_unlock_p": None,
+                "buy_unlock_p": {},
                 "verbose": verbose,
             },
         )
 
-        ctx = {"ledger": ledger_obj}
         price = float(df.iloc[t]["close"])
-        buy_res = evaluate_buy_signal(ctx, t, df, cfg, state)
-        if buy_res:
-            size_usd = buy_res["size_usd"]
-            note_meta = buy_res["note"]
-            amount = size_usd / price if price else 0.0
-            note = {
-                "id": f"{name}-{t}",
-                "window": "default",
-                "entry_idx": t,
-                "entry_price": price,
-                "entry_usdt": size_usd,
-                "entry_amount": amount,
-                **note_meta,
-            }
-            ledger_obj.open_note(note)
-            state["capital"] -= size_usd
-            state["buy_unlock_p"] = note_meta["unlock_p"]
-
-        open_notes = ledger_obj.get_open_notes()
-        sell_notes = evaluate_sell_actions(ctx, t, df, cfg, open_notes, state)
-        sell_notes = sell_notes[: cfg.get("max_notes_sell_per_candle", 1)]
-        for note in sell_notes:
-            exit_usdt = note["entry_amount"] * price
-            note["exit_idx"] = t
-            note["exit_price"] = price
-            note["exit_usdt"] = exit_usdt
-            note["gain"] = exit_usdt - note["entry_usdt"]
-            note["gain_pct"] = (
-                note["gain"] / note["entry_usdt"] if note["entry_usdt"] else 0.0
+        for window_name, wcfg in window_settings.items():
+            ctx = {"ledger": ledger_obj}
+            buy_res = evaluate_buy(
+                ctx,
+                t,
+                df,
+                window_name=window_name,
+                cfg=wcfg,
+                runtime_state=state,
             )
-            ledger_obj.close_note(note)
-            state["capital"] += exit_usdt
+            if buy_res:
+                size_usd = buy_res["size_usd"]
+                amount = size_usd / price if price else 0.0
+                note = {
+                    "id": f"{name}-{window_name}-{t}",
+                    "entry_idx": t,
+                    "entry_price": price,
+                    "entry_usdt": size_usd,
+                    "entry_amount": amount,
+                    "window_name": buy_res["window_name"],
+                    "window_size": buy_res["window_size"],
+                    "p_buy": buy_res["p_buy"],
+                    "target_price": buy_res["target_price"],
+                    "target_roi": buy_res["target_roi"],
+                    "unlock_p": buy_res["unlock_p"],
+                }
+                if "created_idx" in buy_res:
+                    note["created_idx"] = buy_res["created_idx"]
+                if "created_ts" in buy_res:
+                    note["created_ts"] = buy_res["created_ts"]
+                ledger_obj.open_note(note)
+                state["capital"] -= size_usd
+                state["buy_unlock_p"][window_name] = buy_res["unlock_p"]
+
+            open_notes = ledger_obj.get_open_notes()
+            sell_notes = evaluate_sell(
+                ctx,
+                t,
+                df,
+                window_name=window_name,
+                cfg=wcfg,
+                open_notes=open_notes,
+                runtime_state=state,
+            )
+            for note in sell_notes:
+                exit_usdt = note["entry_amount"] * price if price else 0.0
+                note["exit_idx"] = t
+                note["exit_price"] = price
+                note["exit_usdt"] = exit_usdt
+                note["gain"] = exit_usdt - note["entry_usdt"]
+                note["gain_pct"] = (
+                    note["gain"] / note["entry_usdt"] if note["entry_usdt"] else 0.0
+                )
+                ledger_obj.close_note(note)
+                state["capital"] += exit_usdt
 
         save_ledger(ledger_cfg["tag"], ledger_obj)
 

--- a/systems/scripts/evaluate_buy.py
+++ b/systems/scripts/evaluate_buy.py
@@ -8,28 +8,31 @@ from systems.scripts.window_utils import get_window_bounds, get_window_position
 from systems.utils.addlog import addlog
 
 
-def evaluate_buy_signal(
+def evaluate_buy(
     ctx: Dict[str, Any],
     t: int,
     series,
+    *,
+    window_name: str,
     cfg: Dict[str, Any],
     runtime_state: Dict[str, Any],
 ):
-    """Return buy sizing and note metadata when conditions are met.
+    """Return sizing and metadata for a buy signal in ``window_name``.
 
     Parameters
     ----------
     ctx:
-        Context dictionary containing at least a ``ledger`` instance and, if
-        multiple strategies are used, a ``window`` name.
+        Context dictionary containing at least a ``ledger`` instance.
     t:
         Current candle index within ``series``.
     series:
         Candle DataFrame with at least ``close``, ``low`` and ``high`` columns.
+    window_name:
+        Name of the window configuration under evaluation.
     cfg:
-        Strategy configuration.
+        Strategy configuration for ``window_name``.
     runtime_state:
-        Mutable dictionary carrying ``capital`` and ``buy_unlock_p``.
+        Mutable dictionary carrying ``capital`` and ``buy_unlock_p`` mapping.
     """
 
     ledger = ctx.get("ledger")
@@ -39,31 +42,36 @@ def evaluate_buy_signal(
     price = float(series.iloc[t]["close"])
     p = get_window_position(price, win_low, win_high)
 
-    unlock_p = runtime_state.get("buy_unlock_p")
+    unlock_map = runtime_state.setdefault("buy_unlock_p", {})
+    unlock_p = unlock_map.get(window_name)
     if unlock_p is not None:
         if p >= unlock_p:
             addlog(
-                f"[UNLOCK] p={p:.3f} >= unlock_p={unlock_p:.3f} → buys re-enabled",
+                f"[UNLOCK][{window_name} {cfg['window_size']}] p={p:.3f} >= unlock_p={unlock_p:.3f} → buys re-enabled",
                 verbose_int=2,
                 verbose_state=verbose,
             )
-            runtime_state["buy_unlock_p"] = None
+            unlock_map.pop(window_name, None)
         else:
             addlog(
-                f"[GATE] buy blocked; p={p:.3f} < unlock_p={unlock_p:.3f}",
+                f"[GATE][{window_name} {cfg['window_size']}] buy blocked; p={p:.3f} < unlock_p={unlock_p:.3f}",
                 verbose_int=2,
                 verbose_state=verbose,
             )
             return False
 
-    open_notes = ledger.get_open_notes() if ledger else []
+    open_notes = []
+    if ledger:
+        open_notes = [
+            n for n in ledger.get_open_notes() if n.get("window_name") == window_name
+        ]
     if len(open_notes) >= cfg.get("max_open_notes", 0):
         return False
 
     trigger = cfg.get("buy_trigger_position", 0.0)
     if p > trigger:
         addlog(
-            f"[SKIP] p={p:.3f} > buy_trigger={trigger:.3f}",
+            f"[SKIP][{window_name} {cfg['window_size']}] p={p:.3f} > buy_trigger={trigger:.3f}",
             verbose_int=3,
             verbose_state=verbose,
         )
@@ -73,9 +81,10 @@ def evaluate_buy_signal(
     base = cfg.get("investment_fraction", 0.0)
     mult = 1 + (1 - p) * (cfg.get("window_transform_multiplier", 1.0) - 1)
     size_usd = capital * base * mult
+    sz_pct = base * mult * 100
 
     addlog(
-        f"[BUY] p={p:.3f}, base={base*100:.2f}%, mult={mult:.2f}x → size={base*mult*100:.2f}% (cap=${size_usd:.2f})",
+        f"[BUY][{window_name} {cfg['window_size']}] p={p:.3f}, base={base*100:.2f}%, mult={mult:.2f}x → size={sz_pct:.2f}% (cap=${size_usd:.2f})",
         verbose_int=1,
         verbose_state=verbose,
     )
@@ -85,14 +94,16 @@ def evaluate_buy_signal(
     price_target = win_low + p_target * (win_high - win_low)
     roi_target = (price_target - price) / price if price else 0.0
 
-    note_meta = {
+    result = {
+        "size_usd": size_usd,
+        "window_name": window_name,
+        "window_size": cfg["window_size"],
         "p_buy": p,
-        "unlock_p": unlock_p,
         "target_price": price_target,
         "target_roi": roi_target,
-        "created_idx": t,
+        "unlock_p": unlock_p,
     }
     if "timestamp" in series.columns:
-        note_meta["created_ts"] = int(series.iloc[t]["timestamp"])
-
-    return {"size_usd": size_usd, "note": note_meta}
+        result["created_ts"] = int(series.iloc[t]["timestamp"])
+    result["created_idx"] = t
+    return result

--- a/systems/scripts/ledger.py
+++ b/systems/scripts/ledger.py
@@ -26,6 +26,8 @@ class Ledger:
         ``unlock_p``         – bounce threshold to re-enable buys
         ``target_price``     – price at which the note should be sold
         ``target_roi``       – expected ROI at target price
+        ``window_name``      – name of the window configuration
+        ``window_size``      – size of the evaluation window
         ``created_idx/ts``   – creation index or timestamp
 
         These fields are stored verbatim and are not interpreted by the

--- a/systems/sim_engine.py
+++ b/systems/sim_engine.py
@@ -8,8 +8,8 @@ from tqdm import tqdm
 
 from systems.scripts.fetch_canles import fetch_candles
 from systems.scripts.ledger import Ledger, save_ledger
-from systems.scripts.evaluate_buy import evaluate_buy_signal
-from systems.scripts.evaluate_sell import evaluate_sell_actions
+from systems.scripts.evaluate_buy import evaluate_buy
+from systems.scripts.evaluate_sell import evaluate_sell
 from systems.utils.addlog import addlog
 from systems.utils.config import load_settings, load_ledger_config, resolve_path
 
@@ -18,14 +18,14 @@ def run_simulation(*, ledger: str, verbose: int = 0) -> None:
     settings = load_settings()
     ledger_cfg = load_ledger_config(ledger)
     tag = ledger_cfg.get("tag", "").upper()
-    cfg = next(iter(ledger_cfg.get("window_settings", {}).values()))
+    window_settings = ledger_cfg.get("window_settings", {})
 
     df = fetch_candles(tag)
     total = len(df)
 
     runtime_state = {
         "capital": float(settings.get("simulation_capital", 0.0)),
-        "buy_unlock_p": None,
+        "buy_unlock_p": {},
         "verbose": verbose,
     }
 
@@ -35,39 +35,61 @@ def run_simulation(*, ledger: str, verbose: int = 0) -> None:
     for t in tqdm(range(total), desc="📉 Sim Progress", dynamic_ncols=True):
         price = float(df.iloc[t]["close"])
 
-        ctx = {"ledger": ledger_obj}
-        buy_res = evaluate_buy_signal(ctx, t, df, cfg, runtime_state)
-        if buy_res:
-            size_usd = buy_res["size_usd"]
-            note_meta = buy_res["note"]
-            amount = size_usd / price if price else 0.0
-            note = {
-                "id": str(t),
-                "window": "default",
-                "entry_idx": t,
-                "entry_price": price,
-                "entry_usdt": size_usd,
-                "entry_amount": amount,
-                **note_meta,
-            }
-            ledger_obj.open_note(note)
-            runtime_state["capital"] -= size_usd
-            runtime_state["buy_unlock_p"] = note_meta["unlock_p"]
-
-        open_notes = ledger_obj.get_open_notes()
-        sell_notes = evaluate_sell_actions(ctx, t, df, cfg, open_notes, runtime_state)
-        sell_notes = sell_notes[: cfg.get("max_notes_sell_per_candle", 1)]
-        for note in sell_notes:
-            exit_usdt = note["entry_amount"] * price
-            note["exit_idx"] = t
-            note["exit_price"] = price
-            note["exit_usdt"] = exit_usdt
-            note["gain"] = exit_usdt - note["entry_usdt"]
-            note["gain_pct"] = (
-                note["gain"] / note["entry_usdt"] if note["entry_usdt"] else 0.0
+        for window_name, wcfg in window_settings.items():
+            ctx = {"ledger": ledger_obj}
+            buy_res = evaluate_buy(
+                ctx,
+                t,
+                df,
+                window_name=window_name,
+                cfg=wcfg,
+                runtime_state=runtime_state,
             )
-            ledger_obj.close_note(note)
-            runtime_state["capital"] += exit_usdt
+            if buy_res:
+                size_usd = buy_res["size_usd"]
+                amount = size_usd / price if price else 0.0
+                note = {
+                    "id": f"{window_name}-{t}",
+                    "entry_idx": t,
+                    "entry_price": price,
+                    "entry_usdt": size_usd,
+                    "entry_amount": amount,
+                    "window_name": buy_res["window_name"],
+                    "window_size": buy_res["window_size"],
+                    "p_buy": buy_res["p_buy"],
+                    "target_price": buy_res["target_price"],
+                    "target_roi": buy_res["target_roi"],
+                    "unlock_p": buy_res["unlock_p"],
+                }
+                if "created_idx" in buy_res:
+                    note["created_idx"] = buy_res["created_idx"]
+                if "created_ts" in buy_res:
+                    note["created_ts"] = buy_res["created_ts"]
+                ledger_obj.open_note(note)
+                runtime_state["capital"] -= size_usd
+                runtime_state["buy_unlock_p"][window_name] = buy_res["unlock_p"]
+
+            open_notes = ledger_obj.get_open_notes()
+            sell_notes = evaluate_sell(
+                ctx,
+                t,
+                df,
+                window_name=window_name,
+                cfg=wcfg,
+                open_notes=open_notes,
+                runtime_state=runtime_state,
+            )
+            for note in sell_notes:
+                exit_usdt = note["entry_amount"] * price if price else 0.0
+                note["exit_idx"] = t
+                note["exit_price"] = price
+                note["exit_usdt"] = exit_usdt
+                note["gain"] = exit_usdt - note["entry_usdt"]
+                note["gain_pct"] = (
+                    note["gain"] / note["entry_usdt"] if note["entry_usdt"] else 0.0
+                )
+                ledger_obj.close_note(note)
+                runtime_state["capital"] += exit_usdt
 
     final_price = float(df.iloc[-1]["close"]) if total else 0.0
     summary = ledger_obj.get_account_summary(final_price)


### PR DESCRIPTION
## Summary
- Track window name and size for buy and sell evaluations
- Restrict sells to matching window notes and prioritize by ROI
- Warn on duplicate window names in config

## Testing
- `python -m py_compile systems/scripts/evaluate_buy.py systems/scripts/evaluate_sell.py systems/sim_engine.py systems/live_engine.py systems/scripts/ledger.py systems/utils/config.py`
- `python - <<'PY'
from systems.utils.config import load_settings
load_settings(reload=True)
print('loaded settings ok')
PY`

------
https://chatgpt.com/codex/tasks/task_e_689956e00c048326aaba0614199afb20