### PR TITLE
Add jackpot accumulator to simulator and full-history fetch flag

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -79,6 +79,8 @@ def main(argv: list[str] | None = None) -> None:
         return
 
     if mode == "sim":
+        if args.jackpot:
+            settings.setdefault("general_settings", {}).setdefault("jackpot_settings", {})["enable"] = True
         if not args.ledger:
             addlog("Error: --ledger is required for sim mode")
             sys.exit(1)

--- a/settings/settings.json
+++ b/settings/settings.json
@@ -61,7 +61,17 @@
   },
   "general_settings": {
     "max_note_usdt": 1000.0,
-    "minimum_note_size": 10
+    "minimum_note_size": 10,
+    "jackpot_settings": {
+      "enable": false,
+      "drip_interval_hours": 168,
+      "drip_base_frac_of_bank": 0.01,
+      "dd_start": 0.50,
+      "dd_bottom": 0.85,
+      "exit_ath_frac": 0.75,
+      "min_order_quote": 15.0,
+      "max_jackpot_value_frac": 0.10
+    }
   },
   "simulation_capital": 1000
 }

--- a/systems/fetch.py
+++ b/systems/fetch.py
@@ -36,9 +36,17 @@ def main(argv: list[str] | None = None) -> None:
         required=False,
         help="Time window (e.g. 120h)",
     )
+    parser.add_argument(
+        "--full",
+        action="store_true",
+        help="Fetch full available history",
+    )
     args = parser.parse_args(argv)
     if not args.ledger:
         parser.error("--ledger is required")
+    if args.full:
+        fetch_missing_candles(args.ledger, verbose=args.verbose, full=True)
+        return
 
     time_window = args.time if args.time else "48h"
     verbose = args.verbose
@@ -146,7 +154,11 @@ def main(argv: list[str] | None = None) -> None:
 
 
 def fetch_missing_candles(
-    ledger: str, relative_window: str = "48h", verbose: int = 1
+    ledger: str,
+    relative_window: str = "48h",
+    verbose: int = 1,
+    *,
+    full: bool = False,
 ) -> None:
     ledger_cfg = load_ledger_config(ledger)
     tag = ledger_cfg["tag"].upper()
@@ -160,9 +172,13 @@ def fetch_missing_candles(
         )
         raise RuntimeError("Missing exchange symbols")
 
