### PR TITLE
Add lookback pressure bias to control line

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -11,10 +11,42 @@ def main() -> None:
     parser = argparse.ArgumentParser(description="WindowSurfer discovery bot")
     parser.add_argument("--mode", required=True, help="Mode to run (sim)")
     parser.add_argument("--time", default="1m", help="Time window for simulation")
+    parser.add_argument(
+        "--pressure-lookback",
+        type=int,
+        default=sim_engine.PRESSURE_LOOKBACK,
+        help="Lookback candles for pressure bias",
+    )
+    parser.add_argument(
+        "--pressure-scale",
+        type=float,
+        default=sim_engine.PRESSURE_SCALE,
+        help="Scaling factor for pressure bias",
+    )
+    parser.add_argument(
+        "--no-pressure-bias",
+        dest="enable_pressure_bias",
+        action="store_false",
+        default=True,
+        help="Disable pressure bias",
+    )
+    parser.add_argument(
+        "--debug-plots", action="store_true", help="Show pressure bias overlay"
+    )
+    parser.add_argument(
+        "-v", "--verbose", action="count", default=0, help="Increase verbosity"
+    )
     args = parser.parse_args()
 
     if args.mode.lower() == "sim":
-        sim_engine.run_simulation(timeframe=args.time)
+        sim_engine.run_simulation(
+            timeframe=args.time,
+            verbose=args.verbose,
+            debug_plots=args.debug_plots,
+            enable_pressure_bias=args.enable_pressure_bias,
+            pressure_lookback=args.pressure_lookback,
+            pressure_scale=args.pressure_scale,
+        )
     else:
         raise ValueError(f"Unknown mode: {args.mode}")
 

--- a/systems/sim_engine.py
+++ b/systems/sim_engine.py
@@ -30,6 +30,11 @@ CONFIDENCE_THRESHOLD = 0.1  # only use forecasts above this
 ENTRY_THRESHOLD = 0.2
 EXIT_THRESHOLD = 0.03
 
+# Pressure bias defaults
+PRESSURE_LOOKBACK = 200  # candles
+PRESSURE_SCALE = 0.5
+ENABLE_PRESSURE_BIAS = True
+
 
 def parse_timeframe(tf: str) -> timedelta | None:
     match = re.match(r"(\d+)([dhmw])", tf)
@@ -67,7 +72,15 @@ def parse_window_size(window: str | int, base_candle: str = "1h") -> int:
             return int(delta.total_seconds() // (3600 * 24))
     raise TypeError(f"Unsupported window type: {type(window)}")
 
-def run_simulation(*, timeframe: str = "1m") -> None:
+def run_simulation(
+    *,
+    timeframe: str = "1m",
+    verbose: int = 0,
+    debug_plots: bool = False,
+    enable_pressure_bias: bool = ENABLE_PRESSURE_BIAS,
+    pressure_lookback: int = PRESSURE_LOOKBACK,
+    pressure_scale: float = PRESSURE_SCALE,
+) -> None:
     """Run a simple simulation over SOLUSD candles."""
     file_path = "data/sim/SOLUSD_1h.csv"
     df = pd.read_csv(file_path)
@@ -228,10 +241,22 @@ def run_simulation(*, timeframe: str = "1m") -> None:
     df["forecast_angle"] = forecast_angles
     df["confidence"] = forecast_confidences
 
+    # --- Pressure Bias Calculation ---
+    lb_min = df["close"].rolling(pressure_lookback, min_periods=1).min()
+    lb_max = df["close"].rolling(pressure_lookback, min_periods=1).max()
+    pos_series = (df["close"] - lb_min) / (lb_max - lb_min + 1e-9)
+    bias_series = (pos_series - 0.5) * 2 * pressure_scale
+    if not enable_pressure_bias:
+        bias_series = pd.Series(0.0, index=df.index)
+    df["pressure_bias"] = bias_series
+
     # --- Control Line Generation ---
     control_line: list[float] = []
+    slope_signals: list[float] = []
     signal_counts: Dict[float, int] = {}
-    for slope, conf in zip(df["forecast_angle"], df["confidence"]):
+    for idx, (slope, conf, bias, pos) in enumerate(
+        zip(df["forecast_angle"], df["confidence"], bias_series, pos_series)
+    ):
         if slope >= 0 and conf >= ENTRY_THRESHOLD * 2:
             val = 1.0
         elif slope >= 0 and conf >= ENTRY_THRESHOLD:
@@ -242,23 +267,29 @@ def run_simulation(*, timeframe: str = "1m") -> None:
             val = -0.5
         else:
             val = 0.0
-        control_line.append(val)
+        slope_signals.append(val)
         signal_counts[val] = signal_counts.get(val, 0) + 1
+        final_val = val + bias
+        final_val = max(-1.0, min(1.0, final_val))
+        control_line.append(final_val)
+        if verbose >= 3 and idx % 100 == 0:
+            print(f"[PRESSURE] pos={pos:.3f}, bias={bias:.3f}")
 
     if control_line and control_line[-1] > 0:
-        last_val = control_line[-1]
-        signal_counts[last_val] -= 1
+        last_slope = slope_signals[-1]
+        signal_counts[last_slope] -= 1
+        slope_signals[-1] = -1.0
         control_line[-1] = -1.0
         signal_counts[-1.0] = signal_counts.get(-1.0, 0) + 1
 
     df["control_line"] = control_line
 
-    total_signals = len([s for s in control_line if s != 0])
+    total_signals = len([s for s in slope_signals if s != 0])
     correct_signals = 0
     weighted_correct = 0.0
     total_signal_conf = 0.0
-    for idx, signal in enumerate(control_line):
-        if signal == 0:
+    for idx, (signal, slope_sig) in enumerate(zip(control_line, slope_signals)):
+        if slope_sig == 0:
             continue
         actual_sign = np.sign(df["slope_angle"].iloc[idx])
         conf = df["confidence"].iloc[idx]
@@ -315,6 +346,15 @@ def run_simulation(*, timeframe: str = "1m") -> None:
     ax2.step(
         df["candle_index"], df["control_line"], where="mid", color="red"
     )
+    if debug_plots and enable_pressure_bias:
+        ax2.plot(
+            df["candle_index"],
+            df["pressure_bias"],
+            linestyle="--",
+            color="gray",
+            label="Pressure Bias",
+        )
+        ax2.legend(loc="upper left")
     ax2.set_ylim(-1.2, 1.2)
     ax2.set_yticks([-1, -0.5, 0, 0.5, 1])
     ax2.set_yticklabels(


### PR DESCRIPTION
## Summary
- add pressure bias knobs (lookback, scale, enable flag) and blend into control line
- support pressure debug logging and optional plot overlay
- expose pressure options via CLI

## Testing
- `python -m py_compile systems/sim_engine.py bot.py`
- `MPLBACKEND=Agg python bot.py --mode sim --time 120m --no-pressure-bias`
- `MPLBACKEND=Agg python bot.py --mode sim --time 120m --pressure-lookback 50 --pressure-scale 0.5 -vvv`


------
https://chatgpt.com/codex/tasks/task_e_68a0aef87c68832698a627add6e0d40a