### PR TITLE
feat: add symbol resolver cache and wallet code fallback

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -35,6 +35,11 @@ def main(argv: list[str] | None = None) -> None:
         type=int,
         help="After dry tick, replay the last N hours in sim mode",
     )
+    parser.add_argument(
+        "--cache",
+        action="store_true",
+        help="Refresh exchange pair cache before running",
+    )
 
     args = parser.parse_args(argv or sys.argv[1:])
     if not args.mode:
@@ -124,6 +129,7 @@ def main(argv: list[str] | None = None) -> None:
                 ledger=args.ledger,
                 relative_window=time_window,
                 verbose=args.verbose,
+                refresh_cache=args.cache,
             )
         except Exception as e:
             addlog(f"[ERROR] Fetch failed: {e}", verbose_int=1, verbose_state=True)


### PR DESCRIPTION
## Summary
- cache Kraken and Binance market data for symbol resolution
- resolve coin/fiat pairs to exchange symbols and wallet codes with fallback
- support `--cache` in fetch mode and auto wallet code resolution

## Testing
- `python -m py_compile systems/utils/resolve_symbol.py systems/fetch.py bot.py systems/scripts/handle_top_of_hour.py systems/scripts/send_top_hour_report.py systems/manual.py systems/live_engine.py`
- `python bot.py --mode fetch --ledger Kris_Ledger --time 1h --cache -vv` *(fails: kraken GET https://api.kraken.com/0/public/Assets)*

------
https://chatgpt.com/codex/tasks/task_e_689a29970430832693249881d698f7ad