### PR TITLE
Add optional time window for simulations

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -16,6 +16,10 @@ from systems.utils.cli import build_parser
 
 def main(argv: list[str] | None = None) -> None:
     parser = build_parser()
+    parser.add_argument(
+        "--time",
+        help="Optional start time for simulation (e.g. '3m' or '2023-01-01')",
+    )
 
     args = parser.parse_args(argv or sys.argv[1:])
     if not args.mode:
@@ -55,7 +59,11 @@ def main(argv: list[str] | None = None) -> None:
         if not args.ledger:
             addlog("Error: --ledger is required for sim mode")
             sys.exit(1)
-        run_simulation(ledger=args.ledger, verbose=args.verbose)
+        run_simulation(
+            ledger=args.ledger,
+            verbose=args.verbose,
+            time_window=args.time,
+        )
     elif mode == "live":
         run_live(
             ledger=args.ledger,


### PR DESCRIPTION
## Summary
- add `--time` CLI flag for simulations to specify a relative or absolute start time
- slice candle data in `run_simulation` based on provided window using existing time parser
- log effective window and abort when no candles meet the cutoff

## Testing
- `python -m py_compile bot.py systems/sim_engine.py`
- `python bot.py --help`
- `python bot.py --mode sim --ledger Kris_Ledger --time 2100-01-01`
- `python bot.py --mode sim --ledger Kris_Ledger --time 3m`


------
https://chatgpt.com/codex/tasks/task_e_689e14fb56188326bdf76e6d6e817c37