### PR TITLE
feat: add slope-based trend evaluators

### DIFF
--- a/systems/scripts/evaluate_buy.py
+++ b/systems/scripts/evaluate_buy.py
@@ -1,11 +1,38 @@
 from __future__ import annotations
 
-"""Position-based buy evaluation."""
+"""Ultra-simple slope-based buy evaluator."""
 
+import os
 from typing import Dict, Any
 
-from systems.scripts.window_utils import get_window_bounds, check_buy_conditions
 from systems.utils.addlog import addlog
+
+
+# --- tuning constants -----------------------------------------------------
+
+LOOKBACK = int(os.environ.get("WS_LOOKBACK", 50))
+UP_TH = 0.02
+DOWN_TH = -0.01
+
+MIN_GAP_BARS = 5
+FLAT_BUY_MULT = 0.50
+UP_BUY_MULT = 1.00
+DOWN_BUY_MULT = 0.00
+
+
+def _slope_and_trend(series, t: int) -> tuple[float, str]:
+    """Return slope and trend classification for candle ``t``."""
+
+    close_now = float(series.iloc[t]["close"])
+    close_then = float(series.iloc[max(0, t - LOOKBACK)]["close"])
+    slope = (close_now - close_then) / max(close_then, 1e-9)
+    if slope >= UP_TH:
+        trend = "UP"
+    elif slope <= DOWN_TH:
+        trend = "DOWN"
+    else:
+        trend = "FLAT"
+    return slope, trend
 
 
 def evaluate_buy(
@@ -17,59 +44,20 @@ def evaluate_buy(
     cfg: Dict[str, Any],
     runtime_state: Dict[str, Any],
 ):
-    """Return sizing and metadata for a buy signal in ``window_name``.
+    """Return sizing and metadata for a buy signal in ``window_name``."""
 
-    Parameters
-    ----------
-    ctx:
-        Context dictionary containing at least a ``ledger`` instance.
-    t:
-        Current candle index within ``series``.
-    series:
-        Candle DataFrame with at least ``close``, ``low`` and ``high`` columns.
-    window_name:
-        Name of the window configuration under evaluation.
-    cfg:
-        Strategy configuration for ``window_name``.
-    runtime_state:
-        Mutable dictionary carrying ``capital`` and ``buy_unlock_p`` mapping.
-    """
-
-    ledger = ctx.get("ledger")
     verbose = runtime_state.get("verbose", 0)
 
-    candle = series.iloc[t]
-    win_low, win_high = get_window_bounds(series, t, cfg["window_size"])
-    window_data = {"low": win_low, "high": win_high}
+    slope, trend = _slope_and_trend(series, t)
 
-    open_notes = []
-    if ledger:
-        open_notes = [
-            n for n in ledger.get_open_notes() if n.get("window_name") == window_name
-        ]
-
-    ledger_state = {
-        "open_notes": open_notes,
-        "buy_unlock_p": runtime_state.setdefault("buy_unlock_p", {}),
-        "verbose": verbose,
-    }
-
-    ok, meta = check_buy_conditions(
-        candle,
-        window_data,
-        {**cfg, "window_name": window_name},
-        ledger_state,
-    )
-    if not ok:
-        return False
-
-    capital = runtime_state.get("capital", 0.0)
-    base = cfg.get("investment_fraction", 0.0)
-    size_usd = capital * base
-
+    capital = float(runtime_state.get("capital", 0.0))
     limits = runtime_state.get("limits", {})
     min_sz = float(limits.get("min_note_size", 0.0))
     max_sz = float(limits.get("max_note_usdt", float("inf")))
+
+    base = float(cfg.get("investment_fraction", 0.0))
+    mult = {"UP": UP_BUY_MULT, "FLAT": FLAT_BUY_MULT, "DOWN": DOWN_BUY_MULT}[trend]
+    size_usd = capital * base * mult
     raw = size_usd
     size_usd = min(size_usd, capital, max_sz)
     if raw != size_usd:
@@ -78,29 +66,33 @@ def evaluate_buy(
             verbose_int=2,
             verbose_state=verbose,
         )
-    if size_usd < min_sz:
-        addlog(
-            f"[SKIP][{window_name} {cfg['window_size']}] size=${size_usd:.2f} < min=${min_sz:.2f}",
-            verbose_int=2,
-            verbose_state=verbose,
-        )
-        return False
 
-    sz_pct = (size_usd / capital * 100) if capital else 0.0
+    last_key = f"last_buy_idx::{window_name}"
+    last_idx = int(runtime_state.get(last_key, -1))
+    cooldown_ok = (t - last_idx) >= MIN_GAP_BARS
+
+    decision: Dict[str, Any] | bool = False
+    if (
+        trend != "DOWN"
+        and cooldown_ok
+        and size_usd >= min_sz
+        and size_usd > 0.0
+    ):
+        decision = {
+            "size_usd": size_usd,
+            "window_name": window_name,
+            "window_size": cfg["window_size"],
+            "created_idx": t,
+        }
+        if "timestamp" in series.columns:
+            decision["created_ts"] = int(series.iloc[t]["timestamp"])
+        runtime_state[last_key] = t
 
     addlog(
-        f"[BUY][{window_name} {cfg['window_size']}] p={meta['p_buy']:.3f}, base={base*100:.2f}% → size={sz_pct:.2f}% (cap=${size_usd:.2f})",
+        f"[{ 'BUY' if decision else 'SKIP' }][{window_name} {cfg['window_size']}] trend={trend} slope={slope:.4f} mult={mult:.2f} size=${size_usd:.2f}",
         verbose_int=1,
         verbose_state=verbose,
     )
 
-    result = {
-        "size_usd": size_usd,
-        "window_name": window_name,
-        "window_size": cfg["window_size"],
-        **meta,
-    }
-    if "timestamp" in series.columns:
-        result["created_ts"] = int(candle["timestamp"])
-    result["created_idx"] = t
-    return result
+    return decision
+

--- a/systems/scripts/evaluate_sell.py
+++ b/systems/scripts/evaluate_sell.py
@@ -1,11 +1,36 @@
 from __future__ import annotations
 
-"""Price-target-based sell evaluation."""
+"""Ultra-simple slope/pressure-based sell evaluator."""
 
+import math
+import os
 from typing import Any, Dict, List
 
-from systems.scripts.window_utils import check_sell_conditions
 from systems.utils.addlog import addlog
+
+
+# --- tuning constants -----------------------------------------------------
+
+LOOKBACK = int(os.environ.get("WS_LOOKBACK", 50))
+UP_TH = 0.02
+DOWN_TH = -0.01
+
+
+def _slope_and_trend(series, t: int) -> tuple[float, str]:
+    close_now = float(series.iloc[t]["close"])
+    close_then = float(series.iloc[max(0, t - LOOKBACK)]["close"])
+    slope = (close_now - close_then) / max(close_then, 1e-9)
+    if slope >= UP_TH:
+        trend = "UP"
+    elif slope <= DOWN_TH:
+        trend = "DOWN"
+    else:
+        trend = "FLAT"
+    return slope, trend
+
+
+def _clamp01(x: float) -> float:
+    return max(0.0, min(1.0, x))
 
 
 def evaluate_sell(
@@ -24,69 +49,70 @@ def evaluate_sell(
     if runtime_state:
         verbose = runtime_state.get("verbose", 0)
 
-    candle = series.iloc[t]
-    price = float(candle["close"])
+    slope, trend = _slope_and_trend(series, t)
+    price_now = float(series.iloc[t]["close"])
 
-    window_notes = [n for n in open_notes if n.get("window_name") == window_name]
-    open_count = len(window_notes)
+    notes = [n for n in open_notes if n.get("window_name") == window_name]
+    N = len(notes)
 
-    ledger = ctx.get("ledger") if ctx else None
-    closed_count = 0
-    if ledger:
-        closed_count = sum(
-            1 for n in ledger.get_closed_notes() if n.get("window_name") == window_name
-        )
-
-    future_targets = [
-        n.get("target_price", float("inf"))
-        for n in window_notes
-        if n.get("target_price", float("inf")) > price
-    ]
-    next_target = min(future_targets) if future_targets else None
-
-    candidates = [
-        n
-        for n in window_notes
-        if price >= n.get("target_price", float("inf"))
-        and price >= n.get("entry_price", float("inf"))
-    ]
-
-    if not candidates:
-        msg = (
-            f"[HOLD][{window_name} {cfg['window_size']}] price=${price:.4f} Notes | "
-            f"Open={open_count} | Closed={closed_count} | Next="
-        )
-        if next_target is not None:
-            msg += f"${next_target:.4f}"
-        else:
-            msg += "None"
-        addlog(msg, verbose_int=3, verbose_state=verbose)
-        return []
-
-    def roi_now(note: Dict[str, Any]) -> float:
+    def roi(note: Dict[str, Any]) -> float:
         buy = note.get("entry_price", 0.0)
-        return (price - buy) / buy if buy else 0.0
+        return (price_now - buy) / buy if buy else 0.0
 
-    candidates.sort(key=roi_now, reverse=True)
+    def age_bars(note: Dict[str, Any]) -> int:
+        return t - note.get("created_idx", t)
 
-    state = {
-        "sell_count": 0,
-        "verbose": verbose,
-        "window_name": window_name,
-        "window_size": cfg["window_size"],
-        "max_sells": cfg.get("max_notes_sell_per_candle", 1),
-    }
+    def value_usd(note: Dict[str, Any]) -> float:
+        qty = note.get("entry_amount")
+        if qty is not None:
+            return float(qty) * price_now
+        return float(note.get("entry_usd", 0.0))
 
-    selected: List[Dict[str, Any]] = []
-    for note in candidates:
-        if check_sell_conditions(candle, note, cfg, state):
-            selected.append(note)
+    avg_roi_pos = sum(max(roi(n), 0.0) for n in notes) / N if N else 0.0
+    avg_age = sum(age_bars(n) for n in notes) / N if N else 0.0
+    N_norm = min(1.0, N / 10.0)
+    R_norm = min(1.0, avg_roi_pos / 0.10)
+    A_norm = min(1.0, avg_age / 100.0)
+    pressure = _clamp01(0.4 * N_norm + 0.4 * R_norm + 0.2 * A_norm)
 
-    if candidates:
+    cap = int(cfg.get("max_notes_sell_per_candle", 1))
+
+    if trend == "UP":
         addlog(
-            f"[MATURE][{window_name} {cfg['window_size']}] eligible={len(candidates)} sold={len(selected)} cap={state['max_sells']}",
+            f"[MATURE][{window_name} {cfg['window_size']}] trend={trend} slope={slope:.4f} pressure={pressure:.3f} sold=0/{N} cap={cap}",
             verbose_int=1,
             verbose_state=verbose,
         )
+        return []
+
+    if trend == "FLAT":
+        f_sell = min(0.20, 0.05 + 0.30 * pressure)
+    else:  # DOWN
+        f_sell = min(1.00, 0.30 + 0.70 * pressure + 0.50 * abs(min(slope, 0.0)))
+
+    want = math.ceil(f_sell * N)
+    want = min(want, cap)
+
+    sorted_notes = sorted(
+        notes,
+        key=lambda n: (roi(n), value_usd(n), age_bars(n)),
+        reverse=True,
+    )
+
+    selected: List[Dict[str, Any]] = []
+    for note in sorted_notes:
+        r = roi(note)
+        if r < -0.05:
+            continue
+        selected.append(note)
+        if len(selected) >= want:
+            break
+
+    addlog(
+        f"[MATURE][{window_name} {cfg['window_size']}] trend={trend} slope={slope:.4f} pressure={pressure:.3f} sold={len(selected)}/{N} cap={cap}",
+        verbose_int=1,
+        verbose_state=verbose,
+    )
 
     return selected
+


### PR DESCRIPTION
## Summary
- replace buy logic with simple slope-based trend classification and cooldown-limited sizing
- add pressure-aware sell evaluator that prioritizes high ROI/value/age and avoids >5% losses

## Testing
- `python bot.py --mode sim --ledger Kris_Ledger --time 72h -v`


------
https://chatgpt.com/codex/tasks/task_e_689f408e59788326bdc7c6bba204a49e