### PR TITLE
Use candle indices for simulation plots

### DIFF
--- a/systems/scripts/evaluate_buy.py
+++ b/systems/scripts/evaluate_buy.py
@@ -53,6 +53,7 @@ def _extract_features(candle: Any, last_close: Optional[float]) -> Dict[str, flo
         "slope": slope,
         "slope_cls": slope_cls,
         "timestamp": candle.get("timestamp"),
+        "candle_index": candle.get("candle_index"),
     }
 
 
@@ -105,8 +106,8 @@ def evaluate_buy(
         }
         state.setdefault("open_notes", []).append(note)
         trade = note
-        if viz_ax is not None and features.get("timestamp") is not None:
-            viz_ax.scatter(features["timestamp"], features["close"], color="green", marker="o")
+        if viz_ax is not None and features.get("candle_index") is not None:
+            viz_ax.scatter(features["candle_index"], features["close"], color="green", marker="o")
         state["buy_pressure"] = 0.0
 
     return features, state, trade

--- a/systems/scripts/evaluate_sell.py
+++ b/systems/scripts/evaluate_sell.py
@@ -49,8 +49,8 @@ def evaluate_sell(
             cost = sum(n.get("entry_price", 0.0) for n in closed)
             proceeds = price * len(closed)
             state["realized_pnl"] = state.get("realized_pnl", 0.0) + (proceeds - cost)
-            if viz_ax is not None and candle.get("timestamp") is not None:
-                viz_ax.scatter(candle["timestamp"], price, color="red", marker="o")
+            if viz_ax is not None and candle.get("candle_index") is not None:
+                viz_ax.scatter(candle["candle_index"], price, color="red", marker="o")
             state["sell_pressure"] = 0.0
         elif slope_cls == 0:
             flat_trigger = SELL_TRIGGER * FLAT_SELL_FRACTION
@@ -61,8 +61,8 @@ def evaluate_sell(
                 cost = sum(n.get("entry_price", 0.0) for n in closed)
                 proceeds = price * qty
                 state["realized_pnl"] = state.get("realized_pnl", 0.0) + (proceeds - cost)
-                if viz_ax is not None and candle.get("timestamp") is not None:
-                    viz_ax.scatter(candle["timestamp"], price, color="orange", marker="o")
+                if viz_ax is not None and candle.get("candle_index") is not None:
+                    viz_ax.scatter(candle["candle_index"], price, color="orange", marker="o")
                 state["sell_pressure"] = 0.0
 
     return state, closed

--- a/systems/sim_engine.py
+++ b/systems/sim_engine.py
@@ -53,7 +53,9 @@ def run_simulation(*, ledger: str, verbose: int = 0, timeframe: str | None = Non
                 pd.Timestamp.utcnow().tz_localize(None) - delta
             ).timestamp()
             df = df[df[ts_col] >= cutoff]
-            df = df.reset_index(drop=True)
+
+    df = df.reset_index(drop=True)
+    df["candle_index"] = range(len(df))
 
     state: Dict[str, Any] = {
         "buy_pressure": 0.0,
@@ -68,9 +70,8 @@ def run_simulation(*, ledger: str, verbose: int = 0, timeframe: str | None = Non
     if viz:
         import matplotlib.pyplot as plt
 
-        times = pd.to_datetime(df[ts_col], unit="s")
         fig, ax = plt.subplots()
-        ax.plot(times, df["close"], color="gray", zorder=1)
+        ax.plot(df["candle_index"], df["close"], color="gray", zorder=1)
         viz_ax = ax
 
     for i in tqdm(range(len(df)), desc="📉 Sim Progress", dynamic_ncols=True):


### PR DESCRIPTION
## Summary
- plot simulation price series by sequential candle index rather than timestamps
- scatter buy/sell markers using candle index
- assign `candle_index` column after filtering data

## Testing
- `python bot.py --mode sim --ledger Kris_Ledger --time 1m` *(fails: could not install matplotlib to run with `--viz`)*

------
https://chatgpt.com/codex/tasks/task_e_68a1fa3050288326ae56bd201bd659fc