### PR TITLE
refactor: unify strategy config

### DIFF
--- a/settings/settings.json
+++ b/settings/settings.json
@@ -14,24 +14,6 @@
         "trigger_p": 0.75,
         "depth_scale": 5.0,
         "min_usd": 1.0
-      },
-      "window_settings": {
-        "minnow": {
-          "window_size": "12h",
-          "buy_trigger_position": 0.1,
-          "reset_buy_percent": 0.5,
-          "maturity_position": 1.0,
-          "max_notes_sell_per_candle": 1,
-          "investment_fraction": 0.125
-        },
-        "fish": {
-          "window_size": "2d",
-          "buy_trigger_position": 0.1,
-          "reset_buy_percent": 0.5,
-          "maturity_position": 1,
-          "max_notes_sell_per_candle": 1,
-          "investment_fraction": 0.25
-        }
       }
     },
     "Travis_Ledger": {
@@ -48,24 +30,6 @@
         "trigger_p": 0.75,
         "depth_scale": 5.0,
         "min_usd": 1.0
-      },
-      "window_settings": {
-        "mouse": {
-          "window_size": "12h",
-          "buy_trigger_position": 0.1,
-          "reset_buy_percent": 0.5,
-          "maturity_position": 1.0,
-          "max_notes_sell_per_candle": 1,
-          "investment_fraction": 0.125
-        },
-        "rabbit": {
-          "window_size": "2d",
-          "buy_trigger_position": 0.1,
-          "reset_buy_percent": 0.5,
-          "maturity_position": 1,
-          "max_notes_sell_per_candle": 1,
-          "investment_fraction": 0.25
-        }
       }
     }
   },

--- a/systems/scripts/evaluate_buy.py
+++ b/systems/scripts/evaluate_buy.py
@@ -18,14 +18,14 @@ def evaluate_buy(
     t: int,
     series,
     *,
-    window_name: str,
     cfg: Dict[str, Any],
     runtime_state: Dict[str, Any],
 ):
-    """Return sizing and metadata for a buy signal in ``window_name``."""
+    """Return sizing and metadata for a buy signal."""
 
-    strategy = runtime_state.get("strategy", {})
-    window_size = int(strategy.get("window_size") or cfg.get("window_size", 0))
+    window_name = "strategy"
+    strategy = cfg or runtime_state.get("strategy", {})
+    window_size = int(strategy.get("window_size", 0))
     step = int(strategy.get("window_step", 1))
     start = t + 1 - window_size
     if start < 0 or start % step != 0:

--- a/systems/scripts/evaluate_sell.py
+++ b/systems/scripts/evaluate_sell.py
@@ -19,16 +19,16 @@ def evaluate_sell(
     t: int,
     series,
     *,
-    window_name: str,
     cfg: Dict[str, Any],
     open_notes: List[Dict[str, Any]],
     runtime_state: Dict[str, Any] | None = None,
 ) -> List[Dict[str, Any]]:
-    """Return a list of notes to sell in ``window_name`` on this candle."""
+    """Return a list of notes to sell on this candle."""
 
     runtime_state = runtime_state or {}
-    strategy = runtime_state.get("strategy", {})
-    window_size = int(strategy.get("window_size") or cfg.get("window_size", 0))
+    window_name = "strategy"
+    strategy = cfg or runtime_state.get("strategy", {})
+    window_size = int(strategy.get("window_size", 0))
     step = int(strategy.get("window_step", 1))
     start = t + 1 - window_size
     if start < 0 or start % step != 0:
@@ -48,7 +48,7 @@ def evaluate_sell(
     sell_p = pressures["sell"].get(window_name, 0.0)
     max_p = strategy.get("max_pressure", 1.0)
     results: List[Dict[str, Any]] = []
-    window_notes = [n for n in open_notes if n.get("window_name") == window_name]
+    window_notes = open_notes
     n_notes = len(window_notes)
     candle = series.iloc[t]
     price = float(candle["close"])


### PR DESCRIPTION
## Summary
- collapse multi-window profiles into one `strategy` config used by sim and live engines
- streamline evaluate_buy/evaluate_sell to operate on single strategy settings
- drop per-window reporting and window_settings from config

## Testing
- `MPLBACKEND=Agg python bot.py --mode sim --ledger Kris_Ledger --time 60d --viz -v 2>&1 | tail -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68a21d8eab0c83268077aa6e284db391