### PR TITLE
Use pre-fetched CSV data for sim and live modes

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -58,6 +58,7 @@ def main(argv: list[str] | None = None) -> None:
         run_simulation(ledger=args.ledger, verbose=args.verbose)
     elif mode == "live":
         run_live(
+            ledger=args.ledger,
             dry=args.dry,
             verbose=args.verbose,
         )

--- a/systems/fetch.py
+++ b/systems/fetch.py
@@ -11,8 +11,12 @@ if __package__ is None or __package__ == "":
 
 from systems.utils.addlog import addlog
 from systems.utils.config import load_settings
-from systems.utils.resolve_symbol import resolve_ccxt_symbols
-from systems.scripts.candle_cache import tag_from_symbol, live_path_csv, sim_path_csv
+from systems.utils.resolve_symbol import (
+    resolve_ccxt_symbols,
+    to_tag,
+    live_path_csv,
+    sim_path_csv,
+)
 from systems.scripts.fetch_candles import (
     fetch_binance_full_history_1h,
     fetch_kraken_last_n_hours_1h,
@@ -57,7 +61,7 @@ def run_fetch(ledger: str | None) -> None:
         )
         raise SystemExit(1)
 
-    tag = tag_from_symbol(kraken_symbol)
+    tag = to_tag(kraken_symbol)
 
     # Binance full history -> SIM
     df_sim = fetch_binance_full_history_1h(binance_symbol)

--- a/systems/scripts/candle_refresh.py
+++ b/systems/scripts/candle_refresh.py
@@ -95,6 +95,6 @@ def refresh_to_last_closed_hour(
     """Deprecated helper retained for legacy scripts."""
 
     raise RuntimeError(
-        "refresh_to_last_closed_hour is deprecated; use hard_refresh_live_720 from candle_cache"
+        "refresh_to_last_closed_hour is deprecated; use refresh_live_kraken_720 from candle_cache"
     )
 

--- a/systems/utils/resolve_symbol.py
+++ b/systems/utils/resolve_symbol.py
@@ -34,6 +34,21 @@ def resolve_ccxt_symbols(settings: dict, ledger: str) -> tuple[str, str]:
     return cfg.get("kraken_name", ""), cfg.get("binance_name", "")
 
 
+def to_tag(symbol: str) -> str:
+    """Normalize exchange symbol to uppercase tag without separators."""
+    return symbol.replace("/", "").replace(" ", "").upper()
+
+
+def sim_path_csv(tag: str) -> str:
+    """Return canonical SIM CSV path for ``tag``."""
+    return f"data/sim/{tag}_1h.csv"
+
+
+def live_path_csv(tag: str) -> str:
+    """Return canonical LIVE CSV path for ``tag``."""
+    return f"data/live/{tag}_1h.csv"
+
+
 def split_tag(tag: str) -> tuple[str, str]:
     """Return base symbol and Kraken quote asset code for ``tag``.
 


### PR DESCRIPTION
## Summary
- standardize `to_tag`, `sim_path_csv`, and `live_path_csv` helpers
- read sim candles strictly from `data/sim/{TAG}_1h.csv` and log stats
- drive live mode from `data/live/{TAG}_1h.csv` with cached sim highs/lows
- add hourly Kraken refresh with cross-process lock and meta tracking

## Testing
- `python bot.py --mode fetch --ledger Kris_Ledger` *(fails: Network is unreachable)*
- `python bot.py --mode sim --ledger Kris_Ledger -vv` *(fails: Missing data file)*
- `python bot.py --mode live --ledger Kris_Ledger -vv --dry` *(fails: Missing kraken.yaml)*

------
https://chatgpt.com/codex/tasks/task_e_689df16877fc8326a1dd16d200e737a6