### PR TITLE
Remove deprecated window_transform_multiplier and max_open_notes

### DIFF
--- a/settings/knobs.json
+++ b/settings/knobs.json
@@ -1,41 +1,110 @@
 {
   "DOGEUSD": {
     "dog": {
-      "buy_cooldown": [1, 48],
-      "sell_cooldown": [0, 48],
-      "investment_fraction": [0.05, 0.25],
-      "maturity_multiplier": [0.5, 5.0],
-      "buy_multiplier_scale": [1.0, 5.0],
-      "buy_cooldown_multiplier_scale": [0.5, 2.0],
-      "sell_cooldown_multiplier_scale": [0.5, 2.0],
-      "dead_zone_pct": [0.0, 0.1],
-      "max_open_notes": [10, 100]
+      "buy_cooldown": [
+        1,
+        48
+      ],
+      "sell_cooldown": [
+        0,
+        48
+      ],
+      "investment_fraction": [
+        0.05,
+        0.25
+      ],
+      "maturity_multiplier": [
+        0.5,
+        5.0
+      ],
+      "buy_multiplier_scale": [
+        1.0,
+        5.0
+      ],
+      "buy_cooldown_multiplier_scale": [
+        0.5,
+        2.0
+      ],
+      "sell_cooldown_multiplier_scale": [
+        0.5,
+        2.0
+      ],
+      "dead_zone_pct": [
+        0.0,
+        0.1
+      ]
     }
   },
   "SOLDAI": {
     "bunny": {
-      "buy_cooldown": [1, 48],
-      "sell_cooldown": [0, 48],
-      "investment_fraction": [0.05, 0.25],
-      "maturity_multiplier": [0.5, 5.0],
-      "buy_multiplier_scale": [1.0, 5.0],
-      "buy_cooldown_multiplier_scale": [0.5, 2.0],
-      "sell_cooldown_multiplier_scale": [0.5, 2.0],
-      "dead_zone_pct": [0.0, 0.1],
-      "max_open_notes": [10, 100]
+      "buy_cooldown": [
+        1,
+        48
+      ],
+      "sell_cooldown": [
+        0,
+        48
+      ],
+      "investment_fraction": [
+        0.05,
+        0.25
+      ],
+      "maturity_multiplier": [
+        0.5,
+        5.0
+      ],
+      "buy_multiplier_scale": [
+        1.0,
+        5.0
+      ],
+      "buy_cooldown_multiplier_scale": [
+        0.5,
+        2.0
+      ],
+      "sell_cooldown_multiplier_scale": [
+        0.5,
+        2.0
+      ],
+      "dead_zone_pct": [
+        0.0,
+        0.1
+      ]
     }
   },
   "SOLUSD": {
     "goat": {
-      "buy_cooldown": [1, 48],
-      "sell_cooldown": [0, 48],
-      "investment_fraction": [0.05, 0.25],
-      "maturity_multiplier": [0.5, 5.0],
-      "buy_multiplier_scale": [1.0, 5.0],
-      "buy_cooldown_multiplier_scale": [0.5, 2.0],
-      "sell_cooldown_multiplier_scale": [0.5, 2.0],
-      "dead_zone_pct": [0.0, 0.1],
-      "max_open_notes": [10, 100]
+      "buy_cooldown": [
+        1,
+        48
+      ],
+      "sell_cooldown": [
+        0,
+        48
+      ],
+      "investment_fraction": [
+        0.05,
+        0.25
+      ],
+      "maturity_multiplier": [
+        0.5,
+        5.0
+      ],
+      "buy_multiplier_scale": [
+        1.0,
+        5.0
+      ],
+      "buy_cooldown_multiplier_scale": [
+        0.5,
+        2.0
+      ],
+      "sell_cooldown_multiplier_scale": [
+        0.5,
+        2.0
+      ],
+      "dead_zone_pct": [
+        0.0,
+        0.1
+      ]
     }
   }
 }

