### PR TITLE
Add jackpot drip strategy and full-history fetch option

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -24,6 +24,11 @@ def main(argv: list[str] | None = None) -> None:
         "--all", action="store_true", help="Fetch full Binance history for coin"
     )
     parser.add_argument(
+        "--full-history",
+        action="store_true",
+        help="Fetch full history into a separate *_full.csv file",
+    )
+    parser.add_argument(
         "--recent", type=int, help="Fetch recent N hours for coin"
     )
 
@@ -108,24 +113,24 @@ def main(argv: list[str] | None = None) -> None:
                 verbose_state=True,
             )
             sys.exit(1)
-        if args.all and args.recent is not None:
+        if sum([bool(args.all), bool(args.full_history), args.recent is not None]) != 1:
             addlog(
-                "Error: --all and --recent are mutually exclusive",
-                verbose_int=1,
-                verbose_state=True,
-            )
-            sys.exit(1)
-        if not args.all and args.recent is None:
-            addlog(
-                "Error: either --all or --recent is required",
+                "Error: specify exactly one of --all, --recent, or --full-history",
                 verbose_int=1,
                 verbose_state=True,
             )
             sys.exit(1)
         try:
-            from systems.fetch import fetch_all, fetch_recent
+            from systems.fetch import fetch_all, fetch_recent, fetch_full_history
 
-            if args.all:
+            if args.full_history:
+                addlog(
+                    f"[BOT][FETCH][FULL] coin={args.coin}",
+                    verbose_int=1,
+                    verbose_state=True,
+                )
+                fetch_full_history(args.coin)
+            elif args.all:
                 addlog(
                     f"[BOT][FETCH][ALL] coin={args.coin} → full Binance history",
                     verbose_int=1,

--- a/settings/settings.json
+++ b/settings/settings.json
@@ -51,6 +51,21 @@
       }
     }
   },
+  "jackpot": {
+    "enabled": true,
+    "start_level_frac": 0.50,
+    "take_profit_frac": 0.75,
+    "exit_on_new_ath": true,
+    "drip_period_hours": 168,
+    "base_drip_usd": 10.0,
+    "multiplier_floor": 2.0,
+    "invest_only_from_realized_profits": true,
+    "profit_invest_fraction": 1.0,
+    "min_order_usd": 5.0,
+    "fee_bps": 10,
+    "ath_scope": "dataset",
+    "fetch_full_history": false
+  },
   "general_settings": {
     "max_note_usdt": 1000.0,
     "minimum_note_size": 10

--- a/systems/live_engine.py
+++ b/systems/live_engine.py
@@ -15,10 +15,11 @@ from systems.scripts.evaluate_buy import evaluate_buy
 from systems.scripts.evaluate_sell import evaluate_sell
 from systems.scripts.runtime_state import build_runtime_state
 from systems.scripts.trade_apply import apply_sell_result_to_ledger
-from systems.scripts.execution_handler import execute_sell, process_buy_signal
+from systems.scripts.execution_handler import execute_sell, process_buy_signal, execute_buy
 from systems.utils.addlog import addlog
 from systems.utils.config import load_settings, resolve_path
 from systems.utils.resolve_symbol import split_tag
+from systems.scripts import strategy_jackpot
 
 
 def _run_iteration(settings, runtime_states, *, dry: bool, verbose: int) -> None:
@@ -72,8 +73,74 @@ def _run_iteration(settings, runtime_states, *, dry: bool, verbose: int) -> None
             prev=prev,
         )
         runtime_states[name] = state
+        jackpot_cfg = settings.get("jackpot", {})
+        if jackpot_cfg.get("enabled"):
+            first_ts = int(df[ts_col].iloc[0]) if len(df) else 0
+            state["jackpot_state"] = state.get("jackpot_state") or strategy_jackpot.init_state(
+                ledger_cfg.get("tag", ""), ledger_obj, jackpot_cfg, first_ts
+            )
 
         price = float(df.iloc[t]["close"])
