### PR TITLE
Add buy/sell pressure valve system to simulation engine

### DIFF
--- a/settings/config.json
+++ b/settings/config.json
@@ -1,3 +1,6 @@
 {
-  "flat_band_deg": 10
+  "flat_band_deg": 10,
+  "buy_threshold": 1.0,
+  "sell_threshold": 1.0,
+  "pressure_decay": 0.1
 }


### PR DESCRIPTION
## Summary
- Add configurable buy/sell pressure thresholds and decay to simulation engine
- Track pressure from predictions and trigger buy/sell markers when thresholds are exceeded
- Surface pressure-based buy/sell markers in plot legend and expose config knobs

## Testing
- `python - <<'PY'
import matplotlib
matplotlib.use('Agg')
from systems.sim_engine import run_simulation
run_simulation(timeframe='1m')
PY`


------
https://chatgpt.com/codex/tasks/task_e_68a1108c01ac832683e6b3ba2a233fa8