--- a/settings/settings.json
+++ b/settings/settings.json
@@ -13,9 +13,7 @@
           "reset_buy_percent": 0.15,
           "maturity_position": 1.0,
           "max_notes_sell_per_candle": 1,
-          "investment_fraction": 0.15,
-          "window_transform_multiplier": 1,
-          "max_open_notes": 100
+          "investment_fraction": 0.15
         },
         "fish": {
           "window_size": "3d",
@@ -23,9 +21,7 @@
           "reset_buy_percent": 0.15,
           "maturity_position": 1.0,
           "max_notes_sell_per_candle": 1,
-          "investment_fraction": 0.2,
-          "window_transform_multiplier": 2,
-          "max_open_notes": 100
+          "investment_fraction": 0.2
         }
       }
     },
@@ -42,9 +38,7 @@
           "reset_buy_percent": 0.15,
           "maturity_position": 1.0,
           "max_notes_sell_per_candle": 1,
-          "investment_fraction": 0.15,
-          "window_transform_multiplier": 1,
-          "max_open_notes": 100
+          "investment_fraction": 0.15
         },
         "rabbit": {
           "window_size": "3d",
@@ -52,9 +46,7 @@
           "reset_buy_percent": 0.15,
           "maturity_position": 1.0,
           "max_notes_sell_per_candle": 1,
-          "investment_fraction": 0.2,
-          "window_transform_multiplier": 2,
-          "max_open_notes": 100
+          "investment_fraction": 0.2
         }
       }
     }

--- a/systems/scripts/evaluate_buy.py
+++ b/systems/scripts/evaluate_buy.py
@@ -66,8 +66,6 @@ def evaluate_buy(
                 verbose_state=verbose,
             )
             return False
-    if len(open_notes) >= cfg.get("max_open_notes", 0):
-        return False
 
     trigger = cfg.get("buy_trigger_position", 0.0)
     if p > trigger:
@@ -80,8 +78,7 @@ def evaluate_buy(
 
     capital = runtime_state.get("capital", 0.0)
     base = cfg.get("investment_fraction", 0.0)
-    mult = 1 + (1 - p) * (cfg.get("window_transform_multiplier", 1.0) - 1)
-    size_usd = capital * base * mult
+    size_usd = capital * base
 
     limits = runtime_state.get("limits", {})
     min_sz = float(limits.get("min_note_size", 0.0))
@@ -105,7 +102,7 @@ def evaluate_buy(
     sz_pct = (size_usd / capital * 100) if capital else 0.0
 
     addlog(
-        f"[BUY][{window_name} {cfg['window_size']}] p={p:.3f}, base={base*100:.2f}%, mult={mult:.2f}x → size={sz_pct:.2f}% (cap=${size_usd:.2f})",
+        f"[BUY][{window_name} {cfg['window_size']}] p={p:.3f}, base={base*100:.2f}% → size={sz_pct:.2f}% (cap=${size_usd:.2f})",
         verbose_int=1,
         verbose_state=verbose,
     )

--- a/systems/scripts/trade_logic.py
+++ b/systems/scripts/trade_logic.py
@@ -27,30 +27,28 @@ def maybe_buy(
     if position <= cfg.get("buy_floor", 0):
         cooldown = cfg.get("cooldown", 0)
         if tick - last_buy_tick.get(name, float("-inf")) >= cooldown:
-            open_for_window = [n for n in ledger.get_active_notes() if n["window"] == name]
-            if len(open_for_window) < cfg.get("max_open_notes", 0):
-                invest = sim_capital * cfg.get("investment_fraction", 0)
-                invest = min(invest, max_note_usdt)
-                if invest >= min_note_usdt and invest <= sim_capital:
-                    amount = invest / price
-                    mature_price = wave["floor"] + wave["range"] * cfg.get("sell_ceiling", 1)
-                    note = {
-                        "window": name,
-                        "entry_tick": tick,
-                        "entry_price": price,
-                        "entry_usdt": invest,
-                        "entry_amount": amount,
-                        "mature_price": mature_price,
-                        "status": "Open",
-                    }
-                    ledger.open_note(note)
-                    sim_capital -= invest
-                    last_buy_tick[name] = tick
-                    addlog(
-                        f"[BUY] {name} tick {tick} price={price:.6f}",
-                        verbose_int=2,
-                        verbose_state=verbose,
-                    )
+            invest = sim_capital * cfg.get("investment_fraction", 0)
+            invest = min(invest, max_note_usdt)
+            if invest >= min_note_usdt and invest <= sim_capital:
+                amount = invest / price
+                mature_price = wave["floor"] + wave["range"] * cfg.get("sell_ceiling", 1)
+                note = {
+                    "window": name,
+                    "entry_tick": tick,
+                    "entry_price": price,
+                    "entry_usdt": invest,
+                    "entry_amount": amount,
+                    "mature_price": mature_price,
+                    "status": "Open",
+                }
+                ledger.open_note(note)
+                sim_capital -= invest
+                last_buy_tick[name] = tick
+                addlog(
+                    f"[BUY] {name} tick {tick} price={price:.6f}",
+                    verbose_int=2,
+                    verbose_state=verbose,
+                )
     return sim_capital
 
 

--- a/systems/utils/trade_eval.py
+++ b/systems/utils/trade_eval.py
@@ -63,29 +63,27 @@ def evaluate_trade(
         if tick - cooldown_tracker.get(name, float("-inf")) < adjusted_cd:
             return sim_capital, True
 
-        open_for_window = [n for n in ledger.get_active_notes() if n["window"] == name]
-        if len(open_for_window) < cfg.get("max_open_notes", 0):
-            base_note_count = sim_capital * cfg.get("investment_fraction", 0)
-            adjusted_note_count = base_note_count * trade_params["buy_multiplier"]
-            invest = min(adjusted_note_count, max_note_usdt)
-            if invest >= min_note_usdt and invest <= sim_capital:
-                amount = invest / current_price
-                note = {
-                    "window": name,
-                    "entry_tick": tick,
-                    "buy_tick": tick,
-                    "entry_price": current_price,
-                    "entry_amount": amount,
-                    "status": "Open",
-                }
-                ledger.open_note(note)
-                sim_capital -= invest
-                cooldown_tracker[name] = tick
-                addlog(
-                    f"[BUY] {name} tick {tick} price={current_price:.6f}",
-                    verbose_int=2,
-                    verbose_state=verbose,
-                )
+        base_note_count = sim_capital * cfg.get("investment_fraction", 0)
+        adjusted_note_count = base_note_count * trade_params["buy_multiplier"]
+        invest = min(adjusted_note_count, max_note_usdt)
+        if invest >= min_note_usdt and invest <= sim_capital:
+            amount = invest / current_price
+            note = {
+                "window": name,
+                "entry_tick": tick,
+                "buy_tick": tick,
+                "entry_price": current_price,
+                "entry_amount": amount,
+                "status": "Open",
+            }
+            ledger.open_note(note)
+            sim_capital -= invest
+            cooldown_tracker[name] = tick
+            addlog(
+                f"[BUY] {name} tick {tick} price={current_price:.6f}",
+                verbose_int=2,
+                verbose_state=verbose,
+            )
         return sim_capital, False
 
     if trade_type == "sell":


### PR DESCRIPTION
## Summary
- drop `window_transform_multiplier` and `max_open_notes` from all configs
- simplify buy sizing logic to no longer use the transform multiplier or note count limits
- update trading scripts to operate without max open note gating

## Testing
- `python bot.py --mode sim --ledger Kris_Ledger` *(fails: FileNotFoundError: data/raw/SOL.csv)*
- `python bot.py --mode sim --ledger Travis_Ledger` *(fails: FileNotFoundError: data/raw/SOL.csv)*

------
https://chatgpt.com/codex/tasks/task_e_689c90c3af9083268d7c7b49f9b2dec0