+
+        jackpot_cfg = settings.get("jackpot", {})
+        if jackpot_cfg.get("enabled"):
+            j_state = state.get("jackpot_state")
+            ath, atl = strategy_jackpot.update_reference_levels(
+                df, jackpot_cfg.get("ath_scope", "dataset")
+            )
+            j_state["ath_price"], j_state["atl_price"] = ath, atl
+            realized = sum(n.get("gain", 0.0) for n in ledger_obj.get_closed_notes())
+            realized += j_state.get("realized_pnl", 0.0)
+            now_ts = int(df.iloc[t][ts_col])
+            sell_sig = strategy_jackpot.evaluate_sell(j_state, price, jackpot_cfg)
+            if sell_sig and sell_sig.get("qty", 0) > 0:
+                result = execute_sell(
+                    None,
+                    pair_code=ledger_cfg["kraken_pair"],
+                    coin_amount=sell_sig.get("qty", 0.0),
+                    price=price,
+                    ledger_name=ledger_cfg["tag"],
+                    verbose=state.get("verbose", 0),
+                )
+                if result and not result.get("error"):
+                    strategy_jackpot.apply_fills(
+                        j_state,
+                        [
+                            {
+                                **sell_sig,
+                                "price": result.get("avg_price", price),
+                                "usd": result.get("avg_price", price)
+                                * result.get("filled_amount", 0.0),
+                                "timestamp": now_ts,
+                            }
+                        ],
+                    )
+            else:
+                buy_sig = strategy_jackpot.evaluate_buy(
+                    j_state, price, now_ts, realized, jackpot_cfg
+                )
+                if buy_sig:
+                    result = execute_buy(
+                        None,
+                        pair_code=ledger_cfg["kraken_pair"],
+                        price=price,
+                        amount_usd=buy_sig.get("usd", 0.0),
+                        ledger_name=ledger_cfg["tag"],
+                        wallet_code=ledger_cfg.get("wallet_code", ""),
+                        verbose=state.get("verbose", 0),
+                    )
+                    if result and not result.get("error"):
+                        strategy_jackpot.apply_fills(
+                            j_state,
+                            [
+                                {
+                                    **buy_sig,
+                                    "price": result.get("avg_price", price),
+                                    "timestamp": now_ts,
+                                }
+                            ],
+                        )
+
         for window_name, wcfg in window_settings.items():
             ctx = {"ledger": ledger_obj}
             buy_res = evaluate_buy(
@@ -134,6 +201,7 @@ def run_live(*, dry: bool = False, verbose: int = 0) -> None:
 
     # Clear any stale buy unlock gates on startup
     for name, ledger_cfg in settings.get("ledger_settings", {}).items():
+        ledger_obj = Ledger.load_ledger(name, tag=ledger_cfg["tag"])
         state = build_runtime_state(
             settings,
             ledger_cfg,
@@ -141,9 +209,13 @@ def run_live(*, dry: bool = False, verbose: int = 0) -> None:
             prev={"verbose": verbose},
         )
         state["buy_unlock_p"] = {}
+        jackpot_cfg = settings.get("jackpot", {})
+        if jackpot_cfg.get("enabled"):
+            state["jackpot_state"] = strategy_jackpot.init_state(
+                ledger_cfg.get("tag", ""), ledger_obj, jackpot_cfg, 0
+            )
         runtime_states[name] = state
 
-        ledger_obj = Ledger.load_ledger(name, tag=ledger_cfg["tag"])
         open_notes = ledger_obj.get_open_notes()
         total = len(open_notes)
         per_window: Dict[str, int] = {}

--- a/systems/scripts/candle_utils.py
+++ b/systems/scripts/candle_utils.py
@@ -1,0 +1,39 @@
+"""Helper utilities for working with candle data."""
+
+from __future__ import annotations
+
+import pandas as pd
+from pathlib import Path
+from typing import Tuple
+
+from systems.utils.config import resolve_path
+
+
+def compute_ath_atl(df: pd.DataFrame) -> Tuple[float | None, float | None]:
+    """Return the all-time high and low for ``df``.
+
+    The dataframe is expected to contain a ``close`` column. ``None`` is
+    returned for both values when ``df`` is empty.
+    """
+    if df is None or df.empty:
+        return None, None
+    ath = float(df["close"].max())
+    atl = float(df["close"].min())
+    return ath, atl
+
+
+def load_full_history(coin: str) -> pd.DataFrame | None:
+    """Load a pre-fetched full-history file for ``coin`` if it exists.
+
+    The file is expected at ``data/raw/<COIN>_full.csv`` relative to the
+    repository root. ``None`` is returned when the file is missing or could not
+    be parsed.
+    """
+    root = resolve_path("")
+    path = root / "data" / "raw" / f"{coin.upper()}_full.csv"
+    if not path.exists():
+        return None
+    try:
+        return pd.read_csv(path)
+    except Exception:
+        return None

--- a/systems/scripts/strategy_jackpot.py
+++ b/systems/scripts/strategy_jackpot.py
@@ -1,0 +1,174 @@
+"""Simple self-funded jackpot DCA strategy."""
+
+from __future__ import annotations
+
+from typing import Dict, Optional, Tuple
+
+import pandas as pd
+
+from .candle_utils import compute_ath_atl
+
+
+# ---------------------------------------------------------------------------
+# State helpers
+# ---------------------------------------------------------------------------
+
+
+def init_state(tag: str, ledger, settings: Dict, now_ts: int) -> Dict:
+    """Return initial state for a jackpot strategy instance."""
+    return {
+        "last_drip_ts": None,
+        "total_contributed_usd": 0.0,
+        "inventory_qty": 0.0,
+        "avg_entry_price": None,
+        "ath_price": None,
+        "atl_price": None,
+        "realized_pnl": 0.0,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Reference levels
+# ---------------------------------------------------------------------------
+
+
+def update_reference_levels(
+    candles_df: pd.DataFrame,
+    scope: str,
+    full_history_df: Optional[pd.DataFrame] = None,
+) -> Tuple[float | None, float | None]:
+    """Return the ATH and ATL depending on ``scope``.
+
+    Parameters
+    ----------
+    candles_df:
+        Dataframe of the current in-memory dataset.
+    scope:
+        Either ``"dataset"`` or ``"full_history"``. When ``"full_history"`` is
+        requested ``full_history_df`` is used if provided; otherwise the
+        function falls back to ``candles_df``.
+    full_history_df:
+        Optional dataframe representing the full history of the asset.
+    """
+    if scope == "full_history" and full_history_df is not None:
+        return compute_ath_atl(full_history_df)
+    return compute_ath_atl(candles_df)
+
+
+# ---------------------------------------------------------------------------
+# Core math utilities
+# ---------------------------------------------------------------------------
+
+
+def eligibility(price: float, ath: float, atl: float, start_frac: float) -> Tuple[bool, float]:
+    """Determine if current ``price`` is eligible for dripping and return
+    position ``pos`` in [0,1]."""
+    if ath is None or atl is None or ath <= 0 or atl >= ath:
+        return False, 0.0
+    start_line = ath * start_frac
+    if price > start_line:
+        return False, 0.0
+    p_clamped = max(min(price, start_line), atl)
+    pos = (start_line - p_clamped) / (start_line - atl) if start_line > atl else 0.0
+    return True, pos
+
+
+def compute_drip_usd(
+    cfg: Dict,
+    state: Dict,
+    realized_pnl_available: float,
+    pos: float,
+) -> float:
+    base = cfg.get("base_drip_usd", 0.0)
+    mult = 1.0 + pos * (cfg.get("multiplier_floor", 1.0) - 1.0)
+    desired = base * mult
+
+    if cfg.get("invest_only_from_realized_profits", True):
+        contributed = state.get("total_contributed_usd", 0.0)
+        budget = max(0.0, realized_pnl_available - contributed)
+        desired = min(desired * cfg.get("profit_invest_fraction", 1.0), budget)
+
+    fee_bps = cfg.get("fee_bps", 0)
+    fee_buffer = desired * fee_bps / 10000
+    min_order = cfg.get("min_order_usd", 0.0) + fee_buffer
+    if desired < min_order:
+        return 0.0
+    return desired
+
+
+def maybe_drip(now_ts: int, last_drip_ts: Optional[int], period_hours: float) -> bool:
+    if last_drip_ts is None:
+        return True
+    return (now_ts - last_drip_ts) >= period_hours * 3600
+
+
+# ---------------------------------------------------------------------------
+# Signal evaluation
+# ---------------------------------------------------------------------------
+
+
+def evaluate_buy(
+    state: Dict,
+    price: float,
+    now_ts: int,
+    realized_pnl_available: float,
+    cfg: Dict,
+) -> Optional[Dict]:
+    ath = state.get("ath_price")
+    atl = state.get("atl_price")
+    eligible, pos = eligibility(price, ath, atl, cfg.get("start_level_frac", 0.5))
+    if not eligible:
+        return None
+    if not maybe_drip(now_ts, state.get("last_drip_ts"), cfg.get("drip_period_hours", 0)):
+        return None
+    usd = compute_drip_usd(cfg, state, realized_pnl_available, pos)
+    if usd <= 0:
+        return None
+    qty = usd / price if price > 0 else 0.0
+    return {"type": "BUY", "qty": qty, "usd": usd, "reason": f"jackpot_drip pos={pos:.2f}"}
+
+
+def evaluate_sell(state: Dict, price: float, cfg: Dict) -> Optional[Dict]:
+    ath = state.get("ath_price")
+    if ath is None or state.get("inventory_qty", 0.0) <= 0:
+        return None
+    take_frac = cfg.get("take_profit_frac", 0.75)
+    exit_new_ath = cfg.get("exit_on_new_ath", True)
+    if price >= take_frac * ath or (exit_new_ath and price > ath):
+        return {
+            "type": "SELL_ALL",
+            "qty": state.get("inventory_qty", 0.0),
+            "reason": "jackpot_take_profit",
+        }
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Fill application
+# ---------------------------------------------------------------------------
+
+
+def apply_fills(state: Dict, fills: list[Dict]) -> None:
+    for fill in fills:
+        ftype = fill.get("type")
+        if ftype == "BUY":
+            qty = float(fill.get("qty", 0.0))
+            usd = float(fill.get("usd", 0.0))
+            price = float(fill.get("price", 0.0))
+            inv = state.get("inventory_qty", 0.0)
+            total_cost = (state.get("avg_entry_price", 0.0) or 0.0) * inv
+            total_cost += price * qty
+            inv += qty
+            state["inventory_qty"] = inv
+            state["avg_entry_price"] = total_cost / inv if inv > 0 else None
+            state["total_contributed_usd"] = state.get("total_contributed_usd", 0.0) + usd
+            state["last_drip_ts"] = fill.get("timestamp")
+        elif ftype == "SELL_ALL":
+            qty = float(fill.get("qty", 0.0))
+            price = float(fill.get("price", 0.0))
+            avg = state.get("avg_entry_price", 0.0) or 0.0
+            pnl = (price - avg) * qty
+            state["realized_pnl"] = state.get("realized_pnl", 0.0) + pnl
+            state["inventory_qty"] = 0.0
+            state["avg_entry_price"] = None
+            # total_contributed_usd intentionally not reset


### PR DESCRIPTION
## Summary
- add configurable jackpot drip strategy with ATH/ATL scaling
- support optional full-history fetch via `--full-history`
- wire jackpot logic into sim and live engines

## Testing
- `python -m py_compile settings/settings.json systems/scripts/candle_utils.py systems/scripts/strategy_jackpot.py systems/fetch.py bot.py systems/sim_engine.py systems/live_engine.py`


------
https://chatgpt.com/codex/tasks/task_e_689c947ae1b4832688023720c0ef3557