-    start_ts, end_ts = parse_relative_time(relative_window)
-    start_ts = int(start_ts // 3600 * 3600)
-    end_ts = int(end_ts // 3600 * 3600)
+    if full:
+        start_ts = 0
+        end_ts = int(datetime.now(timezone.utc).timestamp())
+    else:
+        start_ts, end_ts = parse_relative_time(relative_window)
+        start_ts = int(start_ts // 3600 * 3600)
+        end_ts = int(end_ts // 3600 * 3600)
     interval_ms = 3_600_000
     out_path = get_raw_path(tag)
     existing = _load_existing(out_path)

--- a/systems/scripts/jackpot_manager.py
+++ b/systems/scripts/jackpot_manager.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+"""Jackpot accumulator for simulation mode."""
+
+from dataclasses import dataclass
+from typing import Optional
+
+from systems.utils.addlog import addlog
+
+
+@dataclass
+class BuyQuote:
+    amount_quote: float
+
+
+@dataclass
+class ExitAll:
+    pass
+
+
+class JackpotManager:
+    """Manage profit-funded jackpot DCA buying and exiting."""
+
+    def __init__(self, cfg: dict, start_ts: int, ath_from_data: float, min_from_data: float) -> None:
+        self.cfg = cfg
+        interval = int(cfg.get("drip_interval_hours", 0) * 3600)
+        self.last_drip_ts = start_ts - interval
+        self.bank = 0.0
+        self.bank_in = 0.0
+        self.bank_spent = 0.0
+        self.held_qty = 0.0
+        self.avg_cost = 0.0
+        self.ath = ath_from_data
+        self.min_price = min_from_data
+        self.exit_value: Optional[float] = None
+        self.realized_from_exit: Optional[float] = None
+
+    def on_tick(
+        self,
+        ts: int,
+        price: float,
+        realized_pnl_delta: float,
+        wallet_quote_available: float,
+        wallet_total_quote: float,
+    ) -> Optional[object]:
+        if realized_pnl_delta > 0:
+            self.bank += realized_pnl_delta
+            self.bank_in += realized_pnl_delta
+
+        exit_frac = self.cfg.get("exit_ath_frac", 0.75)
+        if self.held_qty > 0 and price >= exit_frac * self.ath:
+            value = self.held_qty * price
+            realized = (price - self.avg_cost) * self.held_qty
+            addlog(
+                f"[JACKPOT][EXIT] ts={ts} price=${price:.4f} qty={self.held_qty:.6f} value=${value:.2f}",
+                verbose_int=1,
+                verbose_state=True,
+            )
+            self.exit_value = value
+            self.realized_from_exit = realized
+            self.held_qty = 0.0
+            self.avg_cost = 0.0
+            self.last_drip_ts = ts
+            return ExitAll()
+
+        dd = 1.0 - price / self.ath if self.ath else 0.0
+        dd_start = self.cfg.get("dd_start", 0.5)
+        if dd < dd_start:
+            return None
+        if ts - self.last_drip_ts < int(self.cfg.get("drip_interval_hours", 0) * 3600):
+            addlog("[JACKPOT][SKIP] reason=interval", verbose_int=2, verbose_state=True)
+            return None
+        if self.bank <= 0:
+            addlog("[JACKPOT][SKIP] reason=bank", verbose_int=2, verbose_state=True)
+            return None
+
+        dd_bottom = self.cfg.get("dd_bottom", 0.85)
+        if dd_bottom > dd_start:
+            boost = 1.0 + (dd - dd_start) * (2.0 - 1.0) / (dd_bottom - dd_start)
+        else:
+            boost = 1.0
+        boost = max(1.0, min(2.0, boost))
+        q = self.bank * self.cfg.get("drip_base_frac_of_bank", 0.0) * boost
+        q = min(q, self.bank)
+        min_order = self.cfg.get("min_order_quote", 0.0)
+        if q < min_order:
+            addlog("[JACKPOT][SKIP] reason=min", verbose_int=2, verbose_state=True)
+            return None
+        market_value = self.held_qty * price
+        cap = self.cfg.get("max_jackpot_value_frac", 1.0) * wallet_total_quote
+        if market_value + q > cap:
+            addlog("[JACKPOT][SKIP] reason=cap", verbose_int=2, verbose_state=True)
+            return None
+
+        qty = q / price if price else 0.0
+        total_cost = self.avg_cost * self.held_qty + q
+        self.held_qty += qty
+        self.avg_cost = total_cost / self.held_qty if self.held_qty else 0.0
+        self.bank -= q
+        self.bank_spent += q
+        self.last_drip_ts = ts
+        addlog(
+            f"[JACKPOT][DRIP] ts={ts} price=${price:.4f} spend=${q:.2f} bank=${self.bank:.2f} dd={dd:.2f} boost={boost:.2f} qty={qty:.6f}",
+            verbose_int=1,
+            verbose_state=True,
+        )
+        return BuyQuote(q)
+
+    def snapshot(self) -> dict:
+        return {
+            "bank_in": self.bank_in,
+            "bank_spent": self.bank_spent,
+            "qty": self.held_qty,
+            "avg_cost": self.avg_cost,
+            "exit_value": self.exit_value,
+            "realized_from_exit": self.realized_from_exit,
+        }

--- a/systems/scripts/ledger.py
+++ b/systems/scripts/ledger.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 """Simple in-memory ledger for simulations and live trading."""
 
 import json
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 from systems.utils.config import resolve_path
 
@@ -49,14 +49,24 @@ class Ledger:
         return dict(self.metadata)
 
     # Accessors -------------------------------------------------------------
-    def get_open_notes(self) -> List[Dict]:
-        return list(self.open_notes)
+    def get_open_notes(self, *, strategy: Optional[str] = None) -> List[Dict]:
+        notes = self.open_notes
+        if strategy is not None:
+            notes = [n for n in notes if n.get("strategy") == strategy]
+        return list(notes)
 
-    def get_active_notes(self) -> List[Dict]:
-        return self.get_open_notes()
+    def get_active_notes(self, *, strategy: Optional[str] = None) -> List[Dict]:
+        return self.get_open_notes(strategy=strategy)
 
-    def get_closed_notes(self) -> List[Dict]:
-        return list(self.closed_notes)
+    def get_closed_notes(self, *, strategy: Optional[str] = None) -> List[Dict]:
+        notes = self.closed_notes
+        if strategy is not None:
+            notes = [n for n in notes if n.get("strategy") == strategy]
+        return list(notes)
+
+    def get_cumulative_realized_pnl(self, *, strategy: Optional[str] = None) -> float:
+        notes = self.get_closed_notes(strategy=strategy)
+        return sum(n.get("gain", 0.0) for n in notes)
 
     def get_total_liquid_value(self, final_price: float) -> float:
         """Return all value assuming open notes liquidate at ``final_price``."""

--- a/systems/scripts/trade_apply.py
+++ b/systems/scripts/trade_apply.py
@@ -34,6 +34,8 @@ def apply_buy_result_to_ledger(
         "target_roi": meta.get("target_roi"),
         "unlock_p": meta.get("unlock_p"),
     }
+    if "strategy" in meta:
+        note["strategy"] = meta["strategy"]
     if "created_idx" in meta:
         note["created_idx"] = meta["created_idx"]
     if result.get("timestamp") is not None:

--- a/systems/sim_engine.py
+++ b/systems/sim_engine.py
@@ -12,6 +12,7 @@ from tqdm import tqdm
 
 from systems.scripts.fetch_candles import fetch_candles
 from systems.scripts.ledger import Ledger, save_ledger
+from systems.scripts.jackpot_manager import JackpotManager, BuyQuote, ExitAll
 from systems.scripts.evaluate_buy import evaluate_buy
 from systems.scripts.evaluate_sell import evaluate_sell
 from systems.scripts.runtime_state import build_runtime_state
@@ -33,6 +34,8 @@ def run_simulation(*, ledger: str, verbose: int = 0) -> None:
 
     df = fetch_candles(tag)
     total = len(df)
+    ath_from_data = float(df["close"].max()) if total else 0.0
+    min_from_data = float(df["close"].min()) if total else 0.0
 
     runtime_state = build_runtime_state(
         settings,
@@ -43,6 +46,12 @@ def run_simulation(*, ledger: str, verbose: int = 0) -> None:
     runtime_state["buy_unlock_p"] = {}
 
     ledger_obj = Ledger()
+    jackpot_cfg = settings.get("general_settings", {}).get("jackpot_settings", {})
+    jm: JackpotManager | None = None
+    prev_realized = 0.0
+    if jackpot_cfg.get("enable"):
+        start_ts = int(df.iloc[0]["timestamp"]) if "timestamp" in df.columns else 0
+        jm = JackpotManager(jackpot_cfg, start_ts, ath_from_data, min_from_data)
     win_metrics = {}
     for wname, wcfg in window_settings.items():
         win_metrics[wname] = {
@@ -136,6 +145,45 @@ def run_simulation(*, ledger: str, verbose: int = 0) -> None:
                     m_sell["realized_trades"] += 1
                     m_sell["realized_roi_accum"] += roi_trade
 
+        if jm:
+            realized_total = ledger_obj.get_cumulative_realized_pnl()
+            realized_delta = realized_total - prev_realized
+            prev_realized = realized_total
+            ts_now = int(df.iloc[t]["timestamp"]) if "timestamp" in df.columns else t
+            wallet_quote_available = runtime_state["capital"]
+            open_value = sum(
+                n.get("entry_amount", 0.0) * price for n in ledger_obj.get_open_notes()
+            )
+            wallet_total_quote = wallet_quote_available + open_value
+            act = jm.on_tick(
+                ts_now,
+                price,
+                realized_delta,
+                wallet_quote_available,
+                wallet_total_quote,
+            )
+            if isinstance(act, BuyQuote):
+                result = paper_execute_buy(price, act.amount_quote, timestamp=ts_now)
+                apply_buy_result_to_ledger(
+                    ledger=ledger_obj,
+                    window_name="jackpot",
+                    t=t,
+                    meta={"window_name": "jackpot", "window_size": "jackpot", "strategy": "jackpot"},
+                    result=result,
+                    state=runtime_state,
+                )
+            elif isinstance(act, ExitAll):
+                notes = ledger_obj.get_open_notes(strategy="jackpot")
+                for note in notes:
+                    result = paper_execute_sell(price, note.get("entry_amount", 0.0), timestamp=ts_now)
+                    apply_sell_result_to_ledger(
+                        ledger=ledger_obj,
+                        note=note,
+                        t=t,
+                        result=result,
+                        state=runtime_state,
+                    )
+
 
     final_price = float(df.iloc[-1]["close"]) if total else 0.0
     summary = ledger_obj.get_account_summary(final_price)
@@ -196,6 +244,13 @@ def run_simulation(*, ledger: str, verbose: int = 0) -> None:
         verbose_int=1,
         verbose_state=verbose,
     )
+    if jm:
+        snap = jm.snapshot()
+        addlog(
+            f"[JACKPOT][SUMMARY] bank_in=${snap['bank_in']:.2f} bank_spent=${snap['bank_spent']:.2f} qty={snap['qty']:.6f} avg_cost=${snap['avg_cost']:.4f} exit_value={0 if snap['exit_value'] is None else snap['exit_value']:.2f} realized_from_exit={0 if snap['realized_from_exit'] is None else snap['realized_from_exit']:.2f}",
+            verbose_int=1,
+            verbose_state=verbose,
+        )
 
     root = resolve_path("")
     logs_dir = root / "logs"

--- a/systems/utils/cli.py
+++ b/systems/utils/cli.py
@@ -35,4 +35,9 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Enable Telegram alerts",
     )
+    parser.add_argument(
+        "--jackpot",
+        action="store_true",
+        help="Enable jackpot DCA in simulation",
+    )
     return parser


### PR DESCRIPTION
## Summary
- add profit-funded JackpotManager for DCA drips and exit logic
- wire jackpot into simulation and expose via `--jackpot` CLI flag
- allow fetching entire historical data with new `--full` option

## Testing
- `python -m py_compile systems/scripts/jackpot_manager.py systems/sim_engine.py systems/scripts/ledger.py systems/scripts/trade_apply.py bot.py systems/utils/cli.py systems/fetch.py`
- `python -m json.tool settings/settings.json`

------
https://chatgpt.com/codex/tasks/task_e_689befb905908326ba22db869c046675