### PR TITLE
Use ledger names for ledger persistence

### DIFF
--- a/systems/live_engine.py
+++ b/systems/live_engine.py
@@ -36,7 +36,7 @@ def _run_iteration(settings, runtime_states, *, dry: bool, verbose: int) -> None
         if df.empty:
             continue
         t = len(df) - 1
-        ledger_obj = Ledger.load_ledger(tag=ledger_cfg["tag"])
+        ledger_obj = Ledger.load_ledger(name, tag=ledger_cfg["tag"])
         prev = runtime_states.get(name, {"verbose": verbose})
         state = build_runtime_state(
             settings,
@@ -98,7 +98,7 @@ def _run_iteration(settings, runtime_states, *, dry: bool, verbose: int) -> None
                         state=state,
                     )
 
-        save_ledger(ledger_cfg["tag"], ledger_obj)
+        save_ledger(name, ledger_obj, tag=ledger_cfg["tag"])
 
 
 def run_live(*, dry: bool = False, verbose: int = 0) -> None:
@@ -116,7 +116,7 @@ def run_live(*, dry: bool = False, verbose: int = 0) -> None:
         state["buy_unlock_p"] = {}
         runtime_states[name] = state
 
-        ledger_obj = Ledger.load_ledger(tag=ledger_cfg["tag"])
+        ledger_obj = Ledger.load_ledger(name, tag=ledger_cfg["tag"])
         open_notes = ledger_obj.get_open_notes()
         total = len(open_notes)
         per_window: Dict[str, int] = {}

--- a/systems/manual.py
+++ b/systems/manual.py
@@ -64,6 +64,11 @@ def main(argv: Optional[list[str]] = None) -> None:
 
     coin_amt = args.usd / price
     coin_str = _coin_label(tag)
+    path_new = resolve_path(f"data/ledgers/{args.ledger}.json")
+    legacy_path = resolve_path(f"data/ledgers/{tag}.json") if tag else None
+    if legacy_path and legacy_path.exists() and not path_new.exists():
+        legacy_path.rename(path_new)
+
     ledger = _load_ledger(args.ledger)
 
     if args.buy:
@@ -91,7 +96,7 @@ def main(argv: Optional[list[str]] = None) -> None:
                     "timestamp": result.get("timestamp"),
                 }
             )
-            save_ledger(args.ledger, ledger)
+            save_ledger(args.ledger, ledger, tag=tag)
         addlog(
             f"[MANUAL BUY] {args.ledger} | {tag} | ${args.usd:.2f} → {coin_amt:.4f} {coin_str} @ ${price:.4f}",
             verbose_int=1,
@@ -122,7 +127,7 @@ def main(argv: Optional[list[str]] = None) -> None:
                     "timestamp": result.get("timestamp"),
                 }
             )
-            save_ledger(args.ledger, ledger)
+            save_ledger(args.ledger, ledger, tag=tag)
         else:
             usd_total = args.usd
         addlog(

--- a/systems/scripts/handle_top_of_hour.py
+++ b/systems/scripts/handle_top_of_hour.py
@@ -92,7 +92,7 @@ def handle_top_of_hour(
             window_settings = ledger_cfg.get("window_settings", {})
             triggered_strategies = {wn.title(): False for wn in window_settings}
             strategy_summary: dict[str, dict] = {}
-            ledger = Ledger.load_ledger(tag=ledger_cfg["tag"])
+            ledger = Ledger.load_ledger(ledger_name, tag=ledger_cfg["tag"])
 
             snapshot = load_or_fetch_snapshot(ledger_name)
             if not snapshot:
@@ -350,7 +350,7 @@ def handle_top_of_hour(
                 metadata["last_buy_tick"] = last_buy_tick
                 metadata["last_sell_tick"] = last_sell_tick
             ledger.set_metadata(metadata)
-            save_ledger(ledger_cfg["tag"], ledger)
+            save_ledger(ledger_name, ledger, tag=ledger_cfg["tag"])
 
             usd_balance = float(balance.get(quote, 0.0))
             coin_balance = float(balance.get(wallet_code, 0.0))

--- a/systems/scripts/sim_tuner.py
+++ b/systems/scripts/sim_tuner.py
@@ -110,7 +110,7 @@ def run_sim_tuner(*, ledger: str, verbose: int = 0) -> None:
                 if original_sim_loader:
                     sim_engine.load_settings = original_sim_loader
 
-            ledger_obj = Ledger.load_ledger(ledger, sim=True)
+            ledger_obj = Ledger.load_ledger(ledger, tag=tag, sim=True)
             final_price = float(fetch_candles(tag).iloc[-1]["close"])
             summary = ledger_obj.get_account_summary(final_price)
             open_value = summary.get("open_value", 0.0)

--- a/systems/sim_engine.py
+++ b/systems/sim_engine.py
@@ -234,7 +234,14 @@ def run_simulation(*, ledger: str, verbose: int = 0) -> None:
     with json_path.open("w", encoding="utf-8") as f_json:
         json.dump(json_data, f_json, indent=2)
 
-    save_ledger(ledger_cfg["tag"], ledger_obj, sim=True, final_tick=total - 1, summary=summary)
+    save_ledger(
+        ledger,
+        ledger_obj,
+        sim=True,
+        final_tick=total - 1,
+        summary=summary,
+        tag=ledger_cfg["tag"],
+    )
     default_path = root / "data" / "tmp" / "simulation" / f"{ledger}.json"
     sim_path = root / "data" / "tmp" / f"simulation_{ledger}.json"
     if default_path.exists() and default_path != sim_path:


### PR DESCRIPTION
## Summary
- Store ledgers using configured ledger names instead of coin tags
- Migrate legacy tag-named ledgers to ledger-name files on first access
- Update live, sim, and utility scripts to load and save ledgers by name

## Testing
- `python -m py_compile systems/scripts/ledger.py systems/live_engine.py systems/sim_engine.py systems/scripts/handle_top_of_hour.py systems/scripts/sim_tuner.py systems/manual.py`
- `pytest >/tmp/pytest.log; tail -n 20 /tmp/pytest.log`


------
https://chatgpt.com/codex/tasks/task_e_689bd35238988326aa5081e0b8cf644d