### PR TITLE
Overlay scaled delta line on price graph

### DIFF
--- a/systems/sim_engine.py
+++ b/systems/sim_engine.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 """Very small historical simulation engine."""
 
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta
 from typing import Dict, Any
 
 import matplotlib.pyplot as plt
@@ -15,14 +15,22 @@ def run_simulation(*, timeframe: str = "1m") -> None:
     """Run a simple simulation over SOLUSD candles."""
     file_path = "data/sim/SOLUSD_1h.csv"
     df = pd.read_csv(file_path)
+    df["timestamp"] = pd.to_datetime(df["timestamp"], unit="s")
 
     if timeframe == "1m":
-        cutoff = datetime.now(tz=timezone.utc) - timedelta(days=30)
-        df = df[df["timestamp"] >= int(cutoff.timestamp())]
+        cutoff = datetime.utcnow() - timedelta(days=30)
+        df = df[df["timestamp"] >= cutoff]
 
     df["short"] = df["close"].rolling(window=10, min_periods=1).mean()
     df["long"] = df["close"].rolling(window=50, min_periods=1).mean()
     df["delta"] = df["short"] - df["long"]
+
+    delta = df["delta"]
+    close = df["close"]
+    # scale delta into the price range
+    scale = (close.max() - close.min()) / (delta.max() - delta.min())
+    norm_delta = (delta - delta.min()) * scale + close.min()
+    df["norm_delta"] = norm_delta
 
     state: Dict[str, Any] = {}
     for _, candle in df.iterrows():
@@ -30,11 +38,11 @@ def run_simulation(*, timeframe: str = "1m") -> None:
         evaluate_sell.evaluate_sell(candle.to_dict(), state)
 
     plt.figure(figsize=(12, 6))
-    plt.plot(df["timestamp"], df["close"], label="Close Price")
-    plt.plot(df["timestamp"], df["delta"], label="Delta Line")
+    plt.plot(df["timestamp"], df["close"], label="Close Price", color="blue")
+    plt.plot(df["timestamp"], df["norm_delta"], label="Delta (scaled)", color="red")
     plt.xlabel("Time")
-    plt.ylabel("Price / Delta")
-    plt.legend()
+    plt.ylabel("Price / Scaled Delta")
     plt.title("SOLUSD Discovery Simulation")
+    plt.legend()
     plt.grid(True)
     plt.show()


### PR DESCRIPTION
## Summary
- Scale delta into the close price range and plot alongside price
- Convert timestamps to datetime before filtering by timeframe
- Replace plot with combined price and scaled delta lines sharing a single axis

## Testing
- `pytest`
- `python -m py_compile systems/sim_engine.py`


------
https://chatgpt.com/codex/tasks/task_e_689ffbe3e5a08326b051aef2c3c6c2b4