### PR TITLE
feat: add live smoke test and micro replay

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -20,6 +20,21 @@ def main(argv: list[str] | None = None) -> None:
             action.choices = list(action.choices) + ["fetch"]
             break
     parser.add_argument("--time", required=False, help="Time window (e.g. 120h)")
+    parser.add_argument(
+        "--smoke",
+        action="store_true",
+        help="Perform a paper buy+sell if no actions occur (dry live mode)",
+    )
+    parser.add_argument(
+        "--smoke-save",
+        action="store_true",
+        help="Persist smoke ledger to data/tmp/",
+    )
+    parser.add_argument(
+        "--replay-hours",
+        type=int,
+        help="After dry tick, replay the last N hours in sim mode",
+    )
 
     args = parser.parse_args(argv or sys.argv[1:])
     if not args.mode:
@@ -93,6 +108,9 @@ def main(argv: list[str] | None = None) -> None:
         run_live(
             dry=args.dry,
             verbose=args.verbose,
+            smoke=args.smoke,
+            smoke_save=args.smoke_save,
+            replay_hours=args.replay_hours,
         )
     elif mode == "fetch":
         if not args.ledger:

--- a/systems/live_engine.py
+++ b/systems/live_engine.py
@@ -15,11 +15,20 @@ from systems.scripts.evaluate_sell import evaluate_sell
 from systems.scripts.runtime_state import build_runtime_state
 from systems.scripts.trade_apply import apply_buy_result_to_ledger, apply_sell_result_to_ledger
 from systems.scripts.execution_handler import execute_buy, execute_sell
+from systems.scripts.smoke_test import run_smoke_test
 from systems.utils.addlog import addlog
 from systems.utils.config import load_settings
 
 
-def _run_iteration(settings, runtime_states, *, dry: bool, verbose: int) -> None:
+def _run_iteration(
+    settings,
+    runtime_states,
+    *,
+    dry: bool,
+    verbose: int,
+    smoke: bool = False,
+    smoke_save: bool = False,
+) -> None:
     for name, ledger_cfg in settings.get("ledger_settings", {}).items():
         tag = ledger_cfg.get("tag", "").upper()
         window_settings = ledger_cfg.get("window_settings", {})
@@ -46,6 +55,9 @@ def _run_iteration(settings, runtime_states, *, dry: bool, verbose: int) -> None
         runtime_states[name] = state
 
         price = float(df.iloc[t]["close"])
+        candle = df.iloc[t].to_dict()
+        did_buy = False
+        did_sell = False
         for window_name, wcfg in window_settings.items():
             ctx = {"ledger": ledger_obj}
             buy_res = evaluate_buy(
@@ -75,6 +87,7 @@ def _run_iteration(settings, runtime_states, *, dry: bool, verbose: int) -> None
                         result=result,
                         state=state,
                     )
+                    did_buy = True
 
             open_notes = ledger_obj.get_open_notes()
             sell_notes = evaluate_sell(
@@ -103,16 +116,68 @@ def _run_iteration(settings, runtime_states, *, dry: bool, verbose: int) -> None
                         result=result,
                         state=state,
                     )
+                    did_sell = True
+
+        if dry and smoke and not did_buy and not did_sell:
+            run_smoke_test(
+                ledger_name=ledger_cfg["tag"],
+                ledger_cfg=ledger_cfg,
+                settings=settings,
+                candle=candle,
+                state=state,
+                save=smoke_save,
+                verbose=verbose,
+            )
 
         save_ledger(ledger_cfg["tag"], ledger_obj)
 
 
-def run_live(*, dry: bool = False, verbose: int = 0) -> None:
+def run_live(
+    *,
+    dry: bool = False,
+    verbose: int = 0,
+    smoke: bool = False,
+    smoke_save: bool = False,
+    replay_hours: int | None = None,
+) -> None:
     settings = load_settings()
     runtime_states: Dict[str, Dict] = {}
 
     if dry:
-        _run_iteration(settings, runtime_states, dry=dry, verbose=verbose)
+        _run_iteration(
+            settings,
+            runtime_states,
+            dry=dry,
+            verbose=verbose,
+            smoke=smoke,
+            smoke_save=smoke_save,
+        )
+        if replay_hours:
+            from systems.sim_engine import run_simulation
+
+            for name, ledger_cfg in settings.get("ledger_settings", {}).items():
+                tag = ledger_cfg.get("tag", "").upper()
+                try:
+                    df = fetch_candles(tag)
+                except FileNotFoundError:
+                    continue
+                if df.empty:
+                    continue
+                end_idx = len(df) - 1
+                start_idx = max(0, end_idx - replay_hours + 1)
+                summary = run_simulation(
+                    ledger=name,
+                    verbose=0,
+                    start_idx=start_idx,
+                    end_idx=end_idx,
+                    save_ledger_file=False,
+                    progress=False,
+                )
+                addlog(
+                    f"[REPLAY][N={replay_hours}h] buys={summary['buys']} sells={summary['sells']} pnl=${summary['realized_gain']:.2f} open=${summary['open_value']:.2f}",
+                    verbose_int=1,
+                    verbose_state=verbose,
+                )
         return
 
     while True:
@@ -131,4 +196,11 @@ def run_live(*, dry: bool = False, verbose: int = 0) -> None:
                 time.sleep(1)
                 pbar.update(1)
         addlog("[LIVE] Running top of hour", verbose_int=1, verbose_state=verbose)
