### PR TITLE
Add trend filter and fix pressure sell ROI

### DIFF
--- a/systems/scripts/evaluate_buy.py
+++ b/systems/scripts/evaluate_buy.py
@@ -21,6 +21,15 @@ def evaluate_buy(
 
     candle = series.iloc[t].to_dict()
 
+    slope = runtime_state.get("slope_direction_avg", 0.0)
+    if slope < 0:
+        addlog(
+            "[SKIP][DOWN_TREND] slope<0",
+            verbose_int=2,
+            verbose_state=verbose,
+        )
+        return None
+
     if not pressure_buy_signal(candle, runtime_state):
         return None
 

--- a/systems/scripts/evaluate_sell.py
+++ b/systems/scripts/evaluate_sell.py
@@ -4,10 +4,7 @@ from __future__ import annotations
 
 from typing import Any, Dict, List
 
-from systems.scripts.strategy_pressure import (
-    pressure_sell_signal,
-    pressure_flat_sell_signal,
-)
+from systems.scripts.strategy_pressure import pressure_flat_sell_signal
 from systems.utils.addlog import addlog
 
 
@@ -69,3 +66,24 @@ def evaluate_sell(
                     signal_log.write(f"{t},FLAT_SELL,{price}\n")
 
     return selected
+
+
+def pressure_sell_signal(
+    candle: Dict[str, float], note: Dict[str, Any], state: Dict[str, Any]
+) -> bool:
+    """Return True if conditions trigger a pressure-scaled sell."""
+    price = float(candle.get("close", 0.0))
+    buy_price = float(note.get("entry_price", 0.0))
+    pressure = float(state.get("pressure", 0.0))
+    base_profit = float(state.get("base_profit", 0.01))
+    pressure_scale = float(state.get("pressure_scale", 0.01))
+    target_gain = base_profit + pressure * pressure_scale
+    gain = (price - buy_price) / buy_price if buy_price else 0.0
+    decision = gain >= target_gain
+    if decision and state.get("debug"):
+        addlog(
+            f"[PRESSURE_SELL] price={price:.2f} gain={gain:.4f} "
+            f"target={target_gain:.4f}",
+            verbose_state=state.get("verbose", 0),
+        )
+    return decision

--- a/systems/sim_engine.py
+++ b/systems/sim_engine.py
@@ -154,6 +154,9 @@ def run_simulation(
     for t in tqdm(range(total), desc="📉 Sim Progress", dynamic_ncols=True):
         candle = df.iloc[t].to_dict()
         update_pressure_state(candle, runtime_state)
+        runtime_state["slope_direction_avg"] = float(
+            candle.get("slope_direction_avg", 0.0)
+        )
         if verbose >= 2:
             addlog(
                 f"[STATE] t={t} anchor={runtime_state['anchor_price']:.2f} "


### PR DESCRIPTION
## Summary
- skip pressure buys when the averaged slope is negative
- compute sell gains from each note's `entry_price`
- track `slope_direction_avg` during simulation for use in buy decisions

## Testing
- `pytest`
- `python bot.py --mode sim --ledger Kris_Ledger --time 2w --viz`


------
https://chatgpt.com/codex/tasks/task_e_68a197f053ec8326836f08c1b8ccbb02