### PR TITLE
Simplify fetch mode and implement direct exchange fetchers

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -50,7 +50,7 @@ def main(argv: list[str] | None = None) -> None:
             )
 
     if mode == "fetch":
-        run_fetch(args.ledger, lookback=args.time)
+        run_fetch(args.ledger)
     elif mode == "sim":
         if not args.ledger:
             addlog("Error: --ledger is required for sim mode")

--- a/systems/fetch.py
+++ b/systems/fetch.py
@@ -2,26 +2,25 @@ from __future__ import annotations
 
 """CLI helpers for candle fetching."""
 
-import sys
+import os
 from pathlib import Path
+import sys
 
 if __package__ is None or __package__ == "":
     sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 from systems.utils.addlog import addlog
 from systems.utils.config import load_settings
-from systems.scripts.candle_refresh import refresh_to_last_closed_hour
+from systems.utils.resolve_symbol import resolve_ccxt_symbols
+from systems.scripts.candle_cache import tag_from_symbol, live_path_csv, sim_path_csv
+from systems.scripts.fetch_candles import (
+    fetch_binance_full_history_1h,
+    fetch_kraken_last_n_hours_1h,
+)
 
 
-def _parse_lookback(value: str) -> int:
-    value = value.strip().lower()
-    if value.endswith("h"):
-        value = value[:-1]
-    return int(value)
-
-
-def run_fetch(ledger: str | None, *, lookback: str | None) -> None:
-    """Fetch missing candles for ``ledger`` within ``lookback`` hours."""
+def run_fetch(ledger: str | None) -> None:
+    """Fetch candles for ``ledger`` from Binance (SIM) and Kraken (LIVE)."""
 
     if not ledger:
         addlog(
@@ -31,15 +30,6 @@ def run_fetch(ledger: str | None, *, lookback: str | None) -> None:
         )
         raise SystemExit(1)
 
-    if not lookback:
-        addlog(
-            "Error: --time is required for fetch mode",
-            verbose_int=1,
-            verbose_state=True,
-        )
-        raise SystemExit(1)
-
-    hours = _parse_lookback(lookback)
     settings = load_settings()
     ledger_cfg = settings.get("ledger_settings", {}).get(ledger)
     if not ledger_cfg:
@@ -50,11 +40,54 @@ def run_fetch(ledger: str | None, *, lookback: str | None) -> None:
         )
         raise SystemExit(1)
 
-    tag = ledger_cfg.get("tag")
+    kraken_symbol, binance_symbol = resolve_ccxt_symbols(settings, ledger)
+
+    if "/" not in kraken_symbol:
+        addlog(
+            f"[ERROR] Kraken symbol missing '/' : {kraken_symbol}",
+            verbose_int=1,
+            verbose_state=True,
+        )
+        raise SystemExit(1)
+    if "/" in binance_symbol:
+        addlog(
+            f"[ERROR] Binance symbol must not contain '/' : {binance_symbol}",
+            verbose_int=1,
+            verbose_state=True,
+        )
+        raise SystemExit(1)
+
+    tag = tag_from_symbol(kraken_symbol)
+
+    # Binance full history -> SIM
+    df_sim = fetch_binance_full_history_1h(binance_symbol)
+    sim_path = sim_path_csv(tag)
+    tmp_sim = sim_path + ".tmp"
+    os.makedirs(os.path.dirname(sim_path), exist_ok=True)
+    df_sim.to_csv(tmp_sim, index=False)
+    os.replace(tmp_sim, sim_path)
     addlog(
-        f"[BOT][FETCH] ledger={ledger} tag={tag} lookback={hours}h",
+        f"[FETCH][SIM] source=binance symbol={binance_symbol} tag={tag} rows={len(df_sim)} path={sim_path}",
         verbose_int=1,
         verbose_state=True,
     )
-    refresh_to_last_closed_hour(settings, tag, lookback_hours=hours, exchange="kraken")
 