-        _run_iteration(settings, runtime_states, dry=dry, verbose=verbose)
+        _run_iteration(
+            settings,
+            runtime_states,
+            dry=dry,
+            verbose=verbose,
+            smoke=smoke,
+            smoke_save=smoke_save,
+        )

--- a/systems/scripts/smoke_test.py
+++ b/systems/scripts/smoke_test.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+"""Utilities to perform a live-mode smoke test using paper execution."""
+
+import json
+import time
+from typing import Dict, Any
+
+from systems.scripts.ledger import Ledger
+from systems.scripts.trade_apply import (
+    paper_execute_buy,
+    paper_execute_sell,
+    apply_buy_result_to_ledger,
+    apply_sell_result_to_ledger,
+)
+from systems.utils.addlog import addlog
+from systems.utils.config import resolve_path
+
+
+def _copy_state(state: Dict[str, Any]) -> Dict[str, Any]:
+    """Return a shallow copy of ``state`` with nested dicts copied."""
+    out: Dict[str, Any] = {}
+    for k, v in state.items():
+        if isinstance(v, dict):
+            out[k] = dict(v)
+        else:
+            out[k] = v
+    return out
+
+
+def run_smoke_test(
+    *,
+    ledger_name: str,
+    ledger_cfg: Dict[str, Any],
+    settings: Dict[str, Any],
+    candle: Dict[str, Any],
+    state: Dict[str, Any],
+    save: bool,
+    verbose: int,
+) -> Dict[str, Any]:
+    """Execute a paper buy then sell to exercise the trade pipeline."""
+
+    tmp_state = _copy_state(state)
+    limits = tmp_state.get("limits", {})
+    min_sz = float(limits.get("min_note_size", 0.0))
+    max_sz = float(limits.get("max_note_usdt", float("inf")))
+    capital = float(tmp_state.get("capital", 0.0))
+    size_usd = min(max(min_sz, min(capital, max_sz)), capital)
+    if size_usd < min_sz:
+        addlog("[SMOKE][SKIP] size < min", verbose_int=1, verbose_state=verbose)
+        return {}
+
+    price = float(candle.get("close", 0.0))
+    ts = int(candle.get("timestamp", 0)) or None
+
+    buy_res = paper_execute_buy(price, size_usd, timestamp=ts)
+    ledger = Ledger()
+    meta = {
+        "window_name": "SMOKE",
+        "window_size": 0,
+    }
+    note = apply_buy_result_to_ledger(
+        ledger=ledger,
+        window_name="SMOKE",
+        t=0,
+        meta=meta,
+        result=buy_res,
+        state=tmp_state,
+    )
+    addlog(
+        f"[SMOKE][BUY] size=${size_usd:.2f}, amount={buy_res['filled_amount']:.8f}, price=${buy_res['avg_price']:.2f}, ts={buy_res['timestamp']}",
+        verbose_int=1,
+        verbose_state=verbose,
+    )
+
+    sell_price = max(buy_res["avg_price"], price)
+    sell_res = paper_execute_sell(sell_price, buy_res["filled_amount"], timestamp=ts)
+    apply_sell_result_to_ledger(
+        ledger=ledger,
+        note=note,
+        t=1,
+        result=sell_res,
+        state=tmp_state,
+    )
+    buy_cost = buy_res["filled_amount"] * buy_res["avg_price"]
+    sell_proceeds = sell_res["filled_amount"] * sell_res["avg_price"]
+    gain = sell_proceeds - buy_cost
+    roi = (gain / buy_cost * 100.0) if buy_cost > 0 else 0.0
+    addlog(
+        f"[SMOKE][SELL] amount={sell_res['filled_amount']:.8f}, price=${sell_res['avg_price']:.2f}, gain=${gain:.2f}, roi={roi:.2f}%",
+        verbose_int=1,
+        verbose_state=verbose,
+    )
+
+    summary = ledger.get_account_summary(sell_res["avg_price"])
+    addlog(f"[SMOKE][SUMMARY] {summary}", verbose_int=1, verbose_state=verbose)
+
+    path = None
+    if save:
+        root = resolve_path("")
+        out_dir = root / "data" / "tmp"
+        out_dir.mkdir(parents=True, exist_ok=True)
+        ts_save = int(time.time())
+        out_path = out_dir / f"ledger-smoke-{ledger_name}-{ts_save}.json"
+        with out_path.open("w", encoding="utf-8") as f:
+            json.dump(
+                {
+                    "open_notes": ledger.get_open_notes(),
+                    "closed_notes": ledger.get_closed_notes(),
+                },
+                f,
+                indent=2,
+            )
+        path = str(out_path)
+
+    return {"path": path, "summary": summary}


### PR DESCRIPTION
## Summary
- add CLI flags for smoke trading and micro-replay
- integrate paper smoke trades into live engine when dry
- support bounded simulations and no-file option for replay

## Testing
- `python -m py_compile bot.py systems/live_engine.py systems/scripts/smoke_test.py systems/sim_engine.py`
- `python bot.py --mode live --dry --smoke -v` *(fails: Missing kraken.yaml in project root)*
- `python bot.py --mode live --dry --replay-hours 5 -v` *(fails: Missing kraken.yaml in project root)*

------
https://chatgpt.com/codex/tasks/task_e_689a27b890848326abf15deda9aef039