### PR TITLE
feat: add exchange symbol mapping for fetch

### DIFF
--- a/settings/settings.json
+++ b/settings/settings.json
@@ -1,62 +1,8 @@
 {
   "ledger_settings": {
-    "Kris_Ledger": {
-      "tag": "SOLUSD",
-      "wallet_code": "SOL.F",
+    "SOL": {
       "kraken_name": "SOL/USD",
-      "kraken_pair": "SOLUSD",
-      "binance_name": "SOLUSD",
-      "window_settings": {
-        "minnow": {
-          "window_size": "1d",
-          "buy_trigger_position": 0.1,
-          "reset_buy_percent": 0.15,
-          "maturity_position": 1.0,
-          "max_notes_sell_per_candle": 1,
-          "investment_fraction": 0.15,
-          "window_transform_multiplier": 1,
-          "max_open_notes": 100
-        },
-        "fish": {
-          "window_size": "3d",
-          "buy_trigger_position": 0.1,
-          "reset_buy_percent": 0.15,
-          "maturity_position": 1.0,
-          "max_notes_sell_per_candle": 1,
-          "investment_fraction": 0.2,
-          "window_transform_multiplier": 2,
-          "max_open_notes": 100
-        }
-      }
-    },
-    "Travis_Ledger": {
-      "tag": "SOLUSDC",
-      "wallet_code": "SOL.F",
-      "kraken_name": "SOL/USDC",
-      "kraken_pair": "SOLUSDC",
-      "binance_name": "SOLUSDC",
-      "window_settings": {
-        "mouse": {
-          "window_size": "1d",
-          "buy_trigger_position": 0.1,
-          "reset_buy_percent": 0.15,
-          "maturity_position": 1.0,
-          "max_notes_sell_per_candle": 1,
-          "investment_fraction": 0.15,
-          "window_transform_multiplier": 1,
-          "max_open_notes": 100
-        },
-        "rabbit": {
-          "window_size": "3d",
-          "buy_trigger_position": 0.1,
-          "reset_buy_percent": 0.15,
-          "maturity_position": 1.0,
-          "max_notes_sell_per_candle": 1,
-          "investment_fraction": 0.2,
-          "window_transform_multiplier": 2,
-          "max_open_notes": 100
-        }
-      }
+      "binance_name": "SOL/USDC"
     }
   },
   "general_settings": {

--- a/systems/fetch.py
+++ b/systems/fetch.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import argparse
 import sys
 import time
-from datetime import datetime, timezone
 from pathlib import Path
 
 if __package__ is None or __package__ == "":
@@ -14,7 +13,7 @@ if __package__ is None or __package__ == "":
 import pandas as pd
 
 from systems.utils.addlog import addlog
-from systems.utils.config import resolve_ccxt_symbols_by_coin
+from systems.utils.config import load_settings
 from systems.scripts.fetch_candles import load_coin_csv
 from systems.scripts.fetch_core import (
     COLUMNS,
@@ -35,21 +34,31 @@ def _save_df(coin: str, df: pd.DataFrame) -> int:
     return len(df)
 
 
+def _get_symbols(coin: str) -> tuple[str, str]:
+    settings = load_settings()
+    try:
+        entry = settings["ledger_settings"][coin]
+        return entry["kraken_name"], entry["binance_name"]
+    except KeyError as exc:
+        raise KeyError(f"Missing exchange symbol mapping for {coin}") from exc
+
+
 def fetch_all(coin: str) -> int:
     """Fetch full Binance history for ``coin`` and write to disk."""
 
     coin = coin.upper()
-    _, binance_symbol = resolve_ccxt_symbols_by_coin(coin)
+    _, binance_symbol = _get_symbols(coin)
 
     end_ts = int(time.time() // 3600 * 3600)
     all_df = fetch_binance_range(binance_symbol, 0, end_ts)
-    rows = len(all_df)
 
     addlog(
-        f"[FETCH][ALL] coin={coin} rows={rows}",
+        f"[FETCH][ALL] {coin} via Binance symbol={binance_symbol}",
         verbose_int=1,
         verbose_state=True,
     )
+    raw_path = get_coin_raw_path(coin)
+    raw_path.unlink(missing_ok=True)
     return _save_df(coin, all_df)
 
 
@@ -57,27 +66,34 @@ def fetch_recent(coin: str, hours: int) -> int:
     """Fetch the last ``hours`` candles for ``coin`` and merge with existing data."""
 
     coin = coin.upper()
-    kraken_symbol, _ = resolve_ccxt_symbols_by_coin(coin)
+    kraken_symbol, binance_symbol = _get_symbols(coin)
 
     end_ts = int(time.time() // 3600 * 3600)
-    start_ts = end_ts - (hours - 1) * 3600
-    recent = fetch_kraken_range(kraken_symbol, start_ts, end_ts)
+    frames = []
 
-    start_iso = datetime.fromtimestamp(start_ts, tz=timezone.utc).strftime("%Y-%m-%dT%H:00Z")
-    end_iso = datetime.fromtimestamp(end_ts, tz=timezone.utc).strftime("%Y-%m-%dT%H:00Z")
-    addlog(
-        f"[FETCH][RECENT] coin={coin} from={start_iso} to={end_iso} rows={len(recent)}",
-        verbose_int=1,
-        verbose_state=True,
-    )
+    if hours <= 720:
+        start_ts = end_ts - (hours - 1) * 3600
+        frames.append(fetch_kraken_range(kraken_symbol, start_ts, end_ts))
+    else:
+        kraken_start = end_ts - 719 * 3600
+        bin_start = end_ts - (hours - 1) * 3600
+        bin_end = kraken_start - 3600
+        frames.append(fetch_binance_range(binance_symbol, bin_start, bin_end))
+        frames.append(fetch_kraken_range(kraken_symbol, kraken_start, end_ts))
 
     try:
         existing = load_coin_csv(coin)
     except FileNotFoundError:
         existing = pd.DataFrame(columns=COLUMNS)
 
-    merged = pd.concat([existing, recent], ignore_index=True)
+    merged = pd.concat([existing] + frames, ignore_index=True)
     merged = merged.drop_duplicates(subset="timestamp").sort_values("timestamp")
+
+    addlog(
+        f"[FETCH][RECENT] {coin} hours={hours} kraken={kraken_symbol} binance={binance_symbol}",
+        verbose_int=1,
+        verbose_state=True,
+    )
 
     return _save_df(coin, merged)
 
@@ -92,10 +108,10 @@ def main(argv: list[str] | None = None) -> None:
     parser = argparse.ArgumentParser(description="Fetch candles for a coin")
     parser.add_argument("--coin", required=True, help="Base currency ticker")
     parser.add_argument(
-        "--all", action="store_true", help="Fetch full Binance history"
+        "--all", action="store_true", help="Fetch full Binance history",
     )
     parser.add_argument(
-        "--recent", type=int, help="Fetch recent N hours from Kraken"
+        "--recent", type=int, help="Fetch recent N hours from Kraken",
     )
     args = parser.parse_args(argv)
 
@@ -112,4 +128,3 @@ def main(argv: list[str] | None = None) -> None:
 
 if __name__ == "__main__":
     main()
-


### PR DESCRIPTION
## Summary
- allow fetch commands to use coin-specific Kraken and Binance symbols from settings
- simplify settings.json to per-coin mapping and validate coin symbols in fetch mode
- fetch recent data from both exchanges when needed and replace stale raw files

## Testing
- `python bot.py --mode fetch --coin SOL --all` *(fails: binance GET https://api.binance.com/api/v3/exchangeInfo)*
- `python bot.py --mode fetch --coin SOL --recent 500` *(fails: kraken GET https://api.kraken.com/0/public/Assets)*

------
https://chatgpt.com/codex/tasks/task_e_689c04af46108326a28cf1378bb0a743