### PR TITLE
Add discovery simulation and plotting entrypoint

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+"""Minimal command-line entry point for discovery simulation."""
+
+import argparse
+
+from systems import sim_engine
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="WindowSurfer discovery bot")
+    parser.add_argument("--mode", required=True, help="Mode to run (sim)")
+    parser.add_argument("--time", default="1m", help="Time window for simulation")
+    args = parser.parse_args()
+
+    if args.mode.lower() == "sim":
+        sim_engine.run_simulation(timeframe=args.time)
+    else:
+        raise ValueError(f"Unknown mode: {args.mode}")
+
+
+if __name__ == "__main__":
+    main()

--- a/data/sim/SOLUSD.csv
+++ b/data/sim/SOLUSD.csv
@@ -1,0 +1,1 @@
+SOLUSD_1h.csv

--- a/systems/__init__.py
+++ b/systems/__init__.py
@@ -1,0 +1,1 @@
+"""Core system modules for simple simulations."""

--- a/systems/scripts/__init__.py
+++ b/systems/scripts/__init__.py
@@ -1,0 +1,1 @@
+"""Script stubs for discovery simulation."""

--- a/systems/scripts/evaluate_buy.py
+++ b/systems/scripts/evaluate_buy.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+"""Stub buy evaluator for discovery simulation."""
+
+from typing import Any, Dict
+
+
+def evaluate_buy(candle: Dict[str, Any], state: Dict[str, Any]) -> bool:
+    """Return ``False`` to indicate no buy action."""
+    return False

--- a/systems/scripts/evaluate_sell.py
+++ b/systems/scripts/evaluate_sell.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+"""Stub sell evaluator for discovery simulation."""
+
+from typing import Any, Dict
+
+
+def evaluate_sell(candle: Dict[str, Any], state: Dict[str, Any]) -> bool:
+    """Return ``False`` to indicate no sell action."""
+    return False

--- a/systems/sim_engine.py
+++ b/systems/sim_engine.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+"""Very small historical simulation engine."""
+
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Dict, Any
+
+import matplotlib.pyplot as plt
+import pandas as pd
+
+from .scripts import evaluate_buy, evaluate_sell
+
+
+def run_simulation(*, timeframe: str = "1m") -> None:
+    """Run a simple simulation over SOLUSD candles."""
+    csv_path = Path("data/sim/SOLUSD.csv")
+    df = pd.read_csv(csv_path)
+
+    if timeframe == "1m":
+        cutoff = datetime.now(tz=timezone.utc) - timedelta(days=30)
+        df = df[df["timestamp"] >= int(cutoff.timestamp())]
+
+    df["short"] = df["close"].rolling(window=10, min_periods=1).mean()
+    df["long"] = df["close"].rolling(window=50, min_periods=1).mean()
+    df["delta"] = df["short"] - df["long"]
+
+    state: Dict[str, Any] = {}
+    for _, candle in df.iterrows():
+        evaluate_buy.evaluate_buy(candle.to_dict(), state)
+        evaluate_sell.evaluate_sell(candle.to_dict(), state)
+
+    out_path = Path("data/tmp/discovery.png")
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    plt.figure(figsize=(10, 5))
+    plt.plot(df["timestamp"], df["close"], label="Close")
+    plt.plot(df["timestamp"], df["delta"], label="Delta")
+    plt.legend()
+    plt.tight_layout()
+    plt.savefig(out_path)
+    plt.close()


### PR DESCRIPTION
## Summary
- add minimal CLI `bot.py` to run discovery simulations
- implement simple `systems/sim_engine` that loads SOLUSD data, computes moving-average delta, calls eval stubs, and plots to `data/tmp/discovery.png`
- provide stub `evaluate_buy` and `evaluate_sell` scripts
- include symlink to `data/sim/SOLUSD.csv`

## Testing
- `python bot.py --mode sim --time 1m`


------
https://chatgpt.com/codex/tasks/task_e_689fef6b0f548326b39ffd28bde05443