### PR TITLE
Switch simulation plots to candle index

### DIFF
--- a/systems/sim_engine.py
+++ b/systems/sim_engine.py
@@ -43,13 +43,17 @@ def run_simulation(*, timeframe: str = "1m") -> None:
     """Run a simple simulation over SOLUSD candles."""
     file_path = "data/sim/SOLUSD_1h.csv"
     df = pd.read_csv(file_path)
-    df["timestamp"] = pd.to_datetime(df["timestamp"], unit="s")
 
     if timeframe:
         delta = parse_timeframe(timeframe)
         if delta:
-            cutoff = pd.Timestamp.utcnow().tz_localize(None) - delta
+            cutoff = (
+                pd.Timestamp.utcnow().tz_localize(None) - delta
+            ).timestamp()
             df = df[df["timestamp"] >= cutoff]
+
+    df = df.reset_index(drop=True)
+    df["candle_index"] = range(len(df))
 
     bottom_window = DEFAULT_BOTTOM_WINDOW
     match = re.match(r"(\d+)", timeframe)
@@ -105,9 +109,9 @@ def run_simulation(*, timeframe: str = "1m") -> None:
         evaluate_sell.evaluate_sell(candle.to_dict(), state)
 
     fig, ax1 = plt.subplots(figsize=(12, 6))
-    ax1.plot(df["timestamp"], df["close"], label="Close Price", color="blue")
+    ax1.plot(df["candle_index"], df["close"], label="Close Price", color="blue")
     ax1.plot(
-        df["timestamp"],
+        df["candle_index"],
         df["bottom_slope"],
         label=f"Slope Line ({bottom_window})",
         color="black",
@@ -115,7 +119,7 @@ def run_simulation(*, timeframe: str = "1m") -> None:
         drawstyle="steps-post",
     )
     ax1.plot(
-        df["timestamp"],
+        df["candle_index"],
         df["forecast_slope"],
         label="Forecast Slope",
         color="red",
@@ -123,11 +127,12 @@ def run_simulation(*, timeframe: str = "1m") -> None:
         alpha=0.8,
     )
     ax1.set_ylabel("Price")
+    ax1.set_xlabel("Candles (Index)")
     ax1.legend(loc="upper left")
 
     ax2 = ax1.twinx()
     ax2.plot(
-        df["timestamp"],
+        df["candle_index"],
         df["slope_angle"],
         label="Slope Angle [-1,1]",
         color="green",


### PR DESCRIPTION
## Summary
- replace timestamp axis with sequential candle index for clearer slope and forecast plots
- add `candle_index` column and label x-axis accordingly
- drop unnecessary `pd.to_datetime` conversion

## Testing
- `MPLBACKEND=Agg python - <<'PY'
from systems.sim_engine import run_simulation
run_simulation()
PY`


------
https://chatgpt.com/codex/tasks/task_e_68a00da52b408326b71d6ebe3839f702