### PR TITLE
feat: add source option for candle fetch

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -43,6 +43,12 @@ def main(argv: list[str] | None = None) -> None:
         action="store_true",
         help="Refresh exchange pair cache before running",
     )
+    parser.add_argument(
+        "--source",
+        choices=["auto", "binance", "kraken"],
+        default="auto",
+        help="Where to fetch OHLC: auto (default), binance, or kraken",
+    )
 
     args = parser.parse_args(argv or sys.argv[1:])
     if not args.mode:
@@ -152,6 +158,7 @@ def main(argv: list[str] | None = None) -> None:
                 relative_window=time_window,
                 verbose=args.verbose,
                 refresh_cache=args.cache,
+                source=args.source,
             )
         except Exception as e:
             addlog(f"[ERROR] Fetch failed: {e}", verbose_int=1, verbose_state=True)


### PR DESCRIPTION
## Summary
- add `--source` flag to CLI for selecting data source
- support binance-only, kraken-only, or auto fetch modes
- log chosen source and per-exchange segments

## Testing
- `python -m py_compile bot.py systems/fetch.py`
- `PYTHONPATH=. pytest`

------
https://chatgpt.com/codex/tasks/task_e_689a7aa3c5b48326afbd219a52713130