### PR TITLE
Enforce 720-candle refresh policy for historical fetches

### DIFF
--- a/systems/fetch.py
+++ b/systems/fetch.py
@@ -6,11 +6,14 @@ from datetime import datetime, timezone
 from typing import Optional
 
 from systems.utils.cli import build_parser
-from systems.utils.config import load_settings
+from systems.utils.config import load_settings, resolve_path
 from systems.scripts.fetch_core import (
     FetchAbort,
-    get_gapless_1h_for_span,
+    _fetch_binance,
+    _fetch_kraken,
+    canonicalize,
     get_raw_path,
+    reindex_hourly,
 )
 
 
@@ -51,33 +54,68 @@ def main(argv: Optional[list[str]] = None) -> None:
     ledger_name = args.ledger or "default"
     ledgers = settings.get("ledger_settings", {})
     cfg = ledgers.get(ledger_name, ledgers.get("default", {}))
+    tag = cfg.get("tag")
     binance_symbol = cfg.get("binance_name")
     kraken_symbol = cfg.get("kraken_name")
-
-    print(
-        f"[FETCH] ledger={ledger_name} time={args.time} "
-        f"binance={binance_symbol} kraken={kraken_symbol}"
-    )
 
     candles = parse_time_to_candles(args.time)
     now_ms = int(datetime.now(tz=timezone.utc).timestamp() * 1000)
     end_ms = floor_to_top_of_hour(now_ms)
     start_ms = end_ms - candles * 3_600_000
 
-    try:
-        df = get_gapless_1h_for_span(cfg, start_ms, end_ms)
-    except FetchAbort as exc:
-        print(f"[ABORT][FETCH] {exc}")
-        return
-
-    out_path = get_raw_path(cfg["tag"].upper())
-    df.to_parquet(out_path, index=False)
-
     start_iso = datetime.fromtimestamp(start_ms / 1000, tz=timezone.utc).isoformat()
     end_iso = datetime.fromtimestamp(end_ms / 1000, tz=timezone.utc).isoformat()
+
     print(
-        f"[FETCH] gapless \u2713 rows={len(df)} span=[{start_iso}, {end_iso}]"
+        f"[FETCH] ledger={ledger_name} time={args.time} candles={candles} "
+        f"binance={binance_symbol} kraken={kraken_symbol} range={start_iso}→{end_iso}"
     )
+
+    out_path = get_raw_path(tag)
+    root = resolve_path("")
+    print(f"[FETCH][PATH] root={root} out={out_path}")
+
+    try:
+        if candles > 720:
+            if out_path.exists():
+                print(f"[REFRESH] deleting cache at {out_path}")
+                out_path.unlink()
+            df_b = _fetch_binance(binance_symbol, start_ms, end_ms)
+            df_b = canonicalize(df_b)
+            if df_b.empty:
+                raise FetchAbort(
+                    f"Binance returned 0 candles for span. symbol={binance_symbol} "
+                    f"range={start_iso}→{end_iso}"
+                )
+            df_full, gaps = reindex_hourly(df_b, start_ms, end_ms)
+            if gaps:
+                raise FetchAbort(
+                    f"Full refresh not gapless. symbol={binance_symbol} gaps={gaps} "
+                    "(Policy: >720 → no healing. Use a symbol with full history or shorten --time.)"
+                )
+        else:
+            df_k = _fetch_kraken(kraken_symbol, start_ms, end_ms)
+            df_k = canonicalize(df_k)
+            df_full, gaps = reindex_hourly(df_k, start_ms, end_ms)
+            if gaps:
+                print(f"[HEAL][≤720] gaps={len(gaps)} via Binance (same span)")
+                df_b = _fetch_binance(binance_symbol, start_ms, end_ms)
+                df_b = canonicalize(df_b)
+                df_full_idx = df_full.set_index("ts")
+                df_b_idx = df_b.set_index("ts")
+                df_full = df_full_idx.combine_first(df_b_idx).reset_index()
+                df_full, gaps = reindex_hourly(df_full, start_ms, end_ms)
+                if gaps:
+                    raise FetchAbort(
+                        "Unhealable gaps in ≤720 span. symbols: "
+                        f"kraken={kraken_symbol} binance={binance_symbol} details={gaps}"
+                    )
+        df_full.to_parquet(out_path, index=False)
+        print(
+            f"[FETCH] gapless \u2713 rows={len(df_full)} span={start_iso}→{end_iso}"
+        )
+    except FetchAbort as exc:
+        print(f"[ABORT][FETCH] {exc}")
 
 
 if __name__ == "__main__":

