### PR TITLE
Enforce capital gating and lossless trades in simulation

### DIFF
--- a/systems/scripts/evaluate_sell.py
+++ b/systems/scripts/evaluate_sell.py
@@ -33,6 +33,7 @@ def evaluate_sell(
         for n in open_notes
         if n.get("window_name") == window_name
         and price >= n.get("target_price", float("inf"))
+        and price >= n.get("entry_price", float("inf"))
     ]
 
     if not candidates:


### PR DESCRIPTION
## Summary
- Carry global min/max note limits into the simulation runtime state.
- Clamp buy sizing to available capital and max note size, skip below-minimum notes.
- Deduct capital with a safety check and prevent loss-making sells by requiring price ≥ entry price.

## Testing
- `python -m py_compile systems/sim_engine.py systems/scripts/evaluate_buy.py systems/scripts/evaluate_sell.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6899d90f4d8483268daf7a86476e9339