### PR TITLE
Switch to dynamic pressure-based cooldowns

### DIFF
--- a/systems/scripts/evaluate_buy.py
+++ b/systems/scripts/evaluate_buy.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 """Pressure-based buy evaluator."""
 
 from typing import Any, Dict
-import math
 import pandas as pd
 
 from systems.utils.addlog import addlog
@@ -20,23 +19,13 @@ PRESSURE_WINDOWS = [
     ("1d", 0.15),
 ]
 
-MIN_GAP_BARS = 12
-
-NORM_N = 10.0
-NORM_V = 5_000.0
-NORM_A = 100.0
-NORM_R = 0.10
-
-BP_SIG_CENTER = 0.40
-BP_SIG_WIDTH = 0.12
+BUY_CD_MIN = 2  # bars
+BUY_CD_MAX = 48  # bars
+BASE_BUY_FRACTION = 0.10  # size = capital * this
 
 
 def _clamp01(x: float) -> float:
-    return max(0.0, min(1.0, x))
-
-
-def _sigmoid(x: float) -> float:
-    return 1.0 / (1.0 + math.exp(-x))
+    return 0.0 if x < 0 else 1.0 if x > 1 else x
 
 
 def _span_to_bars(series: pd.DataFrame, span: str) -> int:
@@ -83,41 +72,16 @@ def _window_scores(series: pd.DataFrame, t: int) -> Dict[str, Dict[str, float]]:
     return scores
 
 