--- a/systems/scripts/fetch_core.py
+++ b/systems/scripts/fetch_core.py
@@ -10,7 +10,8 @@ import pandas as pd
 
 from systems.utils.config import resolve_path
 
-COLUMNS = ["timestamp", "open", "high", "low", "close", "volume"]
+# Canonical column order for 1h OHLCV dataframes.
+COLUMNS = ["ts", "open", "high", "low", "close", "volume"]
 
 
 class FetchAbort(RuntimeError):
@@ -22,26 +23,38 @@ class FetchAbort(RuntimeError):
 # ---------------------------------------------------------------------------
 
 def _fetch_kraken(symbol: str, start_ms: int, end_ms: int) -> pd.DataFrame:
+    """Return raw Kraken candles in the requested span.
+
+    The caller is responsible for canonicalising the dataframe. When no data
+    is available an empty dataframe is returned instead of raising.
+    """
+
     exchange = ccxt.kraken({"enableRateLimit": True})
     limit = min(720, int((end_ms - start_ms) // 3_600_000))
-    ohlcv = exchange.fetch_ohlcv(symbol, timeframe="1h", since=start_ms, limit=limit)
+    try:
+        ohlcv = exchange.fetch_ohlcv(symbol, timeframe="1h", since=start_ms, limit=limit)
+    except Exception:
+        ohlcv = []
     rows = [row for row in ohlcv if row and start_ms <= row[0] < end_ms]
-    df = pd.DataFrame(rows, columns=COLUMNS)
-    df = canonicalize(df)
-    if df.empty:
-        raise FetchAbort(
-            f"0 candles returned symbol={symbol} span=[{start_ms},{end_ms}]"
-        )
-    return df
+    return pd.DataFrame(rows, columns=COLUMNS)
 
 
 def _fetch_binance(symbol: str, start_ms: int, end_ms: int) -> pd.DataFrame:
+    """Return raw Binance candles in the requested span.
+
+    Fetches data in 1000 row chunks. An empty dataframe is returned when no
+    data is available; the caller must handle such cases gracefully.
+    """
+
     exchange = ccxt.binance({"enableRateLimit": True})
     limit = 1_000
     rows: List[List] = []
     current = start_ms
     while current < end_ms:
-        chunk = exchange.fetch_ohlcv(symbol, timeframe="1h", since=current, limit=limit)
+        try:
+            chunk = exchange.fetch_ohlcv(symbol, timeframe="1h", since=current, limit=limit)
+        except Exception:
+            chunk = []
         if not chunk:
             break
         filtered = [r for r in chunk if r and current <= r[0] < end_ms]
@@ -50,26 +63,7 @@ def _fetch_binance(symbol: str, start_ms: int, end_ms: int) -> pd.DataFrame:
         rows.extend(filtered)
         last = filtered[-1][0]
         current = last + 3_600_000
-    df = pd.DataFrame(rows, columns=COLUMNS)
-    df = canonicalize(df)
-    if df.empty:
-        try:
-            recent = exchange.fetch_ohlcv(symbol, timeframe="1h", limit=1)
-            if recent:
-                first_ts = recent[0][0]
-                if first_ts > start_ms:
-                    pass  # listing is newer than requested span
-        except Exception:
-            pass
-        if symbol.upper().endswith("USDC"):
-            print(
-                f"[HINT] Binance {symbol} may have limited history. "
-                "Try SOLUSDT or reduce --time ≤ 720 to use Kraken."
-            )
-        raise FetchAbort(
-            f"0 candles returned symbol={symbol} span=[{start_ms},{end_ms}]"
-        )
-    return df
+    return pd.DataFrame(rows, columns=COLUMNS)
 
 
 # ---------------------------------------------------------------------------
@@ -78,12 +72,13 @@ def _fetch_binance(symbol: str, start_ms: int, end_ms: int) -> pd.DataFrame:
 
 def canonicalize(df: pd.DataFrame) -> pd.DataFrame:
     """Ensure canonical columns and hourly UTC timestamps in ms."""
+
     if df.empty:
         return pd.DataFrame(columns=COLUMNS)
     df = df.copy()
     df.columns = COLUMNS
-    df["timestamp"] = (df["timestamp"].astype("int64") // 3_600_000) * 3_600_000
-    df = df.drop_duplicates(subset="timestamp").sort_values("timestamp")
+    df["ts"] = (df["ts"].astype("int64") // 3_600_000) * 3_600_000
+    df = df.drop_duplicates(subset="ts").sort_values("ts")
     return df.reset_index(drop=True)
 
 
@@ -103,26 +98,27 @@ def reindex_hourly(
     df: pd.DataFrame, start_ms: int, end_ms: int
 ) -> Tuple[pd.DataFrame, List[Tuple[int, int, int]]]:
     """Reindex ``df`` to an hourly grid and return gaps."""
+
     idx = range(start_ms, end_ms, 3_600_000)
     if df.empty:
-        full = pd.DataFrame(index=idx, columns=COLUMNS)
-        full.index.name = "timestamp"
+        full = pd.DataFrame(index=idx, columns=COLUMNS[1:])
+        full.index.name = "ts"
         full = full.reset_index()
         gap_end = end_ms - 3_600_000 if end_ms > start_ms else start_ms
         gaps = [(start_ms, gap_end, len(idx))] if len(idx) else []
         return full, gaps
 
-    df = df.set_index("timestamp").reindex(idx)
-    df.index.name = "timestamp"
+    df = df.set_index("ts").reindex(idx)
+    df.index.name = "ts"
     full = df.reset_index()
     gaps = []
     i = 0
     while i < len(full):
         if pd.isna(full.loc[i, "open"]):
-            gap_start = full.loc[i, "timestamp"]
+            gap_start = full.loc[i, "ts"]
             while i < len(full) and pd.isna(full.loc[i, "open"]):
                 i += 1
-            gap_end = full.loc[i - 1, "timestamp"]
+            gap_end = full.loc[i - 1, "ts"]
             k = int((gap_end - gap_start) // 3_600_000 + 1)
             gaps.append((gap_start, gap_end, k))
         else:
@@ -135,59 +131,11 @@ def reindex_hourly(
 # ---------------------------------------------------------------------------
 
 def get_raw_path(tag: str) -> Path:
+    """Return the canonical raw-data path for ``tag``."""
+
     root = resolve_path("")
     raw_dir = root / "data" / "raw"
     raw_dir.mkdir(parents=True, exist_ok=True)
     return raw_dir / f"{tag}_1h.parquet"
 
 
-# ---------------------------------------------------------------------------
-# public entry
-# ---------------------------------------------------------------------------
-
-def get_gapless_1h_for_span(
-    ledger_cfg: dict, start_ms: int, end_ms: int
-) -> pd.DataFrame:
-    """Return a gapless DataFrame for the requested span applying policy A/B."""
-
-    binance_symbol = ledger_cfg["binance_name"]
-    kraken_symbol = ledger_cfg["kraken_name"]
-    candles = int((end_ms - start_ms) // 3_600_000)
-
-    if candles <= 720:
-        df_k = _fetch_kraken(kraken_symbol, start_ms, end_ms)
-        df_full, gaps = reindex_hourly(df_k, start_ms, end_ms)
-        if gaps:
-            df_b = _fetch_binance(binance_symbol, start_ms, end_ms)
-            df_merge = canonicalize(pd.concat([df_k, df_b], ignore_index=True))
-            df_full, gaps = reindex_hourly(df_merge, start_ms, end_ms)
-            if gaps:
-                raise FetchAbort(
-                    "[ABORT][FETCH] Unhealable gaps in ≤720 span (Kraken primary). "
-                    f"details={gaps}"
-                )
-        return df_full
-
-    # Policy B: >720 candles
-    df_b = _fetch_binance(binance_symbol, start_ms, end_ms)
-    df_full, gaps = reindex_hourly(df_b, start_ms, end_ms)
-    if gaps:
-        recent_threshold = end_ms - 720 * 3_600_000
-        recent = [g for g in gaps if g[1] >= recent_threshold]
-        older = [g for g in gaps if g[1] < recent_threshold]
-        if older:
-            raise FetchAbort(
-                "[ABORT][FETCH] Old gaps outside the last 720 candles. Run a full refresh or shorten --time."
-                f" details={older}"
-            )
-        df_current = df_b
-        for gstart, gend, _ in recent:
-            df_k = _fetch_kraken(kraken_symbol, gstart, gend)
-            df_current = canonicalize(pd.concat([df_current, df_k], ignore_index=True))
-        df_full, gaps = reindex_hourly(df_current, start_ms, end_ms)
-        if gaps:
-            raise FetchAbort(
-                "[ABORT][FETCH] Unhealable gaps after auto-heal. details="
-                f"{gaps}"
-            )
-    return df_full


### PR DESCRIPTION
## Summary
- Implement CLI logic that enforces the 720-candle policy: spans >720 fully refresh from Binance with no healing, spans ≤720 fetch from Kraken and heal with Binance
- Add robust fetch helpers returning empty frames for missing data and utilities for canonicalization and gap detection

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68997fd9fa1c83268946ec60b7cba2c3