### PR TITLE
refactor: drop tag-based candle paths

### DIFF
--- a/systems/scripts/execution_handler.py
+++ b/systems/scripts/execution_handler.py
@@ -8,7 +8,6 @@ from urllib.parse import urlencode
 from systems.scripts.kraken_auth import load_kraken_keys
 from systems.scripts.kraken_utils import get_live_price
 from systems.utils.addlog import addlog, send_telegram_message
-from systems.utils.resolve_symbol import split_tag
 from systems.utils.snapshot import load_snapshot, prime_snapshot
 
 
@@ -173,7 +172,8 @@ def place_order(
 def execute_buy(
     client,
     *,
-    symbol: str,
+    pair_code: str,
+    fiat_symbol: str,
     price: float,
     amount_usd: float,
     ledger_name: str,
@@ -186,10 +186,9 @@ def execute_buy(
     currently unused as ``place_order`` pulls pricing from Kraken directly.
     """
 
-    _, fiat_symbol = split_tag(symbol)
     result = place_order(
         "buy",
-        symbol,
+        pair_code,
         fiat_symbol,
         amount_usd,
         ledger_name,
@@ -222,7 +221,8 @@ def execute_buy(
 def execute_sell(
     client,
     *,
-    symbol: str,
+    pair_code: str,
+    fiat_symbol: str,
     coin_amount: float,
     price: float | None = None,
     ledger_name: str,
@@ -233,12 +233,11 @@ def execute_sell(
     ``price`` is optional and, if absent, the current live price is fetched to
     estimate USD notional.
     """
-    sell_price = price if price is not None else get_live_price(symbol)
+    sell_price = price if price is not None else get_live_price(pair_code)
     usd_amount = coin_amount * sell_price
-    _, fiat_symbol = split_tag(symbol)
     result = place_order(
         "sell",
-        symbol,
+        pair_code,
         fiat_symbol,
         usd_amount,
         ledger_name,

--- a/systems/scripts/fetch_canles.py
+++ b/systems/scripts/fetch_canles.py
@@ -5,12 +5,22 @@ from __future__ import annotations
 import pandas as pd
 
 from systems.utils.config import resolve_path
+from systems.utils.addlog import addlog
 
 
-def fetch_candles(tag: str) -> pd.DataFrame:
-    """Load historical candles for ``tag`` from ``data/raw``."""
+def fetch_candles(coin: str, fiat: str | None = None) -> pd.DataFrame:
+    """Load historical candles for ``coin`` from ``data/raw``."""
     root = resolve_path("")
-    path = root / "data" / "raw" / f"{tag.upper()}.csv"
+    path = root / "data" / "raw" / f"{coin.upper()}.csv"
+    if not path.exists() and fiat:
+        legacy = root / "data" / "raw" / f"{(coin + fiat).upper()}.csv"
+        if legacy.exists():
+            addlog(
+                f"[COMPAT] Using legacy raw file: {legacy.name}",
+                verbose_int=1,
+                verbose_state=0,
+            )
+            path = legacy
     if not path.exists():  # pragma: no cover - file presence check
         raise FileNotFoundError(f"Candle file not found: {path}")
     return pd.read_csv(path)

--- a/systems/scripts/fetch_core.py
+++ b/systems/scripts/fetch_core.py
@@ -66,10 +66,12 @@ def _merge_and_save(path: Path, existing: pd.DataFrame, new_frames: List[pd.Data
     return len(combined)
 
 
-def get_raw_path(tag: str, ext: str = "csv") -> Path:
-    """Return the full path to the raw-data file for a given tag."""
+def get_raw_path_for_coin(coin: str, ext: str = "csv") -> Path:
+    """Return the full path to the raw-data file for a given coin."""
     root = resolve_path("")
-    return root / "data" / "raw" / f"{tag}.{ext}"
+    raw_dir = root / "data" / "raw"
+    raw_dir.mkdir(parents=True, exist_ok=True)
+    return raw_dir / f"{coin.strip().upper()}.{ext}"
 
 
 def compute_missing_ranges(

--- a/systems/scripts/handle_top_of_hour.py
+++ b/systems/scripts/handle_top_of_hour.py
@@ -366,9 +366,11 @@ def handle_top_of_hour(
                     1 for n in ledger.get_closed_notes() if n.get("window") == win
                 )
                 note_counts[win.title()] = (open_n, closed_n)
+            coin = ledger_cfg.get("coin") or split_tag(tag)[0]
+            fiat = ledger_cfg.get("fiat") or split_tag(tag)[1]
             report = format_top_of_hour_report(
                 ledger_name,
-                tag,
+                f"{coin}/{fiat}",
                 datetime.utcnow(),
                 usd_balance,
                 coin_balance_usd,
@@ -381,7 +383,8 @@ def handle_top_of_hour(
 
             send_top_hour_report(
                 ledger_name=ledger_name,
-                tag=tag,
+                coin=coin,
+                fiat=fiat,
                 strategy_summary=strategy_summary,
                 verbose=general_cfg.get("verbose", 0),
             )

--- a/systems/sim_engine.py
+++ b/systems/sim_engine.py
@@ -36,10 +36,11 @@ def run_simulation(
 ) -> dict:
     settings = load_settings()
     ledger_cfg = load_ledger_config(ledger)
-    tag = ledger_cfg.get("tag", "").upper()
+    coin = ledger_cfg["coin"]
+    fiat = ledger_cfg["fiat"]
     window_settings = ledger_cfg.get("window_settings", {})
 
-    df = fetch_candles(tag)
+    df = fetch_candles(coin, fiat)
     total = len(df)
     if total == 0:
         return {"buys": 0, "sells": 0, "realized_gain": 0.0, "open_value": 0.0}
@@ -53,6 +54,7 @@ def run_simulation(
         settings,
         ledger_cfg,
         mode="sim",
+        ledger_name=ledger,
         prev={"verbose": verbose},
     )
 
@@ -69,7 +71,11 @@ def run_simulation(
             "realized_trades": 0,
             "realized_roi_accum": 0.0,
         }
-    addlog(f"[SIM] Starting simulation for {tag}", verbose_int=1, verbose_state=verbose)
+    addlog(
+        f"[SIM] Starting simulation for {coin}/{fiat}",
+        verbose_int=1,
+        verbose_state=verbose,
+    )
 
     iterator = range(start, end + 1)
     if progress:
@@ -262,7 +268,7 @@ def run_simulation(
         json.dump(json_data, f_json, indent=2)
 
     save_ledger(
-        ledger_cfg["tag"],
+        ledger,
         ledger_obj,
         sim=True,
         final_tick=end,

--- a/tools/migrate_candles_to_coin.py
+++ b/tools/migrate_candles_to_coin.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+"""Utility to migrate legacy <COIN><FIAT>.csv candle files to <COIN>.csv."""
+
+import argparse
+import shutil
+from pathlib import Path
+
+from systems.utils.config import load_settings, resolve_path
+
+
+def migrate(apply: bool = False) -> None:
+    settings = load_settings()
+    root = resolve_path("")
+    raw_dir = root / "data" / "raw"
+    for name, cfg in settings.get("ledger_settings", {}).items():
+        coin = cfg.get("coin")
+        fiat = cfg.get("fiat")
+        if not coin or not fiat:
+            continue
+        new_path = raw_dir / f"{coin.upper()}.csv"
+        legacy_path = raw_dir / f"{(coin + fiat).upper()}.csv"
+        if not new_path.exists() and legacy_path.exists():
+            if apply:
+                shutil.copyfile(legacy_path, new_path)
+                print(f"Migrated {legacy_path.name} -> {new_path.name}")
+            else:
+                print(f"Would migrate {legacy_path.name} -> {new_path.name}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Migrate legacy candle files")
+    parser.add_argument("--apply", action="store_true", help="Perform rename/copy")
+    args = parser.parse_args()
+    migrate(apply=args.apply)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- derive canonical coin/fiat in ledger config and warn on shared coins
- store and load raw candles by coin with legacy tag compatibility
- resolve symbols and wallet codes via coin/fiat across engines and reports
- add helper to migrate legacy candle filenames

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'systems')*
- `python -m py_compile bot.py systems/fetch.py systems/live_engine.py systems/sim_engine.py systems/scripts/*.py tools/migrate_candles_to_coin.py`


------
https://chatgpt.com/codex/tasks/task_e_689a6cceb4208326ba721e9fe4db36ec