### PR TITLE
feat: add sliding candle stepper

### DIFF
--- a/math_modules/atr_ratio.py
+++ b/math_modules/atr_ratio.py
@@ -1,0 +1,16 @@
+"""ATR(5) over ATR(20) ratio."""
+
+from __future__ import annotations
+
+import pandas as pd
+
+NAME = "atr_ratio"
+LOOKBACK = 20
+
+
+def calculate(df: pd.DataFrame, i: int) -> dict[str, float | None]:
+    atr5 = df["atr_5"].iloc[i] if "atr_5" in df.columns else None
+    atr20 = df["atr_20"].iloc[i] if "atr_20" in df.columns else None
+    if atr5 is None or atr20 in (0, None):
+        return {"atr_ratio": None}
+    return {"atr_ratio": float(atr5 / atr20) if atr20 else None}

--- a/math_modules/short_slope.py
+++ b/math_modules/short_slope.py
@@ -1,0 +1,16 @@
+"""Mean percent change of last 5 closes."""
+
+from __future__ import annotations
+
+import pandas as pd
+
+NAME = "short_slope"
+LOOKBACK = 5
+
+
+def calculate(df: pd.DataFrame, i: int) -> dict[str, float | None]:
+    closes = df["close"].iloc[i - 4 : i + 1]
+    if len(closes) < 5:
+        return {"slope": None}
+    pct = closes.pct_change().dropna()
+    return {"slope": float(pct.mean())}