-def _compute_pressures(series: pd.DataFrame, t: int) -> tuple[float, float, Dict[str, Dict[str, float]]]:
-    scores = _window_scores(series, t)
-    bp = 0.0
-    sp = 0.0
-    for span, weight in PRESSURE_WINDOWS:
-        sc = scores.get(span, {})
-        bp += weight * sc.get("depth", 0.0)
-        sp += weight * sc.get("height", 0.0)
-    return bp, sp, scores
+def _pressure(scores: Dict[str, Dict[str, float]], windows) -> tuple[float, float]:
+    wsum = sum(w for _, w in windows) or 1.0
+    sell_p = sum(w * scores[s]["height"] for s, w in windows if s in scores) / wsum
+    buy_p = sum(w * scores[s]["depth"] for s, w in windows if s in scores) / wsum
+    return _clamp01(buy_p), _clamp01(sell_p)
 
 
-def _compute_sp_load(notes, price_now: float, t: int) -> float:
-    N = len(notes)
-    val = 0.0
-    ages = []
-    rois = []
-    for n in notes:
-        qty = n.get("entry_amount")
-        if qty is not None:
-            val += float(qty) * price_now
-        else:
-            val += float(n.get("entry_usd", 0.0))
-        created = n.get("created_idx", t)
-        ages.append(t - created)
-        buy = n.get("entry_price", 0.0)
-        if buy:
-            rois.append(max((price_now - buy) / buy, 0.0))
-    avg_age = sum(ages) / N if N else 0.0
-    avg_roi_pos = sum(rois) / N if N else 0.0
-    N_norm = min(1.0, N / NORM_N)
-    V_norm = min(1.0, val / NORM_V)
-    A_norm = min(1.0, avg_age / NORM_A)
-    R_norm = min(1.0, avg_roi_pos / NORM_R)
-    load = 0.35 * N_norm + 0.35 * V_norm + 0.15 * A_norm + 0.15 * R_norm
-    return _clamp01(load)
+def _cooldown_bars(pressure: float, min_bars: int, max_bars: int) -> int:
+    p = _clamp01(pressure)
+    return int(round(max_bars - p * (max_bars - min_bars)))
 
 
 def evaluate_buy(
@@ -133,52 +97,18 @@ def evaluate_buy(
 
     verbose = runtime_state.get("verbose", 0)
 
-    bp_price, sp_price, scores = _compute_pressures(series, t)
-    close_now = float(series.iloc[t]["close"])
-
-    ledger = ctx.get("ledger")
-    notes = []
-    if ledger is not None:
-        notes = ledger.get_open_notes()
-    sp_load = _compute_sp_load(notes, close_now, t)
-    sp_total = _clamp01(0.6 * sp_price + 0.4 * sp_load)
-
-    short_height = 0.5 * (
-        scores.get("1d", {}).get("height", 0.0)
-        + scores.get("3d", {}).get("height", 0.0)
-    )
-
-    if short_height > 0.65 and sp_total > 0.6:
-        addlog(
-            f"[GATE][{window_name} {cfg['window_size']}] short_h={short_height:.3f} sp={sp_total:.3f}",
-            verbose_int=2,
-            verbose_state=verbose,
-        )
-        return False
-
-    capital = float(runtime_state.get("capital", 0.0))
-    limits = runtime_state.get("limits", {})
-    min_sz = float(limits.get("min_note_size", 0.0))
-    max_sz = float(limits.get("max_note_usdt", float("inf")))
-
-    base = float(cfg.get("investment_fraction", 0.0))
-    m_buy = _sigmoid((bp_price - BP_SIG_CENTER) / BP_SIG_WIDTH)
-    size_usd = capital * base * m_buy
-    raw = size_usd
-    size_usd = min(size_usd, capital, max_sz)
-    if raw != size_usd:
-        addlog(
-            f"[CLAMP] size=${raw:.2f} → ${size_usd:.2f} (cap=${capital:.2f}, max=${max_sz:.2f})",
-            verbose_int=2,
-            verbose_state=verbose,
-        )
+    scores = _window_scores(series, t)
+    buy_p, sell_p = _pressure(scores, PRESSURE_WINDOWS)
+    cd = _cooldown_bars(buy_p, BUY_CD_MIN, BUY_CD_MAX)
 
     last_key = f"last_buy_idx::{window_name}"
-    last_idx = int(runtime_state.get(last_key, -1))
-    cooldown_ok = (t - last_idx) >= MIN_GAP_BARS
+    last_idx = int(runtime_state.get(last_key, -10**9))
+    elapsed = t - last_idx
 
     decision: Dict[str, Any] | bool = False
-    if cooldown_ok and size_usd >= min_sz and size_usd > 0.0:
+    if elapsed >= cd:
+        capital = float(runtime_state.get("capital", 0.0))
+        size_usd = max(0.0, capital * BASE_BUY_FRACTION)
         decision = {
             "size_usd": size_usd,
             "window_name": window_name,
@@ -190,7 +120,7 @@ def evaluate_buy(
         runtime_state[last_key] = t
 
     addlog(
-        f"[{ 'BUY' if decision else 'SKIP' }][{window_name} {cfg['window_size']}] bp={bp_price:.3f} sp={sp_total:.3f} size=${size_usd:.2f}",
+        f"[{ 'BUY' if decision else 'SKIP' }][{window_name} {cfg['window_size']}] buy_p={buy_p:.3f} cd={cd} elapsed={elapsed}",
         verbose_int=1,
         verbose_state=verbose,
     )

--- a/systems/scripts/evaluate_sell.py
+++ b/systems/scripts/evaluate_sell.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 """Pressure-based sell evaluator."""
 
 from typing import Any, Dict, List
-import math
 import pandas as pd
 
 from systems.utils.addlog import addlog
@@ -20,16 +19,13 @@ PRESSURE_WINDOWS = [
     ("1d", 0.15),
 ]
 
-NORM_N = 10.0
-NORM_V = 5_000.0
-NORM_A = 100.0
-NORM_R = 0.10
-
+SELL_CD_MIN = 2  # bars
+SELL_CD_MAX = 48  # bars
 LOSS_CAP = -0.05
 
 
 def _clamp01(x: float) -> float:
-    return max(0.0, min(1.0, x))
+    return 0.0 if x < 0 else 1.0 if x > 1 else x
 
 
 def _span_to_bars(series: pd.DataFrame, span: str) -> int:
@@ -76,52 +72,16 @@ def _window_scores(series: pd.DataFrame, t: int) -> Dict[str, Dict[str, float]]:
     return scores
 
 
-def _compute_pressures(series: pd.DataFrame, t: int) -> tuple[float, Dict[str, Dict[str, float]]]:
-    scores = _window_scores(series, t)
-    sp = 0.0
-    for span, weight in PRESSURE_WINDOWS:
-        sp += weight * scores.get(span, {}).get("height", 0.0)
-    return sp, scores
+def _pressure(scores: Dict[str, Dict[str, float]], windows) -> tuple[float, float]:
+    wsum = sum(w for _, w in windows) or 1.0
+    sell_p = sum(w * scores[s]["height"] for s, w in windows if s in scores) / wsum
+    buy_p = sum(w * scores[s]["depth"] for s, w in windows if s in scores) / wsum
+    return _clamp01(buy_p), _clamp01(sell_p)
 
 
-def _compute_sp_load(notes, price_now: float, t: int) -> float:
-    N = len(notes)
-    val = 0.0
-    ages = []
-    rois = []
-    for n in notes:
-        qty = n.get("entry_amount")
-        if qty is not None:
-            val += float(qty) * price_now
-        else:
-            val += float(n.get("entry_usd", 0.0))
-        created = n.get("created_idx", t)
-        ages.append(t - created)
-        buy = n.get("entry_price", 0.0)
-        if buy:
-            rois.append(max((price_now - buy) / buy, 0.0))
-    avg_age = sum(ages) / N if N else 0.0
-    avg_roi_pos = sum(rois) / N if N else 0.0
-    N_norm = min(1.0, N / NORM_N)
-    V_norm = min(1.0, val / NORM_V)
-    A_norm = min(1.0, avg_age / NORM_A)
-    R_norm = min(1.0, avg_roi_pos / NORM_R)
-    load = 0.35 * N_norm + 0.35 * V_norm + 0.15 * A_norm + 0.15 * R_norm
-    return _clamp01(load)
-
-
-def _blend_slope(series: pd.DataFrame, t: int) -> float:
-    def _slope(bars: int) -> float:
-        idx = max(0, t - bars)
-        past = float(series.iloc[idx]["close"])
-        now = float(series.iloc[t]["close"])
-        return (now - past) / max(past, 1e-9)
-
-    b1 = _span_to_bars(series, "1d")
-    b3 = _span_to_bars(series, "3d")
-    s1 = _slope(b1)
-    s3 = _slope(b3)
-    return 0.5 * (s1 + s3)
+def _cooldown_bars(pressure: float, min_bars: int, max_bars: int) -> int:
+    p = _clamp01(pressure)
+    return int(round(max_bars - p * (max_bars - min_bars)))
 
 
 def evaluate_sell(
@@ -136,63 +96,31 @@ def evaluate_sell(
 ) -> List[Dict[str, Any]]:
     """Return a list of notes to sell in ``window_name`` on this candle."""
 
-    verbose = 0
-    if runtime_state:
-        verbose = runtime_state.get("verbose", 0)
+    verbose = runtime_state.get("verbose", 0) if runtime_state else 0
 
-    sp_price, scores = _compute_pressures(series, t)
+    scores = _window_scores(series, t)
+    buy_p, sell_p = _pressure(scores, PRESSURE_WINDOWS)
+    cd = _cooldown_bars(sell_p, SELL_CD_MIN, SELL_CD_MAX)
+
+    last_key = f"last_sell_idx::{window_name}"
+    last_idx = int(runtime_state.get(last_key, -10**9)) if runtime_state else -10**9
+    elapsed = t - last_idx
+    if elapsed < cd:
+        return []
+
     price_now = float(series.iloc[t]["close"])
-
     notes = [n for n in open_notes if n.get("window_name") == window_name]
-    sp_load = _compute_sp_load(notes, price_now, t)
-    sp_total = _clamp01(0.6 * sp_price + 0.4 * sp_load)
 
-    N = len(notes)
-    cap = int(cfg.get("max_notes_sell_per_candle", 1))
-
-    slope = _blend_slope(series, t)
-    trend_nudge = 0.0
-    if slope < 0:
-        trend_nudge = 0.10 * abs(slope)
-
-    f_base = 0.02 + 0.28 * sp_total
-    f_sell = _clamp01(f_base + trend_nudge)
-
-    want = math.ceil(f_sell * N)
-    want = min(want, cap)
-
-    def roi(note: Dict[str, Any]) -> float:
-        buy = note.get("entry_price", 0.0)
+    def roi(n: Dict[str, Any]) -> float:
+        buy = n.get("entry_price", 0.0)
         return (price_now - buy) / buy if buy else 0.0
 
-    def age_bars(note: Dict[str, Any]) -> int:
-        return t - note.get("created_idx", t)
-
-    def value_usd(note: Dict[str, Any]) -> float:
-        qty = note.get("entry_amount")
-        if qty is not None:
-            return float(qty) * price_now
-        return float(note.get("entry_usd", 0.0))
-
-    sorted_notes = sorted(
-        notes,
-        key=lambda n: (roi(n), value_usd(n), age_bars(n)),
-        reverse=True,
-    )
-
-    selected: List[Dict[str, Any]] = []
-    for note in sorted_notes:
-        r = roi(note)
-        if r < LOSS_CAP:
-            continue
-        if r < 0 and (sp_total < 0.75 or len(selected) >= want):
-            continue
-        selected.append(note)
-        if len(selected) >= want:
-            break
+    selected = [n for n in notes if roi(n) >= LOSS_CAP]
+    if selected and runtime_state is not None:
+        runtime_state[last_key] = t
 
     addlog(
-        f"[MATURE][{window_name} {cfg['window_size']}] sp={sp_total:.3f} sold={len(selected)}/{N} cap={cap}",
+        f"[MATURE][{window_name} {cfg['window_size']}] sell_p={sell_p:.3f} cd={cd} sold={len(selected)}/{len(notes)}",
         verbose_int=1,
         verbose_state=verbose,
     )


### PR DESCRIPTION
## Summary
- drive buy frequency via pressure-weighted cooldowns and constant sizing
- gate sells with pressure-based cooldowns and ROI loss cap

## Testing
- `python -m py_compile systems/scripts/evaluate_buy.py systems/scripts/evaluate_sell.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689fab4cace48326b2e01204089480ef