### PR TITLE
feat: add pressure strategy module

### DIFF
--- a/systems/scripts/strategy_pressure.py
+++ b/systems/scripts/strategy_pressure.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+"""Pressure-based trading signal helpers."""
+
+from typing import Any, Dict
+
+from systems.utils.addlog import addlog
+
+
+def pressure_buy_signal(candle: Dict[str, float], state: Dict[str, Any]) -> bool:
+    """Return True if conditions trigger a pressure buy.
+
+    Parameters
+    ----------
+    candle:
+        Dictionary representing current candle with at least ``close``.
+    state:
+        Mutable state providing ``anchor_price``, ``pressure`` and config knobs.
+    """
+    price = float(candle.get("close", 0.0))
+    anchor = float(state.get("anchor_price", price))
+    pressure = float(state.get("pressure", 0.0))
+    drop_scale = float(state.get("drop_scale", 0.005))
+    trigger = anchor * (1.0 - pressure * drop_scale)
+    decision = price <= trigger
+    if decision and state.get("debug"):
+        addlog(
+            f"[PRESSURE_BUY] price={price:.2f} trigger={trigger:.2f} "
+            f"anchor={anchor:.2f} pressure={pressure:.3f}",
+            verbose_state=state.get("verbose", 0),
+        )
+    return decision
+
+
+def pressure_sell_signal(
+    candle: Dict[str, float], note: Dict[str, Any], state: Dict[str, Any]
+) -> bool:
+    """Return True if conditions trigger a pressure-scaled sell."""
+    price = float(candle.get("close", 0.0))
+    buy_price = float(note.get("price", 0.0))
+    pressure = float(state.get("pressure", 0.0))
+    base_profit = float(state.get("base_profit", 0.01))
+    pressure_scale = float(state.get("pressure_scale", 0.01))
+    target_gain = base_profit + pressure * pressure_scale
+    gain = (price - buy_price) / buy_price if buy_price else 0.0
+    decision = gain >= target_gain
+    if decision and state.get("debug"):
+        addlog(
+            f"[PRESSURE_SELL] price={price:.2f} gain={gain:.4f} "
+            f"target={target_gain:.4f}",
+            verbose_state=state.get("verbose", 0),
+        )
+    return decision
+
+
+def pressure_flat_sell_signal(candle: Dict[str, float], state: Dict[str, Any]) -> bool:
+    """Return True if conditions trigger a flat sell (stop-loss)."""
+    price = float(candle.get("close", 0.0))
+    anchor = float(state.get("anchor_price", price))
+    drawdown = float(state.get("flat_sell_drawdown", 0.03))
+    trigger = anchor * (1.0 - drawdown)
+    decision = price <= trigger
+    if decision and state.get("debug"):
+        addlog(
+            f"[FLAT_SELL] price={price:.2f} trigger={trigger:.2f} "
+            f"anchor={anchor:.2f} drawdown={drawdown:.3f}",
+            verbose_state=state.get("verbose", 0),
+        )
+    return decision

--- a/tests/test_strategy_pressure.py
+++ b/tests/test_strategy_pressure.py
@@ -1,0 +1,63 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from systems.scripts.strategy_pressure import (
+    pressure_buy_signal,
+    pressure_sell_signal,
+    pressure_flat_sell_signal,
+)
+
+
+def _ref_pressure_buy_signal(candle, state):
+    price = float(candle.get("close", 0.0))
+    anchor = float(state.get("anchor_price", price))
+    pressure = float(state.get("pressure", 0.0))
+    drop_scale = float(state.get("drop_scale", 0.005))
+    trigger = anchor * (1.0 - pressure * drop_scale)
+    return price <= trigger
+
+
+def _ref_pressure_sell_signal(candle, note, state):
+    price = float(candle.get("close", 0.0))
+    buy_price = float(note.get("price", 0.0))
+    pressure = float(state.get("pressure", 0.0))
+    base_profit = float(state.get("base_profit", 0.01))
+    pressure_scale = float(state.get("pressure_scale", 0.01))
+    target_gain = base_profit + pressure * pressure_scale
+    gain = (price - buy_price) / buy_price if buy_price else 0.0
+    return gain >= target_gain
+
+
+def _ref_pressure_flat_sell_signal(candle, state):
+    price = float(candle.get("close", 0.0))
+    anchor = float(state.get("anchor_price", price))
+    drawdown = float(state.get("flat_sell_drawdown", 0.03))
+    trigger = anchor * (1.0 - drawdown)
+    return price <= trigger
+
+
+def test_pressure_buy_parity():
+    state = {"anchor_price": 100.0, "pressure": 1.0, "drop_scale": 0.01}
+    candle_hit = {"close": 98.0}
+    candle_miss = {"close": 99.5}
+    assert pressure_buy_signal(candle_hit, state) == _ref_pressure_buy_signal(candle_hit, state)
+    assert pressure_buy_signal(candle_miss, state) == _ref_pressure_buy_signal(candle_miss, state)
+
+
+def test_pressure_sell_parity():
+    note = {"price": 100.0}
+    state = {"pressure": 2.0, "base_profit": 0.02, "pressure_scale": 0.01}
+    candle_hit = {"close": 104.0}
+    candle_miss = {"close": 103.0}
+    assert pressure_sell_signal(candle_hit, note, state) == _ref_pressure_sell_signal(candle_hit, note, state)
+    assert pressure_sell_signal(candle_miss, note, state) == _ref_pressure_sell_signal(candle_miss, note, state)
+
+
+def test_pressure_flat_sell_parity():
+    state = {"anchor_price": 100.0, "flat_sell_drawdown": 0.05}
+    candle_hit = {"close": 94.0}
+    candle_miss = {"close": 96.0}
+    assert pressure_flat_sell_signal(candle_hit, state) == _ref_pressure_flat_sell_signal(candle_hit, state)
+    assert pressure_flat_sell_signal(candle_miss, state) == _ref_pressure_flat_sell_signal(candle_miss, state)


### PR DESCRIPTION
## Summary
- add pressure-based buy, sell, and flat-sell signal helpers
- cover pressure logic with parity tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a125fdee808326a231eaff6ba6163c