### PR TITLE
Align buy/sell timing with reference mini-bot

### DIFF
--- a/systems/scripts/evaluate_buy.py
+++ b/systems/scripts/evaluate_buy.py
@@ -109,7 +109,8 @@ def evaluate_buy(
     window_size = int(strategy.get("window_size", 0))
     step = int(strategy.get("window_step", 1))
     start = t + 1 - window_size
-    if start < 0 or start % step != 0:
+    if start < 0:
+        runtime_state["last_slope_cls"] = None
         return False
 
     verbose = runtime_state.get("verbose", 0)
@@ -151,9 +152,10 @@ def evaluate_buy(
     else:
         runtime_state["last_slope_cls"] = None
 
-    # Compute features for next iteration
-    features = compute_window_features(series, start, window_size)
-    runtime_state["last_features"][window_name] = features
+    # Compute features for next iteration only on step boundaries
+    if start % step == 0:
+        features = compute_window_features(series, start, window_size)
+        runtime_state["last_features"][window_name] = features
 
     if buy_p < strategy.get("buy_trigger", 0.0):
         return False

--- a/systems/scripts/evaluate_sell.py
+++ b/systems/scripts/evaluate_sell.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 """Sell evaluation based on predictive pressures."""
 
-from math import ceil
 from typing import Any, Dict, List
 
 from systems.utils.addlog import addlog
@@ -17,16 +16,18 @@ def evaluate_sell(
     open_notes: List[Dict[str, Any]],
     runtime_state: Dict[str, Any] | None = None,
 ) -> List[Dict[str, Any]]:
-    """Return a list of notes to sell on this candle."""
+    """Return a list of sell instructions for this candle.
+
+    Each instruction contains:
+    ``note``         – the note object to reduce or close
+    ``sell_amount``  – coin amount to sell from the note
+    ``sell_mode``    – "normal" or "flat"
+    """
 
     runtime_state = runtime_state or {}
     window_name = "strategy"
     strategy = cfg or runtime_state.get("strategy", {})
     window_size = int(strategy.get("window_size", 0))
-    step = int(strategy.get("window_step", 1))
-    start = t + 1 - window_size
-    if start < 0 or start % step != 0:
-        return []
 
     verbose = runtime_state.get("verbose", 0)
 
@@ -34,26 +35,19 @@ def evaluate_sell(
     sell_p = pressures["sell"].get(window_name, 0.0)
     max_p = strategy.get("max_pressure", 1.0)
     results: List[Dict[str, Any]] = []
-    window_notes = open_notes
-    n_notes = len(window_notes)
-    candle = series.iloc[t]
-    price = float(candle["close"])
 
-    def roi_now(note: Dict[str, Any]) -> float:
-        buy = note.get("entry_price", 0.0)
-        return (price - buy) / buy if buy else 0.0
-
-    window_notes.sort(key=roi_now, reverse=True)
-
-    if sell_p >= strategy.get("sell_trigger", 0.0) and window_notes:
+    total_size = sum(n.get("entry_amount", 0.0) for n in open_notes)
+    if sell_p >= strategy.get("sell_trigger", 0.0) and total_size > 0:
         sell_frac = sell_p / max_p if max_p else 0.0
-        k = max(1, ceil(sell_frac * n_notes))
-        results = window_notes[:k]
-        for n in results:
-            n["sell_mode"] = "normal"
+        trade_size = sell_frac * total_size
+        for n in open_notes:
+            note_amt = n.get("entry_amount", 0.0)
+            amt = sell_frac * note_amt
+            if amt > 0:
+                results.append({"note": n, "sell_amount": amt, "sell_mode": "normal"})
         pressures["sell"][window_name] = 0.0
         addlog(
-            f"[SELL][{window_name} {window_size}] mode=normal count={k}/{n_notes} pressure={sell_p:.1f}/{max_p:.1f}",
+            f"[SELL][{window_name} {window_size}] mode=normal size={trade_size:.4f} pressure={sell_p:.1f}/{max_p:.1f}",
             verbose_int=1,
             verbose_state=verbose,
         )
@@ -61,18 +55,20 @@ def evaluate_sell(
 
     slope_cls = runtime_state.get("last_slope_cls", None)
     flat_trigger = strategy.get("sell_trigger", 0.0) * strategy.get("flat_sell_threshold", 1.0)
-    if slope_cls == 0 and sell_p >= flat_trigger and window_notes:
-        k = max(1, ceil(strategy.get("flat_sell_fraction", 0.0) * n_notes))
-        results = window_notes[:k]
-        for n in results:
-            n["sell_mode"] = "flat"
+    if slope_cls == 0 and sell_p >= flat_trigger and total_size > 0:
+        frac = strategy.get("flat_sell_fraction", 0.0)
+        trade_size = frac * total_size
+        for n in open_notes:
+            note_amt = n.get("entry_amount", 0.0)
+            amt = frac * note_amt
+            if amt > 0:
+                results.append({"note": n, "sell_amount": amt, "sell_mode": "flat"})
         pressures["sell"][window_name] = 0.0
         addlog(
-            f"[SELL][{window_name} {window_size}] mode=flat count={k}/{n_notes} pressure={sell_p:.1f}/{max_p:.1f}",
+            f"[SELL][{window_name} {window_size}] mode=flat size={trade_size:.4f} pressure={sell_p:.1f}/{max_p:.1f}",
             verbose_int=1,
             verbose_state=verbose,
         )
         return results
-
 
     return []


### PR DESCRIPTION
## Summary
- Update buy evaluation to refresh pressures each candle and record slope class per tick
- Rework sell evaluation to distribute sells proportionally across all open notes and support flat sells
- Adjust simulation and live engines to execute proportional and partial sells for sim/live parity

## Testing
- `python -m pytest`
- `python bot.py --mode sim --ledger Kris_Ledger`


------
https://chatgpt.com/codex/tasks/task_e_68a2303a166483269f25d40d58c2eedd