### PR TITLE
Add jackpot metrics to hourly scripts

### DIFF
--- a/systems/scripts/handle_top_of_hour.py
+++ b/systems/scripts/handle_top_of_hour.py
@@ -346,6 +346,29 @@ def handle_top_of_hour(
             ledger.set_metadata(metadata)
             save_ledger(ledger_name, ledger, tag=ledger_cfg["tag"])
 
+            jackpot_path = root / "data" / "tmp" / "jackpot.json"
+            if jackpot_path.exists():
+                with jackpot_path.open("r") as jfile:
+                    jackpot_state = json.load(jfile)
+            else:
+                jackpot_state = {}
+            pool_usd = float(jackpot_state.get("pool_usd", 0.0))
+            drips = float(jackpot_state.get("drips", 0.0))
+            buys = int(jackpot_state.get("buys", 0))
+            sells = int(jackpot_state.get("sells", 0))
+            coin_value = sum(
+                n.get("entry_amount", 0.0) * price
+                for n in ledger.get_open_notes()
+                if n.get("kind") == "jackpot"
+            )
+            strategy_summary["jackpot"] = {
+                "pool": pool_usd,
+                "coin_value": coin_value,
+                "drips": drips,
+                "buys": buys,
+                "sells": sells,
+            }
+
             usd_balance = float(balance.get(quote, 0.0))
             coin_balance = float(balance.get(wallet_code, 0.0))
             coin_balance_usd = coin_balance * price

--- a/systems/scripts/send_top_hour_report.py
+++ b/systems/scripts/send_top_hour_report.py
@@ -93,11 +93,16 @@ def send_top_hour_report(
 
     jackpot = strategy_summary.get("jackpot")
     if jackpot:
+        pool = float(jackpot.get("pool", 0.0))
+        coin_value = float(jackpot.get("coin_value", 0.0))
+        total_jackpot = pool + coin_value
         lines.append(
             " ".join(
                 [
                     "🎰 Jackpot",
-                    f"| Pool: ${jackpot.get('pool', 0.0):.2f}",
+                    f"| Pool: ${pool:.2f}",
+                    f"| Coin: ${coin_value:.2f}",
+                    f"| Total: ${total_jackpot:.2f}",
                     f"| Drips: +${jackpot.get('drips', 0.0):.2f}",
                     f"| Buys: {jackpot.get('buys', 0)}",
                     f"| Sells: {jackpot.get('sells', 0)}",


### PR DESCRIPTION
## Summary
- Track jackpot pool and coin values during hourly processing and expose these stats in the strategy summary.
- Show pool, coin value, and their total in the top-of-hour report along with existing jackpot metrics.

## Testing
- `python -m py_compile systems/scripts/handle_top_of_hour.py systems/scripts/send_top_hour_report.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689cfa5e07c88326a358229ecb4c64e0