--- a/tools/_stepper_io.py
+++ b/tools/_stepper_io.py
@@ -1,0 +1,81 @@
+"""CSV loading and path resolution helpers for candle stepper."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+import pandas as pd
+
+# Base directories relative to repo root
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SIM_DIR = REPO_ROOT / "data" / "sim"
+RAW_DIR = REPO_ROOT / "data" / "raw"
+
+
+def resolve_csv(tag: Optional[str] = None, csv: Optional[str] = None) -> Path:
+    """Resolve a CSV path from a tag or explicit path.
+
+    Precedence: explicit ``csv`` argument > ``SIM_DIR`` > ``RAW_DIR``.
+    ``tag`` should not include an extension.  When ``csv`` is provided the
+    path is interpreted relative to the repository root.
+    """
+
+    attempted: list[Path] = []
+
+    if csv:
+        path = (REPO_ROOT / csv.lstrip("/")).resolve()
+        if path.exists():
+            return path
+        attempted.append(path)
+        raise FileNotFoundError(
+            f"CSV not found at {path}. Provide a valid path with --csv.")
+
+    if tag:
+        path = (SIM_DIR / f"{tag}.csv").resolve()
+        if path.exists():
+            return path
+        attempted.append(path)
+
+        path = (RAW_DIR / f"{tag}.csv").resolve()
+        if path.exists():
+            return path
+        attempted.append(path)
+
+    attempted_str = "\n".join(str(p) for p in attempted)
+    raise FileNotFoundError(
+        f"Could not locate CSV for tag '{tag}'. Tried:\n{attempted_str}\n"
+        "Use --csv <path> to specify a file explicitly.")
+
+
+def read_candles(csv_path: Path) -> pd.DataFrame:
+    """Read and normalize candle data from ``csv_path``.
+
+    Columns are lower-cased with timestamp synonyms normalised.
+    Required columns: timestamp, open, high, low, close.  Volume is optional.
+    Timestamps are parsed in UTC, invalid rows dropped, sorted and reindexed.
+    """
+
+    df = pd.read_csv(
+        csv_path,
+        engine="python",
+        on_bad_lines="skip",
+        skip_blank_lines=True,
+    )
+
+    df.columns = [c.strip().lower() for c in df.columns]
+    rename_map = {c: "timestamp" for c in ["timestamp", "time", "date"] if c in df.columns}
+    df = df.rename(columns=rename_map)
+
+    required = {"timestamp", "open", "high", "low", "close"}
+    missing = required - set(df.columns)
+    if missing:
+        sample_cols = ", ".join(list(df.columns)[:3])
+        raise ValueError(
+            f"Missing required columns: {missing}. First columns: {sample_cols}")
+
+    df["timestamp"] = pd.to_datetime(df["timestamp"], utc=True, errors="coerce")
+    df = df.dropna(subset=["timestamp"])
+    df = df.sort_values("timestamp").reset_index(drop=True)
+
+    return df

--- a/tools/candle_stepper.py
+++ b/tools/candle_stepper.py
@@ -1,123 +1,236 @@
-"""Interactive candlestick stepper with pluggable math modules."""
+"""Interactive sliding candlestick viewer with pluggable math modules."""
 
 from __future__ import annotations
 
 import argparse
+from dataclasses import dataclass
 import importlib.util
-import pathlib
-from typing import Callable, Dict
+from pathlib import Path
+from typing import Callable, List
 
-import pandas as pd
+import matplotlib.dates as mdates
 import matplotlib.pyplot as plt
-from matplotlib.widgets import Slider
+from matplotlib.patches import Rectangle
+from matplotlib.widgets import Button, Slider
+import pandas as pd
 
-try:
-    import mplfinance as mpf
-    HAS_MPLFINANCE = True
-except Exception:  # pragma: no cover - optional dependency
-    HAS_MPLFINANCE = False
+from _stepper_io import read_candles, resolve_csv
 
-MODULES_PATH = pathlib.Path(__file__).resolve().parent.parent / "math_modules"
-DEFAULT_WINDOW = 100
+MODULES_PATH = Path(__file__).resolve().parent.parent / "math_modules"
+DEFAULT_WINDOW = 200
 
 
-def load_modules() -> Dict[str, Callable[[pd.DataFrame, int], dict[str, float]]]:
-    """Dynamically import all calculate functions from math_modules."""
-    modules: Dict[str, Callable[[pd.DataFrame, int], dict[str, float]]] = {}
+@dataclass
+class Module:
+    name: str
+    lookback: int
+    func: Callable[[pd.DataFrame, int], dict[str, float | int | None]]
+
+
+def load_modules() -> List[Module]:
+    """Dynamically import all modules from math_modules/ directory."""
+    modules: List[Module] = []
     for path in MODULES_PATH.glob("*.py"):
         if path.name.startswith("_"):
             continue
         spec = importlib.util.spec_from_file_location(path.stem, path)
-        if spec and spec.loader:
-            module = importlib.util.module_from_spec(spec)
-            spec.loader.exec_module(module)
-            calc = getattr(module, "calculate", None)
-            if callable(calc):
-                modules[path.stem] = calc
+        if not spec or not spec.loader:
+            continue
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        name = getattr(module, "NAME", None)
+        lookback = getattr(module, "LOOKBACK", None)
+        calc = getattr(module, "calculate", None)
+        if name and isinstance(lookback, int) and callable(calc):
+            modules.append(Module(name, lookback, calc))
     return modules
 
 
-def standardize_columns(df: pd.DataFrame) -> pd.DataFrame:
-    """Ensure standard OHLCV column names and types."""
-    df = df.rename(columns={c: c.strip().lower() for c in df.columns})
-    df = df[["timestamp", "open", "high", "low", "close", "volume"]]
-    df["timestamp"] = pd.to_datetime(df["timestamp"])
+def precompute(df: pd.DataFrame) -> pd.DataFrame:
+    """Precompute rolling indicators used by modules."""
+    df["close_pct"] = df["close"].pct_change()
+    hl = df["high"] - df["low"]
+    hc = (df["high"] - df["close"].shift()).abs()
+    lc = (df["low"] - df["close"].shift()).abs()
+    tr = pd.concat([hl, hc, lc], axis=1).max(axis=1)
+    df["atr_5"] = tr.rolling(5).mean()
+    df["atr_20"] = tr.rolling(20).mean()
     return df
 
 
-def plot_segment(ax: plt.Axes, segment: pd.DataFrame, tag: str) -> None:
-    """Plot a candle segment on given axis."""
-    ax.clear()
-    if HAS_MPLFINANCE:
-        mpf.plot(
-            segment.set_index("timestamp"),
-            type="candle",
-            ax=ax,
-            style="yahoo",
-            warn_too_much_data=9999999,
-            show_nontrading=True,
-        )
-    else:  # fallback line plot
-        ax.plot(segment["timestamp"], segment["close"], color="black")
-    ax.set_title(f"{tag} @ index {segment.index[-1]}")
-
-
-def display_metrics(ax: plt.Axes, metrics: dict[str, float]) -> None:
+def display_metrics(ax: plt.Axes, metrics: dict[str, float | int | None]) -> None:
     """Render metric text items on the metrics axis."""
     ax.clear()
     ax.axis("off")
     for idx, (name, value) in enumerate(metrics.items()):
-        color = "green" if isinstance(value, (int, float)) and value >= 0 else "red"
         ax.text(
             0.01,
-            1 - idx * 0.1,
+            1 - idx * 0.07,
             f"{name}: {value}",
             transform=ax.transAxes,
             va="top",
             fontsize=9,
-            color=color,
         )
+
+
+class Candles:
+    """Maintain candle artists for fast updates."""
+
+    def __init__(self, ax: plt.Axes):
+        self.ax = ax
+        self.wicks: list[plt.Line2D] = []
+        self.bodies: list[Rectangle] = []
+        self.target_line = ax.axvline(0, color="grey", linestyle="--", visible=False)
+
+    def draw(self, df: pd.DataFrame) -> None:
+        while len(self.wicks) < len(df):
+            (line,) = self.ax.plot([], [], color="black")
+            rect = Rectangle((0, 0), 0, 0, edgecolor="black")
+            self.ax.add_patch(rect)
+            self.wicks.append(line)
+            self.bodies.append(rect)
+
+        xs = mdates.date2num(df["timestamp"].to_numpy())
+        width = (xs[1] - xs[0]) * 0.8 if len(xs) > 1 else 0.6
+
+        for i, row in enumerate(df.itertuples(index=False)):
+            x = xs[i]
+            open_, high, low, close = row.open, row.high, row.low, row.close
+            self.wicks[i].set_data([x, x], [low, high])
+            lower = min(open_, close)
+            height = abs(close - open_)
+            body = self.bodies[i]
+            body.set_xy((x - width / 2, lower))
+            body.set_width(width)
+            body.set_height(height if height != 0 else 0.001)
+            body.set_facecolor("green" if close >= open_ else "red")
+            body.set_visible(True)
+        for j in range(len(df), len(self.wicks)):
+            self.wicks[j].set_data([], [])
+            self.bodies[j].set_visible(False)
+
+        self.ax.set_xlim(xs[0], xs[-1])
+        self.ax.set_ylim(df["low"].min(), df["high"].max())
+
+    def mark_target(self, ts: pd.Timestamp | None) -> None:
+        if ts is None:
+            self.target_line.set_visible(False)
+        else:
+            x = mdates.date2num(ts)
+            self.target_line.set_xdata([x, x])
+            self.target_line.set_visible(True)
 
 
 def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("tag", help="Symbol tag corresponding to data/raw/<TAG>.csv")
-    parser.add_argument(
-        "--window", type=int, default=DEFAULT_WINDOW, help="Number of candles to display"
-    )
+    parser.add_argument("tag", nargs="?", help="Symbol tag or CSV path")
+    parser.add_argument("--csv", help="Direct CSV path")
+    parser.add_argument("--window", type=int, default=DEFAULT_WINDOW, help="Window size")
     args = parser.parse_args()
 
-    csv_path = pathlib.Path("data/sim") / f"{args.tag}.csv"
-    df = pd.read_csv(csv_path)
-    df = standardize_columns(df)
+    csv_path = resolve_csv(args.tag, args.csv)
+    print(f"Using CSV: {csv_path}")
+    df = read_candles(csv_path)
+    df = precompute(df)
 
     modules = load_modules()
 
-    fig = plt.figure(figsize=(10, 6))
+    fig = plt.figure(figsize=(12, 6))
     gs = fig.add_gridspec(2, 2, height_ratios=[4, 1], width_ratios=[3, 1])
     ax_candles = fig.add_subplot(gs[0, 0])
     ax_metrics = fig.add_subplot(gs[0, 1])
     ax_slider = fig.add_subplot(gs[1, 0])
     ax_metrics.axis("off")
 
-    slider = Slider(ax_slider, "Index", 0, len(df) - 1, valinit=args.window, valstep=1)
+    candles = Candles(ax_candles)
 
-    def update(val: float) -> None:
-        idx = int(val)
-        start = max(0, idx - args.window)
-        segment = df.iloc[start : idx + 1]
-        plot_segment(ax_candles, segment, args.tag)
-        metrics: dict[str, float] = {}
-        for name, fn in modules.items():
-            try:
-                metrics.update(fn(df, idx))
-            except Exception as exc:  # pragma: no cover - runtime errors
-                metrics[name] = f"error: {exc}"
+    max_index = len(df) - 2
+    slider = Slider(ax_slider, "Index", 0, max_index, valinit=min(args.window, max_index), valstep=1)
+
+    def update_idx(idx: int) -> None:
+        idx = max(0, min(int(idx), max_index))
+        slider.eventson = False
+        slider.set_val(idx)
+        slider.eventson = True
+        start = max(0, idx - args.window + 1)
+        view = df.iloc[start : idx + 1]
+        candles.draw(view)
+        target_ts = df["timestamp"].iloc[idx + 1] if idx + 1 < len(df) else None
+        candles.mark_target(target_ts)
+        metrics: dict[str, float | int | None] = {}
+        df_slice = df.iloc[: idx + 1]
+        for mod in modules:
+            if idx >= mod.lookback:
+                result = mod.func(df_slice, idx)
+                for k, v in result.items():
+                    metrics[f"{mod.name} {k}"] = v
+            else:
+                metrics[mod.name] = None
         display_metrics(ax_metrics, metrics)
         fig.canvas.draw_idle()
 
-    slider.on_changed(update)
-    update(slider.val)
+    def on_slider(val: float) -> None:
+        update_idx(int(round(val)))
+
+    slider.on_changed(on_slider)
+
+    # Buttons
+    btn_ax_play = fig.add_axes([0.55, 0.05, 0.05, 0.04])
+    btn_ax_back = fig.add_axes([0.61, 0.05, 0.05, 0.04])
+    btn_ax_fwd = fig.add_axes([0.67, 0.05, 0.05, 0.04])
+    btn_ax_bigback = fig.add_axes([0.73, 0.05, 0.05, 0.04])
+    btn_ax_bigfwd = fig.add_axes([0.79, 0.05, 0.05, 0.04])
+
+    btn_play = Button(btn_ax_play, "\u25B6")  # ▶
+    btn_back = Button(btn_ax_back, "\u23EE")  # ⏮
+    btn_fwd = Button(btn_ax_fwd, "\u23ED")  # ⏭
+    btn_bigback = Button(btn_ax_bigback, "\u23EA")  # ⏪
+    btn_bigfwd = Button(btn_ax_bigfwd, "\u23E9")  # ⏩
+
+    playing = {"value": False}
+    timer = fig.canvas.new_timer(interval=200)
+
+    def play_step() -> None:
+        if slider.val >= max_index:
+            playing["value"] = False
+            return
+        update_idx(int(slider.val) + 1)
+        if playing["value"]:
+            timer.start()
+
+    timer.add_callback(play_step)
+
+    def toggle_play(event) -> None:  # noqa: D401 - callback signature
+        playing["value"] = not playing["value"]
+        if playing["value"]:
+            timer.start()
+
+    def step(delta: int) -> None:
+        update_idx(int(slider.val) + delta)
+
+    btn_play.on_clicked(toggle_play)
+    btn_back.on_clicked(lambda event: step(-1))
+    btn_fwd.on_clicked(lambda event: step(1))
+    btn_bigback.on_clicked(lambda event: step(-args.window // 2))
+    btn_bigfwd.on_clicked(lambda event: step(args.window // 2))
+
+    def on_key(event) -> None:
+        if event.key == "left":
+            step(-1)
+        elif event.key == "right":
+            step(1)
+        elif event.key == "up":
+            step(args.window // 10)
+        elif event.key == "down":
+            step(-args.window // 10)
+        elif event.key == "home":
+            update_idx(0)
+        elif event.key == "end":
+            update_idx(max_index)
+
+    fig.canvas.mpl_connect("key_press_event", on_key)
+
+    update_idx(int(slider.val))
     plt.show()
 
 


### PR DESCRIPTION
## Summary
- add robust CSV resolver and loader for candle stepper
- implement sliding window viewer with play controls and plugin metrics
- provide sample math modules: short_slope and atr_ratio

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689e5d10814c83268c53e63f2a2defe4