### PR TITLE
Use Kraken pair codes and ledger labels in hourly reports

### DIFF
--- a/systems/scripts/handle_top_of_hour.py
+++ b/systems/scripts/handle_top_of_hour.py
@@ -355,6 +355,7 @@ def handle_top_of_hour(
                 )
                 note_counts[win.title()] = (open_n, closed_n)
             report = format_top_of_hour_report(
+                ledger_name,
                 tag,
                 datetime.utcnow(),
                 usd_balance,

--- a/systems/scripts/send_top_hour_report.py
+++ b/systems/scripts/send_top_hour_report.py
@@ -53,8 +53,18 @@ def send_top_hour_report(
 
     usd_balance = float(balance.get(fiat_code, 0.0))
     coin_balance = float(balance.get(wallet_code, 0.0))
-    pair_code = tag
+    pair_code = ledger_cfg.get("kraken_pair") or tag
     price = _get_latest_price(trades, pair_code)
+    if price == 0.0:
+        alt_pair = ledger_cfg.get("kraken_name")
+        if alt_pair:
+            price = _get_latest_price(trades, alt_pair)
+        if price == 0.0:
+            addlog(
+                f"[WARN] Price for {ledger_name} {pair_code} not found; balances only",
+                verbose_int=1,
+                verbose_state=verbose,
+            )
     coin_value = coin_balance * price
     total_value = usd_balance + coin_value
 

--- a/systems/utils/top_hour_report.py
+++ b/systems/utils/top_hour_report.py
@@ -5,6 +5,7 @@ from typing import Dict, Tuple
 
 
 def format_top_of_hour_report(
+    ledger_name: str,
     symbol: str,
     ts: datetime,
     usd_balance: float,
@@ -35,6 +36,6 @@ def format_top_of_hour_report(
     hour_str = ts.strftime("%I:%M%p")
 
     return (
-        f"[My Ledger] {hour_str} | {symbol} | 💰${total_liquid_value:.2f} | "
+        f"[{ledger_name}] {hour_str} | {symbol} | 💰${total_liquid_value:.2f} | "
         f"💵${usd_balance:.2f} | 🪙${coin_balance_usd:.2f} | {trigger_str} | Notes: {notes_str}"
     )


### PR DESCRIPTION
## Summary
- Resolve trade prices using ledger-configured Kraken pair codes with optional altname fallback
- Pass actual ledger name to top-of-hour report formatter for accurate labeling
- Update top-of-hour handler to use new formatter signature

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6899e74036c08326b360d6fa8fac46c6