### PR TITLE
Add rotating pattern evaluator with pluggable math signals

### DIFF
--- a/signal_modules/atr_spike.py
+++ b/signal_modules/atr_spike.py
@@ -1,0 +1,17 @@
+import pandas as pd
+
+NAME = "atr_spike"
+LOOKBACK = 20
+
+def calculate(df, i):
+    if i < LOOKBACK:
+        return 0
+    tr = pd.concat([
+        df["high"] - df["low"],
+        (df["high"] - df["close"].shift()).abs(),
+        (df["low"] - df["close"].shift()).abs(),
+    ], axis=1).max(axis=1)
+    atr = tr.rolling(14).mean()
+    if atr.iloc[i] > atr.rolling(50).mean().iloc[i] * 1.5:
+        return +1 if df["close"].iloc[i] > df["open"].iloc[i] else -1
+    return 0

--- a/signal_modules/ma_diff.py
+++ b/signal_modules/ma_diff.py
@@ -1,0 +1,13 @@
+NAME = "ma_diff"
+LOOKBACK = 10
+
+def calculate(df, i):
+    short_ma = df["close"].rolling(3).mean()
+    long_ma = df["close"].rolling(10).mean()
+    if i < LOOKBACK:
+        return 0
+    if short_ma.iloc[i] > long_ma.iloc[i]:
+        return +1
+    elif short_ma.iloc[i] < long_ma.iloc[i]:
+        return -1
+    return 0

--- a/signal_modules/wick_bias.py
+++ b/signal_modules/wick_bias.py
@@ -1,0 +1,16 @@
+NAME = "wick_bias"
+LOOKBACK = 1
+
+def calculate(df, i):
+    if i < 1:
+        return 0
+    high, low, close = df.loc[i, ["high", "low", "close"]]
+    if high == low:
+        return 0
+    upper_wick = high - close
+    lower_wick = close - low
+    if lower_wick / (high - low) > 0.66:
+        return +1
+    elif upper_wick / (high - low) > 0.66:
+        return -1
+    return 0

--- a/tools/pattern_eval.py
+++ b/tools/pattern_eval.py
@@ -1,0 +1,118 @@
+import argparse
+import importlib.util
+from pathlib import Path
+from typing import List, Dict
+
+try:  # Optional dependency
+    import numpy as np  # type: ignore
+except Exception:  # pragma: no cover - environment fallback
+    np = None
+import pandas as pd
+
+
+def load_data(csv_path: Path) -> pd.DataFrame:
+    df = pd.read_csv(csv_path, engine="python", on_bad_lines="skip")
+    df.columns = [c.strip().lower() for c in df.columns]
+    df["timestamp"] = pd.to_datetime(df["timestamp"], utc=True)
+    df = df[["timestamp", "open", "high", "low", "close", "volume"]]
+    df = df.dropna(subset=["close"]).reset_index(drop=True)
+    return df
+
+
+def load_signal_modules(mod_dir: Path) -> List[Dict]:
+    modules: List[Dict] = []
+    if not mod_dir.exists():
+        return modules
+    for path in mod_dir.glob("*.py"):
+        spec = importlib.util.spec_from_file_location(path.stem, path)
+        module = importlib.util.module_from_spec(spec)
+        try:
+            spec.loader.exec_module(module)  # type: ignore
+        except Exception as exc:  # pragma: no cover - best effort
+            print(f"Failed to load {path.name}: {exc}")
+            continue
+        if not hasattr(module, "calculate"):
+            continue
+        name = getattr(module, "NAME", path.stem)
+        lookback = getattr(module, "LOOKBACK", 0)
+        modules.append({"name": name, "lookback": lookback, "module": module})
+    return modules
+
+
+def evaluate(df: pd.DataFrame, modules: List[Dict], lookahead: int, chunk: int, min_fires: int):
+    results = []
+    total_candles = max(len(df) - lookahead, 1)
+    for info in modules:
+        name = info["name"]
+        mod = info["module"]
+        lookback = info["lookback"]
+        wins = 0
+        fires = 0
+        returns: List[float] = []
+        for start in range(0, len(df), chunk):
+            end = min(start + chunk, len(df))
+            chunk_df = df.iloc[:end]
+            for i in range(start, end - lookahead):
+                if i < lookback:
+                    continue
+                try:
+                    pred = mod.calculate(chunk_df, i)
+                except Exception:  # pragma: no cover - best effort
+                    pred = 0
+                if pred not in (1, -1):
+                    continue
+                future_close = chunk_df["close"].iloc[i + lookahead]
+                current_close = chunk_df["close"].iloc[i]
+                ret = (future_close - current_close) / current_close
+                if pred == -1:
+                    ret = -ret
+                returns.append(ret)
+                fires += 1
+                if ret > 0:
+                    wins += 1
+        if fires >= min_fires and fires > 0:
+            results.append(
+                {
+                    "name": name,
+                    "fires": fires,
+                    "hit_rate": wins / fires,
+                    "coverage": fires / total_candles,
+                    "avg_return": float(np.mean(returns)) if returns and np else (sum(returns) / len(returns) if returns else 0.0),
+                }
+            )
+    return results
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Evaluate signal modules on historical data")
+    parser.add_argument("--csv", required=True, help="Path to historical candle CSV")
+    parser.add_argument("--lookahead", required=True, type=int, help="Candles ahead to check result")
+    parser.add_argument("--chunk", type=int, default=500, help="Walk-forward chunk size")
+    parser.add_argument("--min-fires", type=int, default=1, help="Minimum predictions required")
+    args = parser.parse_args()
+
+    base_dir = Path(__file__).resolve().parent.parent
+    csv_path = Path(args.csv)
+    if not csv_path.is_absolute():
+        csv_path = base_dir / csv_path
+
+    df = load_data(csv_path)
+    modules = load_signal_modules(base_dir / "signal_modules")
+    if not modules:
+        print("No signal modules found")
+        return
+
+    results = evaluate(df, modules, args.lookahead, args.chunk, args.min_fires)
+    if not results:
+        print("No signals met criteria")
+        return
+
+    print(f"{'Signal':<12} {'Fires':>6} {'Hit%':>7} {'Coverage%':>11} {'AvgReturn%':>12}")
+    for r in sorted(results, key=lambda x: x["hit_rate"], reverse=True):
+        print(
+            f"{r['name']:<12} {r['fires']:>6} {r['hit_rate']*100:>6.1f} {r['coverage']*100:>11.1f} {r['avg_return']*100:>12.2f}"
+        )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add standalone `pattern_eval` CLI to score pluggable signal modules over historical candles
- provide example signal modules (`ma_diff`, `wick_bias`, `atr_spike`) loaded dynamically at runtime

## Testing
- `python -m py_compile tools/pattern_eval.py signal_modules/*.py`
- `python tools/pattern_eval.py --csv data/live/SOLUSDC_1h.csv --lookahead 3 --chunk 500 --min-fires 1` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `pip install pandas` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689e65a637d88326a52142ac81f42a21