### PR TITLE
Enforce quote asset and add buy execution logs

### DIFF
--- a/settings/settings.json
+++ b/settings/settings.json
@@ -1,11 +1,11 @@
 {
   "ledger_settings": {
     "Kris_Ledger": {
-      "tag": "SOLUSDC",
+      "tag": "SOLUSD",
       "wallet_code": "SOL.F",
-      "kraken_name": "SOL/USDC",
-      "kraken_pair": "SOLUSDC",
-      "binance_name": "SOLUSDC",
+      "kraken_name": "SOL/USD",
+      "kraken_pair": "SOLUSD",
+      "binance_name": "SOLUSD",
       "window_settings": {
         "minnow": {
           "window_size": "1d",
@@ -25,16 +25,6 @@
           "max_notes_sell_per_candle": 1,
           "investment_fraction": 0.2,
           "window_transform_multiplier": 2,
-          "max_open_notes": 100
-        },
-        "whale": {
-          "window_size": "6d",
-          "buy_trigger_position": 0.1,
-          "reset_buy_percent": 0.15,
-          "maturity_position": 1.0,
-          "max_notes_sell_per_candle": 1,
-          "investment_fraction": 0.15,
-          "window_transform_multiplier": 5,
           "max_open_notes": 100
         }
       }
@@ -64,16 +54,6 @@
           "max_notes_sell_per_candle": 1,
           "investment_fraction": 0.2,
           "window_transform_multiplier": 2,
-          "max_open_notes": 100
-        },
-        "dog": {
-          "window_size": "6d",
-          "buy_trigger_position": 0.1,
-          "reset_buy_percent": 0.15,
-          "maturity_position": 1.0,
-          "max_notes_sell_per_candle": 1,
-          "investment_fraction": 0.15,
-          "window_transform_multiplier": 5,
           "max_open_notes": 100
         }
       }

--- a/systems/manual.py
+++ b/systems/manual.py
@@ -70,14 +70,14 @@ def main(argv: Optional[list[str]] = None) -> None:
         if not args.dry:
             result = execute_buy(
                 None,
-                symbol=tag,
+                pair_code=ledger_cfg["kraken_pair"],
                 wallet_code=ledger_cfg["wallet_code"],
                 price=price,
                 amount_usd=args.usd,
                 ledger_name=args.ledger,
                 verbose=args.verbose,
             )
-            if not result:
+            if not result or result.get("error"):
                 raise SystemExit("[ERROR] Buy order failed")
             coin_amt = result.get("filled_amount", coin_amt)
             price = result.get("avg_price", price)
@@ -101,13 +101,13 @@ def main(argv: Optional[list[str]] = None) -> None:
         if not args.dry:
             result = execute_sell(
                 None,
-                symbol=tag,
+                pair_code=ledger_cfg["kraken_pair"],
                 coin_amount=coin_amt,
                 price=price,
                 ledger_name=args.ledger,
                 verbose=args.verbose,
             )
-            if not result:
+            if not result or result.get("error"):
                 raise SystemExit("[ERROR] Sell order failed")
             coin_amt = result.get("filled_amount", coin_amt)
             price = result.get("avg_price", price)

--- a/systems/scripts/evaluate_sell.py
+++ b/systems/scripts/evaluate_sell.py
@@ -69,11 +69,20 @@ def evaluate_sell(
     cap = cfg.get("max_notes_sell_per_candle", 1)
     selected = candidates[:cap]
 
-    addlog(
-        f"[MATURE][{window_name} {cfg['window_size']}] eligible={len(candidates)} sold={len(selected)} cap={cap}",
-        verbose_int=1,
-        verbose_state=verbose,
-    )
+    if candidates:
+        addlog(
+            f"[MATURE][{window_name} {cfg['window_size']}] eligible={len(candidates)} sold={len(selected)} cap={cap}",
+            verbose_int=1,
+            verbose_state=verbose,
+        )
+    else:
+        msg = (
+            f"[HOLD][{window_name} {cfg['window_size']}] price=${price:.4f} "
+            f"open_notes={open_count}"
+        )
+        if next_sell_price is not None:
+            msg += f" next_sell=${next_sell_price:.4f}"
+        addlog(msg, verbose_int=1, verbose_state=verbose)
 
     maturity_pos = cfg.get("maturity_position", 1.0)
     for note in selected:

--- a/systems/scripts/trade_apply.py
+++ b/systems/scripts/trade_apply.py
@@ -44,7 +44,6 @@ def apply_buy_result_to_ledger(
     ledger.open_note(note)
     cost = result.get("filled_amount", 0.0) * result.get("avg_price", 0.0)
     state["capital"] = state.get("capital", 0.0) - cost
-    state.setdefault("buy_unlock_p", {})[window_name] = meta.get("unlock_p")
     return note
 
 

--- a/systems/sim_engine.py
+++ b/systems/sim_engine.py
@@ -40,6 +40,7 @@ def run_simulation(*, ledger: str, verbose: int = 0) -> None:
         mode="sim",
         prev={"verbose": verbose},
     )
+    runtime_state["buy_unlock_p"] = {}
 
     ledger_obj = Ledger()
     win_metrics = {}
@@ -82,6 +83,7 @@ def run_simulation(*, ledger: str, verbose: int = 0) -> None:
                     result=result,
                     state=runtime_state,
                 )
+                runtime_state.setdefault("buy_unlock_p", {})[window_name] = buy_res.get("unlock_p")
                 if runtime_state["capital"] < -1e-9:
                     addlog(
                         f"[BUG] capital negative after buy: ${runtime_state['capital']:.2f}",
@@ -134,19 +136,6 @@ def run_simulation(*, ledger: str, verbose: int = 0) -> None:
                     m_sell["realized_trades"] += 1
                     m_sell["realized_roi_accum"] += roi_trade
 
-            if not sell_res.get("notes") and sell_res.get("open_notes"):
-                msg = (
-                    f"[HOLD][{window_name} {wcfg['window_size']}] price=${price:.4f} "
-                    f"open_notes={sell_res.get('open_notes')}"
-                )
-                next_price = sell_res.get("next_sell_price")
-                if next_price is not None:
-                    msg += f" next_sell=${next_price:.4f}"
-                addlog(
-                    msg,
-                    verbose_int=3,
-                    verbose_state=runtime_state.get("verbose", 0),
-                )
 
     final_price = float(df.iloc[-1]["close"]) if total else 0.0
     summary = ledger_obj.get_account_summary(final_price)


### PR DESCRIPTION
## Summary
- map Kris_Ledger to SOLUSD and Travis_Ledger to SOLUSDC
- abort trades on quote mismatch and log executed buys with Telegram notification
- reset buy gates and summarise open notes on live startup; refine sell logging

## Testing
- `python -m py_compile systems/live_engine.py systems/manual.py systems/scripts/evaluate_sell.py systems/scripts/execution_handler.py systems/scripts/handle_top_of_hour.py systems/scripts/trade_apply.py systems/sim_engine.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689b66eadddc8326a582ac2f06b23b60