### PR TITLE
Enable pair-specific raw data paths and source-controlled fetches

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -67,7 +67,7 @@ def main(argv: list[str] | None = None) -> None:
     try:
         cache = load_pair_cache()
     except Exception:
-        if mode == "fetch" and args.cache:
+        if args.cache:
             addlog(
                 "[CACHE] Pair cache missing → refreshing…",
                 verbose_int=1,
@@ -75,16 +75,9 @@ def main(argv: list[str] | None = None) -> None:
             )
             refresh_pair_cache(verbose)
             cache = load_pair_cache()
-        elif mode == "fetch":
-            addlog(
-                "[ERROR] Failed to load pair cache (tip: pass --cache once)",
-                verbose_int=1,
-                verbose_state=True,
-            )
-            sys.exit(1)
         else:
             addlog(
-                "[ERROR] Failed to load pair cache",
+                "[ERROR] Failed to load pair cache (tip: pass --cache once)",
                 verbose_int=1,
                 verbose_state=True,
             )

--- a/systems/scripts/fetch_core.py
+++ b/systems/scripts/fetch_core.py
@@ -74,6 +74,13 @@ def get_raw_path_for_coin(coin: str, ext: str = "csv") -> Path:
     return raw_dir / f"{coin.strip().upper()}.{ext}"
 
 
+def get_raw_path_for_pair(coin: str, fiat: str, ext: str = "csv") -> Path:
+    root = resolve_path("")
+    raw_dir = root / "data" / "raw"
+    raw_dir.mkdir(parents=True, exist_ok=True)
+    return raw_dir / f"{coin.strip().upper()}-{fiat.strip().upper()}.{ext}"
+
+
 def compute_missing_ranges(
     candles_df: pd.DataFrame, start_ts: int, end_ts: int, interval_ms: int
 ) -> List[tuple[int, int]]:


### PR DESCRIPTION
## Summary
- Add `get_raw_path_for_pair` to write candles per coin/fiat pair
- Refresh pair cache on demand and improve cache error handling
- Fetcher resolves pairs from cache, resets Binance files when requested, and writes pair-named CSVs

## Testing
- `python -m py_compile bot.py systems/fetch.py systems/scripts/fetch_core.py`


------
https://chatgpt.com/codex/tasks/task_e_689a7dad5c148326b7236d9810c2947b