### PR TITLE
Simplify fetch system with coin-based recent sync

### DIFF
--- a/systems/fetch.py
+++ b/systems/fetch.py
@@ -1,275 +1,85 @@
 from __future__ import annotations
 
-"""Time-aware historical data fetcher."""
+"""Fetch helper exposing a recent-only path."""
 
+import argparse
+import sys
+import time
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import List
-import sys
-import pandas as pd
-from systems.utils.config import load_ledger_config, resolve_path
-from systems.utils.cli import build_parser
 
 if __package__ is None or __package__ == "":
     sys.path.append(str(Path(__file__).resolve().parents[1]))
 
-from systems.utils.time import parse_relative_time
+import pandas as pd
 
 from systems.utils.addlog import addlog
+from systems.utils.config import resolve_ccxt_symbols_by_coin
+from systems.scripts.fetch_candles import load_coin_csv
 from systems.scripts.fetch_core import (
-    _load_existing,
-    _merge_and_save,
-    get_raw_path,
     COLUMNS,
-    compute_missing_ranges,
-    fetch_range,
+    fetch_last_720_kraken,
+    get_coin_raw_path,
+    heal_recent,
 )
 
-# **Inject** the project root so “utils” is importable:
-sys.path.insert(0, str(resolve_path("")))
+
+def fetch_recent_coin(coin: str) -> int:
+    """Fetch and heal the last 720 candles for ``coin``."""
+
+    coin = coin.upper()
+    kraken_symbol, _ = resolve_ccxt_symbols_by_coin(coin)
+
+    end_ts = int(time.time() // 3600 * 3600)
+    recent = fetch_last_720_kraken(kraken_symbol, end_ts)
+    rows = len(recent)
+
+    start_ts = end_ts - 719 * 3600
+    start_iso = datetime.fromtimestamp(start_ts, tz=timezone.utc).strftime("%Y-%m-%dT%H:00Z")
+    end_iso = datetime.fromtimestamp(end_ts, tz=timezone.utc).strftime("%Y-%m-%dT%H:00Z")
+    addlog(
+        f"[FETCH][RECENT] coin={coin} from={start_iso} to={end_iso} rows={rows}",
+        verbose_int=1,
+        verbose_state=True,
+    )
+
+    try:
+        existing = load_coin_csv(coin)
+    except FileNotFoundError:
+        existing = pd.DataFrame(columns=COLUMNS)
+
+    merged, appended, dedup, gaps = heal_recent(existing, recent)
+    addlog(
+        f"[HEAL] appended={appended} dedup={dedup} total={len(merged)}",
+        verbose_int=1,
+        verbose_state=True,
+    )
+    addlog(
+        f"[SYNC] Remaining recent-window gaps: {gaps} hour(s)",
+        verbose_int=1,
+        verbose_state=True,
+    )
+
+    path = get_coin_raw_path(coin)
+    tmp = path.with_suffix(".tmp")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    merged.to_csv(tmp, index=False)
+    tmp.replace(path)
+    return len(merged)
 
 
 def main(argv: list[str] | None = None) -> None:
-    parser = build_parser()
-    parser.add_argument(
-        "--time",
-        required=False,
-        help="Time window (e.g. 120h)",
-    )
+    parser = argparse.ArgumentParser(description="Fetch recent candles for a coin")
+    parser.add_argument("--recent", action="store_true", help="Fetch last 720h from Kraken")
+    parser.add_argument("--coin", required=True, help="Base currency ticker")
     args = parser.parse_args(argv)
-    if not args.ledger:
-        parser.error("--ledger is required")
 
-    time_window = args.time if args.time else "48h"
-    verbose = args.verbose
+    if not args.recent:
+        parser.error("--recent is required")
 
-    ledger_cfg = load_ledger_config(args.ledger)
-    tag = ledger_cfg["tag"].upper()
-    kraken_symbol = ledger_cfg.get("kraken_name")
-    binance_symbol = ledger_cfg.get("binance_name")
-    if not kraken_symbol or not binance_symbol:
-        addlog(
-            f"[ERROR] Missing kraken_name/binance_name in settings for ledger {args.ledger}",
-            verbose_int=1,
-            verbose_state=True,
-        )
-        sys.exit(1)
-
-    start_ts, end_ts = parse_relative_time(time_window)
-    start_ts = int(start_ts // 3600 * 3600)
-    end_ts = int(end_ts // 3600 * 3600)
-    interval_ms = 3_600_000
-    out_path = get_raw_path(tag)
-    existing = _load_existing(out_path)
-    gaps = compute_missing_ranges(existing, start_ts, end_ts, interval_ms)
-
-    new_frames: List[pd.DataFrame] = []
-    added_binance = 0
-    added_kraken = 0
-    kraken_limited = False
-
-    for gap_start, gap_end in gaps:
-        diff_hours = int((gap_end - gap_start) // 3600) + 1
-        iso = lambda ts: datetime.utcfromtimestamp(ts).isoformat()
-        if diff_hours <= 720:
-            addlog(
-                f"[FETCH] Kraken {kraken_symbol} {iso(gap_start)} → {iso(gap_end)} (≤720h)",
-                verbose_int=2,
-                verbose_state=verbose,
-            )
-            df = fetch_range("kraken", kraken_symbol, gap_start, gap_end)
-            if not df.empty:
-                new_frames.append(df)
-                added_kraken += len(df)
-        else:
-            kraken_end = gap_start + 720 * 3600
-            addlog(
-                f"[FETCH] Kraken {kraken_symbol} {iso(gap_start)} → {iso(kraken_end)} (≤720h)",
-                verbose_int=2,
-                verbose_state=verbose,
-            )
-            df_k = fetch_range("kraken", kraken_symbol, gap_start, kraken_end)
-            if not df_k.empty:
-                new_frames.append(df_k)
-                added_kraken += len(df_k)
-                kraken_limited = True
-            binance_start = kraken_end + 3600
-            addlog(
-                f"[FETCH] Binance {binance_symbol} {iso(binance_start)} → {iso(gap_end)} (tail)",
-                verbose_int=2,
-                verbose_state=verbose,
-            )
-            df_b = fetch_range("binance", binance_symbol, binance_start, gap_end)
-            if not df_b.empty:
-                new_frames.append(df_b)
-                added_binance += len(df_b)
-
-    total_rows = _merge_and_save(out_path, existing, new_frames)
-    post_df = _load_existing(out_path)
-    post_gaps = compute_missing_ranges(post_df, start_ts, end_ts, interval_ms)
-    if post_gaps:
-        missing_hours = sum(int((e - s) // 3600) + 1 for s, e in post_gaps)
-        addlog(
-            f"[WARN] Post-merge gaps detected: {missing_hours} hour(s) missing",
-            verbose_state=True,
-        )
-    else:
-        addlog(
-            "[SYNC] No post-merge gaps remain",
-            verbose_int=2,
-            verbose_state=verbose,
-        )
-
-    addlog(
-        f"[SYNC] Total rows in file: {total_rows}",
-        verbose_int=2,
-        verbose_state=verbose,
-    )
-
-    addlog(
-        f"[SYNC] Added {added_kraken} candles from Kraken, {added_binance} from Binance",
-        verbose_int=2,
-        verbose_state=verbose,
-    )
-    if kraken_limited:
-        addlog(
-            "[INFO] Could not retrieve full range: Kraken limited to 720 candles",
-            verbose_int=2,
-            verbose_state=verbose,
-        )
-    if not added_binance and not added_kraken:
-        addlog(
-            " Raw data already complete. No candles fetched",
-            verbose_int=2,
-            verbose_state=verbose,
-        )
-
-
-def fetch_missing_candles(
-    ledger: str, relative_window: str = "48h", verbose: int = 1
-) -> None:
-    ledger_cfg = load_ledger_config(ledger)
-    tag = ledger_cfg["tag"].upper()
-    kraken_symbol = ledger_cfg.get("kraken_name")
-    binance_symbol = ledger_cfg.get("binance_name")
-    if not kraken_symbol or not binance_symbol:
-        addlog(
-            f"[ERROR] Missing kraken_name/binance_name in settings for ledger {ledger}",
-            verbose_int=1,
-            verbose_state=True,
-        )
-        raise RuntimeError("Missing exchange symbols")
-
-    start_ts, end_ts = parse_relative_time(relative_window)
-    start_ts = int(start_ts // 3600 * 3600)
-    end_ts = int(end_ts // 3600 * 3600)
-    interval_ms = 3_600_000
-    out_path = get_raw_path(tag)
-    existing = _load_existing(out_path)
-    gaps = compute_missing_ranges(existing, start_ts, end_ts, interval_ms)
-
-    new_frames: List[pd.DataFrame] = []
-    added_binance = 0
-    added_kraken = 0
-    kraken_limited = False
-
-    for gap_start, gap_end in gaps:
-        diff_hours = int((gap_end - gap_start) // 3600) + 1
-        iso = lambda ts: datetime.utcfromtimestamp(ts).isoformat()
-        if diff_hours <= 720:
-            addlog(
-                f"[FETCH] Kraken {kraken_symbol} {iso(gap_start)} → {iso(gap_end)} (≤720h)",
-                verbose_int=2,
-                verbose_state=verbose,
-            )
-            try:
-                df = fetch_range("kraken", kraken_symbol, gap_start, gap_end)
-                if not df.empty:
-                    new_frames.append(df)
-                    added_kraken += len(df)
-            except Exception as e:
-                addlog(
-                    f"[WARN] Kraken fetch error: {e}",
-                    verbose_int=2,
-                    verbose_state=verbose,
-                )
-        else:
-            kraken_end = gap_start + 720 * 3600
-            addlog(
-                f"[FETCH] Kraken {kraken_symbol} {iso(gap_start)} → {iso(kraken_end)} (≤720h)",
-                verbose_int=2,
-                verbose_state=verbose,
-            )
-            try:
-                df_k = fetch_range("kraken", kraken_symbol, gap_start, kraken_end)
-                if not df_k.empty:
-                    new_frames.append(df_k)
-                    added_kraken += len(df_k)
-                    kraken_limited = True
-            except Exception as e:
-                addlog(
-                    f"[WARN] Kraken fetch error: {e}",
-                    verbose_int=2,
-                    verbose_state=verbose,
-                )
-            binance_start = kraken_end + 3600
-            addlog(
-                f"[FETCH] Binance {binance_symbol} {iso(binance_start)} → {iso(gap_end)} (tail)",
-                verbose_int=2,
-                verbose_state=verbose,
-            )
-            try:
-                df_b = fetch_range("binance", binance_symbol, binance_start, gap_end)
-                if not df_b.empty:
-                    new_frames.append(df_b)
-                    added_binance += len(df_b)
-            except Exception as e:
-                addlog(
-                    f"[WARN] Binance fetch error: {e}",
-                    verbose_int=2,
-                    verbose_state=verbose,
-                )
-
-    total_rows = _merge_and_save(out_path, existing, new_frames)
-    post_df = _load_existing(out_path)
-    post_gaps = compute_missing_ranges(post_df, start_ts, end_ts, interval_ms)
-    if post_gaps:
-        missing_hours = sum(int((e - s) // 3600) + 1 for s, e in post_gaps)
-        addlog(
-            f"[WARN] Post-merge gaps detected: {missing_hours} hour(s) missing",
-            verbose_state=True,
-        )
-    else:
-        addlog(
-            "[SYNC] No post-merge gaps remain",
-            verbose_int=2,
-            verbose_state=verbose,
-        )
-
-    addlog(
-        f"[SYNC] Total rows in file: {total_rows}",
-        verbose_int=2,
-        verbose_state=verbose,
-    )
-
-    addlog(
-        f"[SYNC] Added {added_kraken} candles from Kraken, {added_binance} from Binance",
-        verbose_int=2,
-        verbose_state=verbose,
-    )
-    if kraken_limited:
-        addlog(
-            "[INFO] Could not retrieve full range: Kraken limited to 720 candles",
-            verbose_int=2,
-            verbose_state=verbose,
-        )
-    if not added_binance and not added_kraken:
-        addlog(
-            " Raw data already complete. No candles fetched",
-            verbose_int=2,
-            verbose_state=verbose,
-        )
+    fetch_recent_coin(args.coin)
 
 
 if __name__ == "__main__":
     main()
+

--- a/systems/scripts/fetch_candles.py
+++ b/systems/scripts/fetch_candles.py
@@ -1,16 +1,34 @@
 from __future__ import annotations
 
-"""Utilities to load historical candle data."""
+"""Utilities for loading coin-based candle data."""
 
 import pandas as pd
 
 from systems.utils.config import resolve_path
 
 
-def fetch_candles(tag: str) -> pd.DataFrame:
-    """Load historical candles for ``tag`` from ``data/raw``."""
+def load_coin_csv(coin: str) -> pd.DataFrame:
+    """Load historical candles for ``coin`` from ``data/raw``.
+
+    Parameters
+    ----------
+    coin: str
+        Base currency ticker (e.g., ``"SOL"``).
+
+    Returns
+    -------
+    pandas.DataFrame
+        DataFrame containing the candle history.
+
+    Raises
+    ------
+    FileNotFoundError
+        If the raw CSV file does not exist.
+    """
+
     root = resolve_path("")
-    path = root / "data" / "raw" / f"{tag.upper()}.csv"
+    path = root / "data" / "raw" / f"{coin.upper()}.csv"
     if not path.exists():  # pragma: no cover - file presence check
         raise FileNotFoundError(f"Candle file not found: {path}")
     return pd.read_csv(path)
+

--- a/systems/scripts/sim_tuner.py
+++ b/systems/scripts/sim_tuner.py
@@ -12,7 +12,7 @@ from typing import Any, Dict
 import optuna
 
 from systems.sim_engine import run_simulation
-from systems.scripts.fetch_candles import fetch_candles
+from systems.scripts.fetch_candles import load_coin_csv
 from systems.scripts.ledger import Ledger
 from systems.utils.addlog import addlog
 from systems.utils.config import (
@@ -20,6 +20,7 @@ from systems.utils.config import (
     load_settings,
     resolve_path,
 )
+from systems.utils.resolve_symbol import split_tag
 
 
 def run_sim_tuner(*, ledger: str, verbose: int = 0) -> None:
@@ -111,7 +112,8 @@ def run_sim_tuner(*, ledger: str, verbose: int = 0) -> None:
                     sim_engine.load_settings = original_sim_loader
 
             ledger_obj = Ledger.load_ledger(ledger, tag=tag, sim=True)
-            final_price = float(fetch_candles(tag).iloc[-1]["close"])
+            base, _ = split_tag(tag)
+            final_price = float(load_coin_csv(base).iloc[-1]["close"])
             summary = ledger_obj.get_account_summary(final_price)
             open_value = summary.get("open_value", 0.0)
             realized_gain = summary.get("realized_gain", 0.0)

--- a/systems/sim_engine.py
+++ b/systems/sim_engine.py
@@ -10,7 +10,7 @@ import json
 
 from tqdm import tqdm
 
-from systems.scripts.fetch_candles import fetch_candles
+from systems.scripts.fetch_candles import load_coin_csv
 from systems.scripts.ledger import Ledger, save_ledger
 from systems.scripts.evaluate_buy import evaluate_buy
 from systems.scripts.evaluate_sell import evaluate_sell
@@ -23,15 +23,17 @@ from systems.scripts.trade_apply import (
 )
 from systems.utils.addlog import addlog
 from systems.utils.config import load_settings, load_ledger_config, resolve_path
+from systems.utils.resolve_symbol import split_tag
 
 
 def run_simulation(*, ledger: str, verbose: int = 0) -> None:
     settings = load_settings()
     ledger_cfg = load_ledger_config(ledger)
-    tag = ledger_cfg.get("tag", "").upper()
+    base, _ = split_tag(ledger_cfg["tag"])
+    coin = base.upper()
     window_settings = ledger_cfg.get("window_settings", {})
 
-    df = fetch_candles(tag)
+    df = load_coin_csv(coin)
     total = len(df)
 
     runtime_state = build_runtime_state(
@@ -55,7 +57,7 @@ def run_simulation(*, ledger: str, verbose: int = 0) -> None:
             "realized_trades": 0,
             "realized_roi_accum": 0.0,
         }
-    addlog(f"[SIM] Starting simulation for {tag}", verbose_int=1, verbose_state=verbose)
+    addlog(f"[SIM] Starting simulation for {coin}", verbose_int=1, verbose_state=verbose)
 
     for t in tqdm(range(total), desc="📉 Sim Progress", dynamic_ncols=True):
         price = float(df.iloc[t]["close"])

--- a/systems/utils/config.py
+++ b/systems/utils/config.py
@@ -102,3 +102,31 @@ def load_ledger_config(ledger_name: str) -> Dict[str, Any]:
     if ledger_name not in ledgers:
         raise ValueError(f"Ledger '{ledger_name}' not found in settings")
     return ledgers[ledger_name]
+
+
+def resolve_ccxt_symbols_by_coin(coin: str) -> tuple[str, str]:
+    """Return Kraken and Binance symbols for ``coin``.
+
+    The first ledger whose tag starts with ``coin`` (case-insensitive) is used.
+    Logs which ledger tag was matched.
+    """
+
+    settings = load_settings()
+    coin_up = coin.upper()
+    for cfg in settings.get("ledger_settings", {}).values():
+        tag = cfg.get("tag", "")
+        if tag.upper().startswith(coin_up):
+            kraken = cfg.get("kraken_name", "")
+            binance = cfg.get("binance_name", "")
+            addlog(
+                f"[CONFIG] coin={coin_up} resolved using tag={tag}",
+                verbose_int=1,
+                verbose_state=True,
+            )
+            return kraken, binance
+    msg = (
+        f"[ERROR] No ledger maps coin={coin_up} to exchange symbols. "
+        f"Add a ledger with tag starting '{coin_up}' including kraken_name/binance_name."
+    )
+    addlog(msg, verbose_int=1, verbose_state=True)
+    raise ValueError(msg)


### PR DESCRIPTION
## Summary
- Add `fetch_recent_coin` that grabs the last 720 Kraken candles and heals `data/raw/<COIN>.csv`
- Provide helpers for coin paths, recent merge, and symbol resolution
- Update engines and CLI to use coin-named CSVs and refresh on the hour

## Testing
- `python bot.py --mode fetch --recent --coin SOL -vv` *(fails: kraken GET https://api.kraken.com/0/public/Assets)*

------
https://chatgpt.com/codex/tasks/task_e_689bf28794a08326b41a9743f7d2d2f0