+    # Kraken last 720 -> LIVE
+    df_live = fetch_kraken_last_n_hours_1h(kraken_symbol, n=720)
+    live_path = live_path_csv(tag)
+    tmp_live = live_path + ".tmp"
+    os.makedirs(os.path.dirname(live_path), exist_ok=True)
+    df_live.to_csv(tmp_live, index=False)
+    os.replace(tmp_live, live_path)
+    rows = len(df_live)
+    if rows < 720:
+        addlog(
+            f"[FETCH][LIVE][WARN] source=kraken symbol={kraken_symbol} returned {rows} rows (<720)",
+            verbose_int=1,
+            verbose_state=True,
+        )
+    addlog(
+        f"[FETCH][LIVE] source=kraken symbol={kraken_symbol} tag={tag} rows={rows} path={live_path}",
+        verbose_int=1,
+        verbose_state=True,
+    )

--- a/systems/scripts/fetch_candles.py
+++ b/systems/scripts/fetch_candles.py
@@ -137,6 +137,23 @@ def fetch_candles(symbol: str, start: int, end: int, source: str) -> pd.DataFram
     return _rows_to_df(rows, start, end)
 
 
+def fetch_binance_full_history_1h(symbol: str) -> pd.DataFrame:
+    """Return all available Binance 1h candles for ``symbol``."""
+    now = int(time.time())
+    end_ts = (now // 3600 - 1) * 3600
+    rows = _fetch_binance(symbol, 0, end_ts * 1000)
+    return _rows_to_df(rows, 0, end_ts)
+
+
+def fetch_kraken_last_n_hours_1h(symbol: str, n: int = 720) -> pd.DataFrame:
+    """Return up to ``n`` latest Kraken 1h candles for ``symbol``."""
+    now = int(time.time())
+    end_ts = (now // 3600 - 1) * 3600
+    start_ts = end_ts - (n - 1) * 3600
+    rows = _fetch_kraken(symbol, start_ts * 1000, end_ts * 1000)
+    return _rows_to_df(rows, start_ts, end_ts)
+
+
 def load_coin_csv(coin: str) -> pd.DataFrame:
     """Load historical candles for ``coin`` from ``data/raw``."""
 

--- a/systems/utils/cli.py
+++ b/systems/utils/cli.py
@@ -14,10 +14,6 @@ def build_parser() -> argparse.ArgumentParser:
         help="Ledger name defined in settings.json",
     )
     parser.add_argument(
-        "--time",
-        help="Lookback window for fetch mode (e.g., 72h)",
-    )
-    parser.add_argument(
         "--dry",
         action="store_true",
         help="Run live mode once immediately and exit",

--- a/systems/utils/resolve_symbol.py
+++ b/systems/utils/resolve_symbol.py
@@ -25,6 +25,15 @@ def resolve_symbol(tag: str) -> dict:
     }
 
 
+def resolve_ccxt_symbols(settings: dict, ledger: str) -> tuple[str, str]:
+    """Return Kraken and Binance symbols for ``ledger`` from ``settings``."""
+    ledgers = settings.get("ledger_settings", {})
+    if ledger not in ledgers:
+        raise ValueError(f"Ledger '{ledger}' not found in settings")
+    cfg = ledgers[ledger]
+    return cfg.get("kraken_name", ""), cfg.get("binance_name", "")
+
+
 def split_tag(tag: str) -> tuple[str, str]:
     """Return base symbol and Kraken quote asset code for ``tag``.
 


### PR DESCRIPTION
## Summary
- Drop `--time` option from CLI and bot fetch mode
- Implement dedicated fetch command to pull full Binance history and 720h Kraken slice with atomic writes
- Add helpers for resolving exchange symbols and fetching candles from each source

## Testing
- `python bot.py --help`
- `python -m py_compile bot.py systems/fetch.py systems/utils/cli.py systems/scripts/fetch_candles.py systems/utils/resolve_symbol.py systems/scripts/candle_cache.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689deb31d3f48326bdce6f27ee80a379