### PR TITLE
Normalize Kraken quotes for USD aliases

### DIFF
--- a/systems/scripts/execution_handler.py
+++ b/systems/scripts/execution_handler.py
@@ -9,6 +9,7 @@ from systems.scripts.kraken_utils import load_kraken_keys
 from systems.scripts.kraken_utils import get_live_price
 from systems.utils.addlog import addlog, send_telegram_message
 from systems.utils.resolve_symbol import split_tag
+from systems.utils.quote_norm import norm_quote
 from systems.utils.snapshot import load_snapshot, prime_snapshot
 from systems.scripts.trade_apply import apply_buy
 
@@ -187,19 +188,26 @@ def execute_buy(
     currently unused as ``place_order`` pulls pricing from Kraken directly.
     """
 
-    expected_quote = "USDC" if ledger_name.upper().endswith("USDC") else "USD"
+    expected_raw = "USDC" if ledger_name.upper().endswith("USDC") else "USD"
     _, fiat_symbol = split_tag(pair_code)
-    actual_quote = fiat_symbol
-    if actual_quote != expected_quote:
+    got_raw = fiat_symbol
+    exp = norm_quote(expected_raw)
+    got = norm_quote(got_raw)
+    if exp != got:
         addlog(
-            f"[ABORT][QUOTE_MISMATCH] ledger={ledger_name} expected={expected_quote} got={actual_quote} pair={pair_code}",
+            f"[DEBUG][QUOTE_RAW] expected_raw={expected_raw} got_raw={got_raw}",
+            verbose_int=1,
+            verbose_state=verbose,
+        )
+        addlog(
+            f"[ABORT][QUOTE_MISMATCH] ledger={ledger_name} expected={exp} got={got} pair={pair_code}",
             verbose_int=1,
             verbose_state=verbose,
         )
         return {
             "error": "QUOTE_MISMATCH",
-            "expected": expected_quote,
-            "got": actual_quote,
+            "expected": exp,
+            "got": got,
             "pair": pair_code,
         }
 
@@ -304,18 +312,25 @@ def execute_sell(
     sell_price = price if price is not None else get_live_price(pair_code)
     usd_amount = coin_amount * sell_price
     _, fiat_symbol = split_tag(pair_code)
-    expected_quote = "USDC" if ledger_name.upper().endswith("USDC") else "USD"
-    actual_quote = fiat_symbol
-    if actual_quote != expected_quote:
+    expected_raw = "USDC" if ledger_name.upper().endswith("USDC") else "USD"
+    got_raw = fiat_symbol
+    exp = norm_quote(expected_raw)
+    got = norm_quote(got_raw)
+    if exp != got:
         addlog(
-            f"[ABORT][QUOTE_MISMATCH] ledger={ledger_name} expected={expected_quote} got={actual_quote} pair={pair_code}",
+            f"[DEBUG][QUOTE_RAW] expected_raw={expected_raw} got_raw={got_raw}",
+            verbose_int=1,
+            verbose_state=verbose,
+        )
+        addlog(
+            f"[ABORT][QUOTE_MISMATCH] ledger={ledger_name} expected={exp} got={got} pair={pair_code}",
             verbose_int=1,
             verbose_state=verbose,
         )
         return {
             "error": "QUOTE_MISMATCH",
-            "expected": expected_quote,
-            "got": actual_quote,
+            "expected": exp,
+            "got": got,
             "pair": pair_code,
         }
     result = place_order(

--- a/systems/utils/quote_norm.py
+++ b/systems/utils/quote_norm.py
@@ -1,0 +1,10 @@
+NORM_MAP = {
+    "ZUSD": "USD",
+    "ZEUR": "EUR",
+    "ZGBP": "GBP",
+    "ZJPY": "JPY",
+}
+
+def norm_quote(q: str) -> str:
+    q = (q or "").upper()
+    return NORM_MAP.get(q, q)

--- a/systems/utils/resolve_symbol.py
+++ b/systems/utils/resolve_symbol.py
@@ -1,6 +1,7 @@
 """Helpers for resolving symbol and ledger configuration."""
 
 from systems.utils.config import load_settings
+from systems.utils.quote_norm import norm_quote
 
 
 SETTINGS = load_settings()
@@ -31,7 +32,19 @@ def resolve_ccxt_symbols(settings: dict, ledger: str) -> tuple[str, str]:
     if ledger not in ledgers:
         raise ValueError(f"Ledger '{ledger}' not found in settings")
     cfg = ledgers[ledger]
-    return cfg.get("kraken_name", ""), cfg.get("binance_name", "")
+    kraken = cfg.get("kraken_name", "")
+    if "/" in kraken:
+        base, quote = kraken.split("/", 1)
+        kraken = f"{base}/{norm_quote(quote)}"
+    else:
+        kraken = norm_quote(kraken)
+
+    binance = cfg.get("binance_name", "")
+    if "/" in binance:
+        base_b, quote_b = binance.split("/", 1)
+        binance = f"{base_b}/{norm_quote(quote_b)}"
+
+    return kraken, binance
 
 
 def to_tag(symbol: str) -> str:


### PR DESCRIPTION
## Summary
- add utility to normalize Kraken asset codes like ZUSD to USD
- normalize quotes in resolve_ccxt_symbols and execution handler checks

## Testing
- `python -m py_compile systems/utils/quote_norm.py systems/utils/resolve_symbol.py systems/scripts/execution_handler.py`


------
https://chatgpt.com/codex/tasks/task_e_689fd144c4748326b4a82e0ab41d2e0a