### PR TITLE
Add feature-weighted forecast slope

### DIFF
--- a/systems/sim_engine.py
+++ b/systems/sim_engine.py
@@ -17,6 +17,12 @@ from .scripts import evaluate_buy, evaluate_sell
 # If < 1, treated as fraction of dataset length
 DEFAULT_BOTTOM_WINDOW = 0.1
 
+# Forecast weights
+WEIGHT_PERSISTENCE = 0.5
+WEIGHT_ERROR = 0.2
+WEIGHT_VOLUME = 0.2
+WEIGHT_VOLATILITY = 0.1
+
 
 def parse_timeframe(tf: str) -> timedelta | None:
     match = re.match(r"(\d+)([dhmw])", tf)
@@ -81,49 +87,85 @@ def run_simulation(*, timeframe: str = "1m") -> None:
     df["bottom_slope"] = slopes
     df["slope_angle"] = slope_angles
 
-    # Half-window slope prediction + snapback exploration
-    predicted_angles = [np.nan] * len(df)
-    snapback_conf = [np.nan] * len(df)
-    matches = 0
-    total = 0
+    # Forward slope forecasting
+    forecast_angles = [np.nan] * len(df)
+
+    # track persistence (consecutive slope runs)
+    last_slope_sign = 0
+    persistence_count = 0
 
     for i in range(0, len(df), BOTTOM_WINDOW):
         end = min(i + BOTTOM_WINDOW, len(df))
-        mid = i + BOTTOM_WINDOW // 2
+        y = df["close"].iloc[i:end].values
+        x = np.arange(len(y))
 
-        # First half slope
-        y1 = df["close"].iloc[i:mid].values
-        x1 = np.arange(len(y1))
-        angle1 = None
-        if len(y1) > 1:
-            m1, _ = np.polyfit(x1, y1, 1)
-            angle1 = np.tanh(m1)
-            predicted_angles[mid:end] = [angle1] * (end - mid)
+        if len(y) > 1:
+            m, b = np.polyfit(x, y, 1)
+            actual_angle = np.tanh(m)  # normalized slope angle
 
-        # Second half slope (projected forward)
-        y2 = df["close"].iloc[mid:end].values
-        x2 = np.arange(len(y2))
-        if len(y2) > 1:
-            m2, _ = np.polyfit(x2, y2, 1)
-            angle2 = np.tanh(m2)
-            predicted_angles[end : end + BOTTOM_WINDOW] = [angle2] * min(
-                BOTTOM_WINDOW, len(df) - end
+            # --- Baseline (Codex 1): persistence ---
+            slope_sign = np.sign(actual_angle)
+            if slope_sign == last_slope_sign:
+                persistence_count += 1
+            else:
+                persistence_count = 1
+            last_slope_sign = slope_sign
+            score_persistence = slope_sign * (persistence_count / 5.0)  # scaled
+
+            # --- Improved (Codex 2): error + volume bias ---
+            # residual error (fit quality)
+            y_fit = m * x + b
+            residuals = y - y_fit
+            fit_error = np.mean(np.abs(residuals))
+            score_error = -np.sign(actual_angle) * (fit_error / np.std(y))
+
+            # volume bias
+            recent_vol = df["volume"].iloc[i:end]
+            vol_change = (recent_vol.iloc[-1] - recent_vol.iloc[0]) / max(
+                1e-9, recent_vol.iloc[0]
+            )
+            score_volume = np.sign(vol_change) * abs(vol_change)
+
+            # --- Target (Codex 3): volatility + multi-window alignment ---
+            # volatility (ATR proxy)
+            atr = (df["high"].iloc[i:end] - df["low"].iloc[i:end]).mean()
+            score_volatility = -np.sign(actual_angle) * (
+                atr / max(1e-9, np.mean(df["close"].iloc[i:end]))
             )
 
-            if angle1 is not None:
-                # Snapback confidence high if directions oppose
-                snapback = abs(angle1 - angle2) / 2
-                snapback_conf[mid:end] = [snapback] * (end - mid)
-                total += 1
-                if np.sign(angle1) == np.sign(angle2):
-                    matches += 1
+            # multi-window alignment: compare current slope vs. longer context
+            context_size = min(len(df), BOTTOM_WINDOW * 3)
+            ctx_y = df["close"].iloc[max(0, i - context_size) : end].values
+            ctx_x = np.arange(len(ctx_y))
+            if len(ctx_y) > 1:
+                m_ctx, _ = np.polyfit(ctx_x, ctx_y, 1)
+                ctx_angle = np.tanh(m_ctx)
+            else:
+                ctx_angle = 0
+            score_context = np.sign(ctx_angle) * abs(ctx_angle)
 
-    if total > 0:
-        acc = matches / total * 100
-        print(f"[SIM] Half-window slope directional accuracy: {acc:.1f}%")
+            # --- Combine all features ---
+            forecast_angle = (
+                WEIGHT_PERSISTENCE * score_persistence
+                + WEIGHT_ERROR * score_error
+                + WEIGHT_VOLUME * score_volume
+                + WEIGHT_VOLATILITY * score_volatility
+                + (1 - (
+                    WEIGHT_PERSISTENCE
+                    + WEIGHT_ERROR
+                    + WEIGHT_VOLUME
+                    + WEIGHT_VOLATILITY
+                ))
+                * score_context
+            )
 
-    df["predicted_angle"] = predicted_angles
-    df["snapback_conf"] = snapback_conf
+            # clamp [-1,1]
+            forecast_angle = max(-1, min(1, forecast_angle))
+
+            # assign to full window
+            forecast_angles[i:end] = [forecast_angle] * (end - i)
+
+    df["forecast_angle"] = forecast_angles
 
     state: Dict[str, Any] = {}
     for _, candle in df.iterrows():
@@ -147,22 +189,14 @@ def run_simulation(*, timeframe: str = "1m") -> None:
     ax2 = ax1.twinx()
     ax2.plot(
         df["candle_index"],
-        df["predicted_angle"],
-        label="Predicted Slope Angle (half-window)",
-        color="green",
-        drawstyle="steps-post",
-    )
-    ax2.plot(
-        df["candle_index"],
-        df["snapback_conf"],
-        label="Snapback Confidence",
-        color="orange",
-        linestyle="--",
+        df["forecast_angle"],
+        label="Forecast Slope Angle",
+        color="red",
         drawstyle="steps-post",
     )
     ax2.set_ylim(-1, 1)
     ax2.axhline(0, color="gray", linestyle="--", linewidth=1)
-    ax2.set_ylabel("Slope Angle / Confidence")
+    ax2.set_ylabel("Slope Angle [-1,1]")
     ax2.legend(loc="lower right")
 
     plt.title("SOLUSD Discovery Simulation")


### PR DESCRIPTION
## Summary
- add tunable weights for persistence, error, volume and volatility
- compute feature-weighted forward slope forecast per window
- show forecast slope as red stepped line

## Testing
- `python - <<'PY'
import matplotlib
matplotlib.use('Agg')
from systems.sim_engine import run_simulation
run_simulation(timeframe=None)
PY`


------
https://chatgpt.com/codex/tasks/task_e_68a0934277088326a5c1fe0905acec70