### PR TITLE
Show visualization window when --viz is used

### DIFF
--- a/systems/scripts/viz.py
+++ b/systems/scripts/viz.py
@@ -123,6 +123,7 @@ def plot_viz(
     out_path.parent.mkdir(parents=True, exist_ok=True)
     fig.tight_layout()
     fig.savefig(out_path)
+    plt.show()
     plt.close(fig)
     print(f"[VIZ] Saved plot to {out_path}")
 


### PR DESCRIPTION
## Summary
- display matplotlib visualization window when using the `--viz` flag, while still saving the plot

## Testing
- `pytest`
- `python bot.py --mode sim --ledger Kris_Ledger --time 2m --viz`


------
https://chatgpt.com/codex/tasks/task_e_68a1363205d8832692e94734ed94ef82