### PR TITLE
feat: centralize runtime state and trade application

### DIFF
--- a/systems/scripts/runtime_state.py
+++ b/systems/scripts/runtime_state.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+from systems.scripts.execution_handler import load_or_fetch_snapshot
+from systems.utils.resolve_symbol import split_tag
+
+
+def build_runtime_state(
+    settings: Dict[str, Any],
+    ledger_cfg: Dict[str, Any],
+    mode: str,
+    *,
+    prev: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    """Build and refresh runtime state for engines.
+
+    Parameters
+    ----------
+    settings:
+        Global settings dictionary.
+    ledger_cfg:
+        Ledger configuration mapping containing at least ``tag``.
+    mode:
+        Either ``"sim"`` or ``"live"``.
+    prev:
+        Previous runtime state to carry over verbose level and unlock map.
+    """
+
+    prev = prev or {}
+    general = settings.get("general_settings", {})
+    limits = {
+        "min_note_size": float(general.get("minimum_note_size", 0.0)),
+        "max_note_usdt": float(general.get("max_note_usdt", float("inf"))),
+    }
+
+    buy_unlock_p = prev.get("buy_unlock_p", {})
+    verbose = prev.get("verbose", 0)
+
+    if mode == "sim":
+        capital = float(settings.get("simulation_capital", 0.0))
+    elif mode == "live":
+        tag = ledger_cfg.get("tag", "")
+        snapshot = load_or_fetch_snapshot(tag)
+        _, quote = split_tag(tag)
+        balance = snapshot.get("balance", {})
+        capital = float(balance.get(quote, 0.0))
+    else:
+        capital = prev.get("capital", 0.0)
+
+    return {
+        "capital": capital,
+        "buy_unlock_p": buy_unlock_p,
+        "verbose": verbose,
+        "limits": limits,
+    }

--- a/systems/scripts/trade_apply.py
+++ b/systems/scripts/trade_apply.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+
+def paper_execute_buy(price: float, amount_usd: float, *, timestamp: Optional[int] = None) -> Dict[str, float | int | None]:
+    filled = amount_usd / price if price else 0.0
+    return {"filled_amount": filled, "avg_price": price, "timestamp": timestamp}
+
+
+def paper_execute_sell(price: float, coin_amount: float, *, timestamp: Optional[int] = None) -> Dict[str, float | int | None]:
+    return {"filled_amount": coin_amount, "avg_price": price, "timestamp": timestamp}
+
+
+def apply_buy_result_to_ledger(
+    *,
+    ledger,
+    window_name: str,
+    t: int,
+    meta: Dict[str, Any],
+    result: Dict[str, Any],
+    state: Dict[str, Any],
+) -> Dict[str, Any]:
+    note = {
+        "id": f"{window_name}-{t}",
+        "entry_idx": t,
+        "entry_price": result.get("avg_price", 0.0),
+        "entry_amount": result.get("filled_amount", 0.0),
+        "entry_usdt": result.get("filled_amount", 0.0) * result.get("avg_price", 0.0),
+        "window_name": meta.get("window_name"),
+        "window_size": meta.get("window_size"),
+        "p_buy": meta.get("p_buy"),
+        "target_price": meta.get("target_price"),
+        "target_roi": meta.get("target_roi"),
+        "unlock_p": meta.get("unlock_p"),
+    }
+    if "created_idx" in meta:
+        note["created_idx"] = meta["created_idx"]
+    if result.get("timestamp") is not None:
+        note["created_ts"] = result.get("timestamp")
+    elif "created_ts" in meta:
+        note["created_ts"] = meta["created_ts"]
+
+    ledger.open_note(note)
+    cost = result.get("filled_amount", 0.0) * result.get("avg_price", 0.0)
+    state["capital"] = state.get("capital", 0.0) - cost
+    state.setdefault("buy_unlock_p", {})[window_name] = meta.get("unlock_p")
+    return note
+
+
+def apply_sell_result_to_ledger(
+    *,
+    ledger,
+    note: Dict[str, Any],
+    t: int | None,
+    result: Dict[str, Any],
+    state: Dict[str, Any],
+) -> Dict[str, Any]:
+    exit_price = result.get("avg_price", 0.0)
+    exit_usdt = result.get("filled_amount", 0.0) * exit_price
+    note["exit_price"] = exit_price
+    note["exit_usdt"] = exit_usdt
+    if t is not None:
+        note["exit_idx"] = t
+    if result.get("timestamp") is not None:
+        note["exit_ts"] = result.get("timestamp")
+    entry_usdt = note.get("entry_usdt", 0.0)
+    note["gain"] = exit_usdt - entry_usdt
+    note["gain_pct"] = (note["gain"] / entry_usdt) if entry_usdt else 0.0
+    ledger.close_note(note)
+    state["capital"] = state.get("capital", 0.0) + exit_usdt
+    return note


### PR DESCRIPTION
## Summary
- add `build_runtime_state` helper to provide capital and limits from config or live balances
- introduce shared trade appliers and paper executor for uniform note handling
- refactor sim and live engines to use shared runtime state and trade appliers

## Testing
- `python -m py_compile systems/live_engine.py systems/sim_engine.py systems/scripts/runtime_state.py systems/scripts/trade_apply.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6899e57a46808326b84100fb0b3f7a4a