### PR TITLE
feat: add timeframe filtering and delta settings

### DIFF
--- a/systems/sim_engine.py
+++ b/systems/sim_engine.py
@@ -2,13 +2,35 @@ from __future__ import annotations
 
 """Very small historical simulation engine."""
 
-from datetime import datetime, timedelta
-from typing import Dict, Any
+import re
+from datetime import timedelta
+from typing import Any, Dict
 
 import matplotlib.pyplot as plt
 import pandas as pd
 
 from .scripts import evaluate_buy, evaluate_sell
+
+
+# === Regime Detection Settings ===
+SHORT_MA = 10   # short moving average lookback (candles)
+LONG_MA  = 50   # long moving average lookback (candles)
+
+
+def parse_timeframe(tf: str) -> timedelta | None:
+    match = re.match(r"(\d+)([dhmw])", tf)
+    if not match:
+        return None
+    val, unit = int(match.group(1)), match.group(2)
+    if unit == "d":
+        return timedelta(days=val)
+    if unit == "w":
+        return timedelta(weeks=val)
+    if unit == "m":
+        return timedelta(days=30 * val)  # rough month
+    if unit == "h":
+        return timedelta(hours=val)
+    return None
 
 
 def run_simulation(*, timeframe: str = "1m") -> None:
@@ -17,20 +39,23 @@ def run_simulation(*, timeframe: str = "1m") -> None:
     df = pd.read_csv(file_path)
     df["timestamp"] = pd.to_datetime(df["timestamp"], unit="s")
 
-    if timeframe == "1m":
-        cutoff = datetime.utcnow() - timedelta(days=30)
-        df = df[df["timestamp"] >= cutoff]
+    if timeframe:
+        delta = parse_timeframe(timeframe)
+        if delta:
+            cutoff = pd.Timestamp.utcnow().tz_localize(None) - delta
+            df = df[df["timestamp"] >= cutoff]
 
-    df["short"] = df["close"].rolling(window=10, min_periods=1).mean()
-    df["long"] = df["close"].rolling(window=50, min_periods=1).mean()
+    df["short"] = df["close"].rolling(window=SHORT_MA, min_periods=1).mean()
+    df["long"] = df["close"].rolling(window=LONG_MA, min_periods=1).mean()
     df["delta"] = df["short"] - df["long"]
 
-    delta = df["delta"]
-    close = df["close"]
     # scale delta into the price range
-    scale = (close.max() - close.min()) / (delta.max() - delta.min())
-    norm_delta = (delta - delta.min()) * scale + close.min()
-    df["norm_delta"] = norm_delta
+    scale = (df["close"].max() - df["close"].min()) / (
+        df["delta"].max() - df["delta"].min()
+    )
+    df["norm_delta"] = (
+        (df["delta"] - df["delta"].min()) * scale + df["close"].min()
+    )
 
     state: Dict[str, Any] = {}
     for _, candle in df.iterrows():
@@ -39,7 +64,12 @@ def run_simulation(*, timeframe: str = "1m") -> None:
 
     plt.figure(figsize=(12, 6))
     plt.plot(df["timestamp"], df["close"], label="Close Price", color="blue")
-    plt.plot(df["timestamp"], df["norm_delta"], label="Delta (scaled)", color="red")
+    plt.plot(
+        df["timestamp"],
+        df["norm_delta"],
+        label=f"Delta ({SHORT_MA}-{LONG_MA})",
+        color="red",
+    )
     plt.xlabel("Time")
     plt.ylabel("Price / Scaled Delta")
     plt.title("SOLUSD Discovery Simulation")


### PR DESCRIPTION
## Summary
- add configurable moving average windows for regime detection
- filter simulation data by recent timeframe strings like `2w` or `3d`
- scale and plot delta using the new constants

## Testing
- `MPLBACKEND=Agg python bot.py --mode sim --time 2w`
- `python -m py_compile systems/sim_engine.py`


------
https://chatgpt.com/codex/tasks/task_e_689ffef126c083268314a4a3a12c6472