### PR TITLE
Normalize candle CSV columns in simulation engine

### DIFF
--- a/systems/sim_engine.py
+++ b/systems/sim_engine.py
@@ -16,6 +16,22 @@ def run_simulation(*, timeframe: str = "1m") -> None:
     """Run a simple simulation over SOLUSD candles."""
     csv_path = Path("data/sim/SOLUSD.csv")
     df = pd.read_csv(csv_path)
+    df.columns = [c.lower().strip() for c in df.columns]
+    rename_map = {
+        "c": "close",
+        "close_price": "close",
+        "o": "open",
+        "h": "high",
+        "l": "low",
+        "v": "volume",
+        "t": "timestamp",
+    }
+    df.rename(columns=rename_map, inplace=True)
+
+    required_cols = {"timestamp", "open", "high", "low", "close"}
+    missing = required_cols - set(df.columns)
+    if missing:
+        raise ValueError(f"Missing required candle columns: {sorted(missing)}")
 
     if timeframe == "1m":
         cutoff = datetime.now(tz=timezone.utc) - timedelta(days=30)


### PR DESCRIPTION
## Summary
- Normalize candle CSV column headers to a standard schema in `run_simulation`
- Validate presence of essential candle fields before processing

## Testing
- `python -m py_compile systems/sim_engine.py`
- `pytest`
- `python - <<'PY'
from systems import sim_engine
sim_engine.run_simulation()
PY`


------
https://chatgpt.com/codex/tasks/task_e_689ff123d8f483268447b4efc617c765