### PR TITLE
Restore buy/sell logic with window features

### DIFF
--- a/systems/scripts/evaluate_buy.py
+++ b/systems/scripts/evaluate_buy.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
-"""Buy evaluation based on pressure and simple feature rules."""
+"""Buy evaluation using rolling-window features and pressure balances."""
 
-from dataclasses import dataclass
 from typing import Any, Dict, Optional, Tuple
 
 from systems.utils.config import load_settings
@@ -20,28 +19,43 @@ MAX_PRESSURE = 10.0
 BUY_TRIGGER = 3.0
 
 
-def _extract_features(candle: Any, last_close: Optional[float]) -> Dict[str, float]:
-    """Compute basic features from the current candle.
+def _rule_predict(features: Optional[Dict[str, float]]) -> int:
+    """Classify window features into buy (+1), sell (-1) or neutral (0)."""
 
-    Parameters
-    ----------
-    candle: Any
-        Candle row providing ``open``, ``high``, ``low`` and ``close`` values.
-    last_close: Optional[float]
-        Close price from the previous candle.
-    """
+    if not features:
+        return 0
 
-    open_p = float(candle.get("open", 0.0))
-    close_p = float(candle.get("close", 0.0))
-    high_p = float(candle.get("high", close_p))
-    low_p = float(candle.get("low", close_p))
+    score = 0
+    if features.get("volatility", 0.0) > RANGE_MIN:
+        score += 1
+    if features.get("pct_change", 0.0) > 0:
+        score += 1
+    else:
+        score -= 1
+    if features.get("skew", 0.0) > VOLUME_SKEW_BIAS:
+        score += 1
+    else:
+        score -= 1
+    slope_cls = features.get("slope_cls", 0)
+    if slope_cls > 0:
+        score += 1
+    elif slope_cls < 0:
+        score -= 1
+    return 1 if score > 0 else -1 if score < 0 else 0
+
+
+def _window_features(window: list[Dict[str, Any]], candle: Any) -> Dict[str, float]:
+    """Compute feature dictionary for the current rolling ``window``."""
+
+    open_p = float(window[0].get("open", window[0].get("close", 0.0)))
+    close_p = float(window[-1].get("close", 0.0))
+    high_p = max(float(c.get("high", close_p)) for c in window)
+    low_p = min(float(c.get("low", close_p)) for c in window)
 
     pct_change = (close_p - open_p) / open_p if open_p else 0.0
     volatility = (high_p - low_p) / open_p if open_p else 0.0
     skew = (close_p - (high_p + low_p) / 2) / (high_p - low_p) if high_p != low_p else 0.0
-    slope = 0.0
-    if last_close is not None and last_close:
-        slope = (close_p - last_close) / last_close
+    slope = (close_p - float(window[0].get("close", open_p))) / float(window[0].get("close", open_p)) if window[0].get("close", open_p) else 0.0
     slope_cls = 1 if slope > STRONG_MOVE_THRESHOLD else -1 if slope < -STRONG_MOVE_THRESHOLD else 0
 
     return {
@@ -57,57 +71,42 @@ def _extract_features(candle: Any, last_close: Optional[float]) -> Dict[str, flo
     }
 
 
-def _rule_predict(features: Dict[str, float]) -> float:
-    """Heuristic rule used to accumulate buy pressure."""
-
-    score = 0.0
-    if features["volatility"] > RANGE_MIN:
-        score += 1.0
-    if features["pct_change"] > 0:
-        score += 1.0
-    if features["skew"] > VOLUME_SKEW_BIAS:
-        score += 1.0
-    return score
-
-
 def evaluate_buy(
     candle: Any,
     last_features: Optional[Dict[str, float]],
     state: Dict[str, Any],
     viz_ax=None,
-) -> Tuple[Dict[str, float], Dict[str, Any], Optional[Dict[str, Any]]]:
-    """Update buy pressure and possibly open a new position.
+) -> Tuple[Dict[str, Any], Optional[Dict[str, float]]]:
+    """Update pressure balances and maybe open a new note."""
 
-    Parameters
-    ----------
-    candle:
-        Current market candle.
-    last_features:
-        Feature dictionary from previous candle; may be ``None``.
-    state:
-        Mutable strategy state.
-    viz_ax:
-        Optional Matplotlib axis for plotting buy markers.
-    """
+    pred = _rule_predict(last_features)
 
-    last_close = last_features.get("close") if last_features else None
-    features = _extract_features(candle, last_close)
-
-    pred = _rule_predict(features)
     bp = state.get("buy_pressure", 0.0)
-    bp = min(MAX_PRESSURE, bp + pred + features["slope_cls"])
+    sp = state.get("sell_pressure", 0.0)
+    if pred > 0:
+        bp = min(MAX_PRESSURE, bp + pred)
+        sp = max(0.0, sp - pred)
+    elif pred < 0:
+        sp = min(MAX_PRESSURE, sp + abs(pred))
+        bp = max(0.0, bp + pred)
     state["buy_pressure"] = bp
+    state["sell_pressure"] = sp
 
-    trade = None
     if bp >= BUY_TRIGGER:
-        note = {
-            "entry_price": features["close"],
-            "timestamp": features.get("timestamp"),
-        }
+        price = float(candle.get("close", 0.0))
+        note = {"entry_price": price, "timestamp": candle.get("timestamp")}
         state.setdefault("open_notes", []).append(note)
-        trade = note
-        if viz_ax is not None and features.get("candle_index") is not None:
-            viz_ax.scatter(features["candle_index"], features["close"], color="green", marker="o")
+        if viz_ax is not None and candle.get("candle_index") is not None:
+            viz_ax.scatter(candle["candle_index"], price, color="green", marker="o")
         state["buy_pressure"] = 0.0
 
-    return features, state, trade
+    window = state.setdefault("_window", [])
+    window.append(candle)
+    if len(window) > WINDOW_SIZE:
+        window.pop(0)
+
+    features = last_features
+    if len(window) == WINDOW_SIZE and (candle.get("candle_index", 0) % WINDOW_STEP == 0):
+        features = _window_features(window, candle)
+
+    return state, features


### PR DESCRIPTION
## Summary
- Reinstate window-based feature extraction and rule-driven buy/sell pressure balancing
- Handle full and partial sells based on accumulated sell pressure
- Add explicit legend entries and trade counts to the simulator plot

## Testing
- `python bot.py --mode sim --ledger Kris_Ledger --time 2m --viz` *(fails: ModuleNotFoundError: No module named 'matplotlib')*
- `pip install matplotlib` *(fails: Could not find a version that satisfies the requirement matplotlib)*

------
https://chatgpt.com/codex/tasks/task_e_68a1fce343e8832683ae2ea920a9ab4b