### PR TITLE
Align trade logic with mini-bot reference

### DIFF
--- a/systems/scripts/evaluate_buy.py
+++ b/systems/scripts/evaluate_buy.py
@@ -1,18 +1,12 @@
 from __future__ import annotations
 
-"""Buy evaluation driven by predictive pressures."""
+"""Mini-bot compatible buy evaluation."""
 
 from math import atan, degrees
 from typing import Any, Dict
 
 import numpy as np
 
-from systems.utils.addlog import addlog
-
-
-# ---------------------------------------------------------------------------
-# Feature extraction and prediction rules
-# ---------------------------------------------------------------------------
 
 def classify_slope(slope: float, flat_band_deg: float = 10.0) -> int:
     """Return -1 for down, 0 for flat, +1 for up."""
@@ -23,7 +17,7 @@ def classify_slope(slope: float, flat_band_deg: float = 10.0) -> int:
 
 
 def compute_window_features(series, start: int, window_size: int) -> Dict[str, float]:
-    """Compute window statistics matching reference logic."""
+    """Compute rolling window statistics used by the mini-bot."""
     end = start + window_size
     sub = series.iloc[start:end]
 
@@ -60,7 +54,7 @@ def compute_window_features(series, start: int, window_size: int) -> Dict[str, f
 
 
 def rule_predict(features: Dict[str, float], cfg: Dict[str, float]) -> int:
-    """Classify next window move with multi-feature rules."""
+    """Classify the next window move with mini-bot rules."""
     slope = features.get("slope", 0.0)
     rng = features.get("range", 0.0)
 
@@ -90,43 +84,31 @@ def rule_predict(features: Dict[str, float], cfg: Dict[str, float]) -> int:
     return 0
 
 
-# ---------------------------------------------------------------------------
-# Main evaluator
-# ---------------------------------------------------------------------------
-
 def evaluate_buy(
-    ctx: Dict[str, Any],
     t: int,
     series,
     *,
-    cfg: Dict[str, Any],
-    runtime_state: Dict[str, Any],
-):
-    """Return sizing and metadata for a buy signal."""
+    cfg: Dict[str, float],
+    state: Dict[str, Any],
+) -> Dict[str, float] | None:
+    """Update pressures and return buy size if triggered."""
 
-    window_name = "strategy"
-    strategy = cfg or runtime_state.get("strategy", {})
-    window_size = int(strategy.get("window_size", 0))
+    window_size = int(cfg.get("window_size", 0))
     start = t + 1 - window_size
     if start < 0:
-        runtime_state["last_slope_cls"] = None
-        return False
+        state["last_features"] = None
+        return None
 
-    verbose = runtime_state.get("verbose", 0)
-
-    pressures = runtime_state.setdefault("pressures", {"buy": {}, "sell": {}})
-    last_features = runtime_state.setdefault("last_features", {}).get(window_name)
-
-    buy_p = pressures["buy"].get(window_name, 0.0)
-    sell_p = pressures["sell"].get(window_name, 0.0)
-    max_p = strategy.get("max_pressure", 1.0)
+    last_features = state.get("last_features")
+    buy_p = state.get("buy_pressure", 0.0)
+    sell_p = state.get("sell_pressure", 0.0)
+    max_p = float(cfg.get("max_pressure", 7.0))
 
     if last_features is not None:
-        pred = rule_predict(last_features, strategy)
+        pred = rule_predict(last_features, cfg)
         slope_cls = classify_slope(
-            last_features.get("slope", 0.0), strategy.get("flat_band_deg", 10.0)
+            last_features.get("slope", 0.0), cfg.get("flat_band_deg", 10.0)
         )
-        runtime_state["last_slope_cls"] = slope_cls
         if pred > 0:
             buy_p = min(max_p, buy_p + 1)
             sell_p = max(0.0, sell_p - 2)
@@ -140,63 +122,15 @@ def evaluate_buy(
             else:
                 buy_p = max(0.0, buy_p - 0.5)
                 sell_p = max(0.0, sell_p - 0.5)
-        pressures["buy"][window_name] = buy_p
-        pressures["sell"][window_name] = sell_p
-        if verbose >= 2:
-            addlog(
-                f"[PRESSURE][{window_name}] buy={buy_p:.1f} sell={sell_p:.1f} pred={pred} slope_cls={slope_cls}",
-                verbose_int=2,
-                verbose_state=verbose,
-            )
-    else:
-        runtime_state["last_slope_cls"] = None
 
-    # Compute features for next iteration every tick
     features = compute_window_features(series, start, window_size)
-    runtime_state["last_features"][window_name] = features
+    state["last_features"] = features
+    state["buy_pressure"] = buy_p
+    state["sell_pressure"] = sell_p
 
-    if buy_p < strategy.get("buy_trigger", 0.0):
-        return False
+    if buy_p >= cfg.get("buy_trigger", 0.0):
+        trade_size = buy_p / max_p if max_p else 0.0
+        state["buy_pressure"] = 0.0
+        return {"trade_size": trade_size}
+    return None
 
-    fraction = buy_p / max_p if max_p else 0.0
-    capital = runtime_state.get("capital", 0.0)
-    limits = runtime_state.get("limits", {})
-    max_sz = float(limits.get("max_note_usdt", capital))
-    min_sz = float(limits.get("min_note_size", 0.0))
-
-    raw = capital * fraction
-    size_usd = min(raw, capital, max_sz)
-    if size_usd != raw:
-        addlog(
-            f"[CLAMP] size=${raw:.2f} → ${size_usd:.2f} (cap=${capital:.2f}, max=${max_sz:.2f})",
-            verbose_int=2,
-            verbose_state=verbose,
-        )
-    if size_usd < min_sz:
-        addlog(
-            f"[SKIP][{window_name} {window_size}] size=${size_usd:.2f} < min=${min_sz:.2f}",
-            verbose_int=2,
-            verbose_state=verbose,
-        )
-        return False
-
-    addlog(
-        f"[BUY][{window_name} {window_size}] pressure={buy_p:.1f}/{max_p:.1f} spend=${size_usd:.2f}",
-        verbose_int=1,
-        verbose_state=verbose,
-    )
-
-    pressures["buy"][window_name] = 0.0
-
-    result = {
-        "size_usd": size_usd,
-        "window_name": window_name,
-        "window_size": window_size,
-        "p_buy": fraction,
-        "unlock_p": None,
-    }
-    candle = series.iloc[t]
-    if "timestamp" in series.columns:
-        result["created_ts"] = int(candle.get("timestamp"))
-    result["created_idx"] = t
-    return result

--- a/systems/scripts/evaluate_sell.py
+++ b/systems/scripts/evaluate_sell.py
@@ -1,82 +1,51 @@
 from __future__ import annotations
 
-"""Sell evaluation based on predictive pressures."""
+"""Mini-bot compatible sell evaluation."""
 
 from typing import Any, Dict, List
 
-from systems.utils.addlog import addlog
 from .evaluate_buy import classify_slope
 
 
 def evaluate_sell(
-    ctx: Dict[str, Any],
     t: int,
     series,
     *,
-    cfg: Dict[str, Any],
-    open_notes: List[Dict[str, Any]],
-    runtime_state: Dict[str, Any] | None = None,
+    cfg: Dict[str, float],
+    open_notes: List[Dict[str, float]],
+    state: Dict[str, Any],
 ) -> List[Dict[str, Any]]:
-    """Return a list of sell instructions for this candle.
+    """Return proportional sell instructions for this tick."""
 
-    Each instruction contains:
-    ``note``         – the note object to reduce or close
-    ``sell_amount``  – coin amount to sell from the note
-    ``sell_mode``    – "normal" or "flat"
-    """
-
-    runtime_state = runtime_state or {}
-    window_name = "strategy"
-    strategy = cfg or runtime_state.get("strategy", {})
-    window_size = int(strategy.get("window_size", 0))
-
-    verbose = runtime_state.get("verbose", 0)
-
-    pressures = runtime_state.setdefault("pressures", {"buy": {}, "sell": {}})
-    sell_p = pressures["sell"].get(window_name, 0.0)
-    max_p = strategy.get("max_pressure", 1.0)
+    sell_p = state.get("sell_pressure", 0.0)
+    max_p = float(cfg.get("max_pressure", 7.0))
     results: List[Dict[str, Any]] = []
 
-    total_size = sum(n.get("entry_amount", 0.0) for n in open_notes)
-    if sell_p >= strategy.get("sell_trigger", 0.0) and total_size > 0:
+    total_size = sum(n.get("amount", 0.0) for n in open_notes)
+    if sell_p >= cfg.get("sell_trigger", 0.0) and total_size > 0:
         sell_frac = sell_p / max_p if max_p else 0.0
-        trade_size = sell_frac * total_size
         for n in open_notes:
-            note_amt = n.get("entry_amount", 0.0)
-            amt = sell_frac * note_amt
+            amt = sell_frac * n.get("amount", 0.0)
             if amt > 0:
                 results.append({"note": n, "sell_amount": amt, "sell_mode": "normal"})
-        pressures["sell"][window_name] = 0.0
-        addlog(
-            f"[SELL][{window_name} {window_size}] mode=normal size={trade_size:.4f} pressure={sell_p:.1f}/{max_p:.1f}",
-            verbose_int=1,
-            verbose_state=verbose,
-        )
+        state["sell_pressure"] = 0.0
         return results
 
-    features = runtime_state.get("last_features", {}).get(window_name)
+    features = state.get("last_features")
     slope_cls = (
-        classify_slope(
-            features.get("slope", 0.0), strategy.get("flat_band_deg", 10.0)
-        )
+        classify_slope(features.get("slope", 0.0), cfg.get("flat_band_deg", 10.0))
         if features
         else None
     )
-    flat_trigger = strategy.get("sell_trigger", 0.0) * strategy.get("flat_sell_threshold", 1.0)
+    flat_trigger = cfg.get("sell_trigger", 0.0) * cfg.get("flat_sell_threshold", 1.0)
     if slope_cls == 0 and sell_p >= flat_trigger and total_size > 0:
-        frac = strategy.get("flat_sell_fraction", 0.0)
-        trade_size = frac * total_size
+        frac = cfg.get("flat_sell_fraction", 0.0)
         for n in open_notes:
-            note_amt = n.get("entry_amount", 0.0)
-            amt = frac * note_amt
+            amt = frac * n.get("amount", 0.0)
             if amt > 0:
                 results.append({"note": n, "sell_amount": amt, "sell_mode": "flat"})
-        pressures["sell"][window_name] = 0.0
-        addlog(
-            f"[SELL][{window_name} {window_size}] mode=flat size={trade_size:.4f} pressure={sell_p:.1f}/{max_p:.1f}",
-            verbose_int=1,
-            verbose_state=verbose,
-        )
+        state["sell_pressure"] = 0.0
         return results
 
     return []
+

--- a/systems/sim_engine.py
+++ b/systems/sim_engine.py
@@ -1,433 +1,128 @@
 from __future__ import annotations
 
-"""Historical simulation engine for position-based strategy."""
+"""Simple historical simulation matching mini-bot trade logic."""
 
-import shutil
-from datetime import datetime, timezone
-import csv
-import json
+import argparse
+import re
+from datetime import timedelta
 
+import matplotlib.pyplot as plt
 import pandas as pd
-from tqdm import tqdm
 
-from systems.scripts.ledger import Ledger, save_ledger
 from systems.scripts.evaluate_buy import evaluate_buy
 from systems.scripts.evaluate_sell import evaluate_sell
-from systems.scripts.runtime_state import build_runtime_state
-from systems.scripts.trade_apply import (
-    apply_buy,
-    apply_sell,
-    paper_execute_buy,
-    paper_execute_sell,
-)
-from systems.scripts.strategy_jackpot import (
-    init_jackpot,
-    on_buy_drip,
-    maybe_periodic_jackpot_buy,
-    maybe_cashout_jackpot,
-)
-from systems.utils.addlog import addlog
-from pathlib import Path
-
-from systems.utils.config import load_settings, load_ledger_config, resolve_path
-from systems.utils.resolve_symbol import (
-    split_tag,
-    resolve_ccxt_symbols,
-    to_tag,
-    sim_path_csv,
-)
-from systems.utils.time import parse_cutoff as parse_timeframe
 
 
-def run_simulation(
-    *,
-    ledger: str,
-    verbose: int = 0,
-    timeframe: str = "1m",
-    viz: bool = True,
-) -> None:
-    settings = load_settings()
-    ledger_cfg = load_ledger_config(ledger)
-    base, _ = split_tag(ledger_cfg["tag"])
-    coin = base.upper()
-    strategy_cfg = settings.get("general_settings", {}).get("strategy_settings", {})
+CFG = {
+    "window_size": 24,
+    "flat_band_deg": 10.0,
+    "strong_move_threshold": 0.15,
+    "range_min": 0.08,
+    "volume_skew_bias": 0.4,
+    "max_pressure": 7,
+    "buy_trigger": 2,
+    "sell_trigger": 4,
+    "flat_sell_fraction": 0.2,
+    "flat_sell_threshold": 0.5,
+}
 
-    kraken_symbol, _ = resolve_ccxt_symbols(settings, ledger)
-    tag = to_tag(kraken_symbol)
-    csv_path = sim_path_csv(tag)
-    if not Path(csv_path).exists():
-        print(
-            f"[ERROR] Missing data file: {csv_path}. Run: python bot.py --mode fetch --ledger {ledger}"
-        )
-        raise SystemExit(1)
-    df = pd.read_csv(csv_path)
 
-    # Normalize + guard
-    ts_col = None
-    for c in df.columns:
-        lc = str(c).lower()
-        if lc in ("timestamp", "time", "date"):
-            ts_col = c
-            break
-    if ts_col is None:
-        raise ValueError(f"No timestamp column in {csv_path}")
+def parse_timeframe(tf: str) -> timedelta | None:
+    match = re.match(r"(\d+)([dhmw])", tf)
+    if not match:
+        return None
+    val, unit = int(match.group(1)), match.group(2)
+    if unit == "d":
+        return timedelta(days=val)
+    if unit == "w":
+        return timedelta(weeks=val)
+    if unit == "m":
+        return timedelta(days=30 * val)  # rough month
+    if unit == "h":
+        return timedelta(hours=val)
+    return None
 
-    df[ts_col] = pd.to_numeric(df[ts_col], errors="coerce")
-    df = df.dropna(subset=[ts_col])
 
-    before = len(df)
-    df = df.sort_values(ts_col).drop_duplicates(subset=[ts_col], keep="last").reset_index(drop=True)
-    removed = before - len(df)
-
-    # Optional hard check
-    if not df[ts_col].is_monotonic_increasing:
-        raise ValueError(f"Candles not sorted by {ts_col}: {csv_path}")
+def run_simulation(*, timeframe: str = "1m", viz: bool = True) -> None:
+    file_path = "data/sim/SOLUSD_1h.csv"
+    df = pd.read_csv(file_path)
 
     if timeframe:
         delta = parse_timeframe(timeframe)
-        cutoff_ts = (datetime.now(tz=timezone.utc) - delta).timestamp()
-        df = df[df[ts_col] >= cutoff_ts].reset_index(drop=True)
+        if delta:
+            cutoff = (pd.Timestamp.utcnow().tz_localize(None) - delta).timestamp()
+            if "timestamp" in df.columns:
+                df = df[df["timestamp"] >= cutoff]
 
-    # Log one line so we always know what we ran on
-    first_ts = int(df[ts_col].iloc[0]) if len(df) else None
-    last_ts = int(df[ts_col].iloc[-1]) if len(df) else None
-    first_iso = (
-        datetime.fromtimestamp(first_ts, tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
-        if first_ts is not None
-        else "n/a"
-    )
-    last_iso = (
-        datetime.fromtimestamp(last_ts, tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
-        if last_ts is not None
-        else "n/a"
-    )
-    print(
-        f"[DATA][SIM] file={csv_path} rows={len(df)} first={first_iso} last={last_iso} dups_removed={removed}"
-    )
+    df = df.reset_index(drop=True)
+    df["candle_index"] = range(len(df))
 
-    total = len(df)
+    state = {"buy_pressure": 0.0, "sell_pressure": 0.0, "last_features": None}
+    open_notes: list[dict[str, float]] = []  # {price, amount}
+    realized_pnl = 0.0
 
-    runtime_state = build_runtime_state(
-        settings,
-        ledger_cfg,
-        mode="sim",
-        prev={"verbose": verbose},
-    )
-    runtime_state["mode"] = "sim"
-    runtime_state["buy_unlock_p"] = {}
-    init_jackpot(runtime_state, ledger_cfg, df)
+    if viz:
+        fig, ax1 = plt.subplots(figsize=(12, 6))
+        ax1.plot(df["candle_index"], df["close"], color="blue", label="Close Price")
+    else:
+        ax1 = None
 
-    ledger_obj = Ledger()
-    buy_points: list[tuple[float, float]] = []
-    sell_points: list[tuple[float, float]] = []
-    win_metrics = {
-        "strategy": {
-            "window_size": str(strategy_cfg.get("window_size", "")),
-            "buys": 0,
-            "sells": 0,
-            "gross_invested": 0.0,
-            "realized_cost": 0.0,
-            "realized_proceeds": 0.0,
-            "realized_trades": 0,
-            "realized_roi_accum": 0.0,
-        }
-    }
-    addlog(f"[SIM] Starting simulation for {coin}", verbose_int=1, verbose_state=verbose)
-
-    for t in tqdm(range(total), desc="📉 Sim Progress", dynamic_ncols=True):
+    for t in range(len(df)):
         price = float(df.iloc[t]["close"])
 
-        ctx = {"ledger": ledger_obj}
-        buy_res = evaluate_buy(
-            ctx,
-            t,
-            df,
-            cfg=strategy_cfg,
-            runtime_state=runtime_state,
-        )
+        buy_res = evaluate_buy(t, df, cfg=CFG, state=state)
         if buy_res:
-            ts = None
-            if "timestamp" in df.columns:
-                ts = int(df.iloc[t]["timestamp"])
+            size = buy_res["trade_size"]
+            open_notes.append({"price": price, "amount": size})
+            if ax1 is not None:
+                ax1.scatter(
+                    df.iloc[t]["candle_index"], price, color="green", s=120, zorder=6
+                )
 
-            result = paper_execute_buy(price, buy_res["size_usd"], timestamp=ts)
-
-            note = apply_buy(
-                ledger=ledger_obj,
-                window_name="strategy",
-                t=t,
-                meta=buy_res,
-                result=result,
-                state=runtime_state,
-            )
-
-            runtime_state.setdefault("buy_unlock_p", {})["strategy"] = buy_res.get("unlock_p")
-
-            m_buy = win_metrics.get("strategy")
-            if m_buy is not None:
-                cost = result["filled_amount"] * result["avg_price"]
-                m_buy["buys"] += 1
-                m_buy["gross_invested"] += cost
-
-            if viz:
-                buy_points.append((float(df.iloc[t][ts_col]), price))
-
-        open_notes = ledger_obj.get_open_notes()
-        sell_orders = evaluate_sell(
-            ctx,
-            t,
-            df,
-            cfg=strategy_cfg,
-            open_notes=open_notes,
-            runtime_state=runtime_state,
-        )
-
+        sell_orders = evaluate_sell(t, df, cfg=CFG, open_notes=open_notes, state=state)
         for order in sell_orders:
             note = order["note"]
             amt = order["sell_amount"]
             mode = order.get("sell_mode", "normal")
-            entry_price = note.get("entry_price", 0.0)
+            entry_price = note["price"]
 
-            ts = None
-            if "timestamp" in df.columns:
-                ts = int(df.iloc[t]["timestamp"])
-            result = paper_execute_sell(price, amt, timestamp=ts)
+            pnl = (price - entry_price) * amt
+            realized_pnl += pnl
 
-            if viz:
-                sell_points.append((float(df.iloc[t][ts_col]), price, mode))
-
-            if amt >= note.get("entry_amount", 0.0) - 1e-9:
-                note["sell_mode"] = mode
-                apply_sell(
-                    ledger=ledger_obj,
-                    note=note,
-                    t=t,
-                    result=result,
-                    state=runtime_state,
-                )
+            if amt >= note["amount"] - 1e-9:
+                open_notes.remove(note)
             else:
-                note["entry_amount"] -= amt
-                note["entry_usdt"] -= amt * entry_price
-                partial = note.copy()
-                partial["entry_amount"] = amt
-                partial["entry_usdt"] = amt * entry_price
-                partial["sell_mode"] = mode
-                apply_sell(
-                    ledger=ledger_obj,
-                    note=partial,
-                    t=t,
-                    result=result,
-                    state=runtime_state,
-                )
-                ledger_obj.closed_notes.append(partial)
+                note["amount"] -= amt
 
-            cost = entry_price * amt
-            proceeds = result.get("avg_price", 0.0) * amt
-            roi_trade = (proceeds - cost) / cost if cost > 0 else 0.0
-            m_sell = win_metrics.get("strategy")
-            if m_sell is not None:
-                m_sell["sells"] += 1
-                m_sell["realized_cost"] += cost
-                m_sell["realized_proceeds"] += proceeds
-                m_sell["realized_trades"] += 1
-                m_sell["realized_roi_accum"] += roi_trade
+            if ax1 is not None:
+                color = "red" if mode == "normal" else "orange"
+                size = 120 if mode == "normal" else 90
+                ax1.scatter(df.iloc[t]["candle_index"], price, color=color, s=size, zorder=6)
 
-        ctx_j = {
-            "ledger": ledger_obj,
-            "verbosity": runtime_state.get("verbose", 0),
-        }
-        maybe_periodic_jackpot_buy(
-            ctx_j,
-            runtime_state,
-            t,
-            df,
-            price,
-            runtime_state.get("limits", {}),
-            ledger_cfg["tag"],
-        )
-        maybe_cashout_jackpot(
-            ctx_j,
-            runtime_state,
-            t,
-            df,
-            price,
-            runtime_state.get("limits", {}),
-            ledger_cfg["tag"],
-        )
+    print(f"[RESULT] PnL={realized_pnl:.2f}, Remaining Notes={len(open_notes)}")
 
-    final_price = float(df.iloc[-1]["close"]) if total else 0.0
-    summary = ledger_obj.get_account_summary(final_price)
+    if ax1 is not None:
+        ax1.scatter([], [], color="green", s=120, label="Buy")
+        ax1.scatter([], [], color="red", s=120, label="Sell")
+        ax1.scatter([], [], color="orange", s=90, label="Flat Sell")
 
-    open_value = sum(
-        n.get("entry_amount", 0.0) * final_price for n in ledger_obj.get_open_notes()
-    )
-
-    wallet_cash = runtime_state["capital"]
-    m = win_metrics.get("strategy", {})
-    realized_roi = (
-        (m.get("realized_proceeds", 0.0) / m.get("realized_cost", 1.0) - 1.0)
-        if m.get("realized_cost", 0.0) > 0
-        else 0.0
-    )
-    avg_trade_roi = (
-        m.get("realized_roi_accum", 0.0) / m.get("realized_trades", 1)
-        if m.get("realized_trades", 0) > 0
-        else 0.0
-    )
-    total_value_at_liq = m.get("realized_proceeds", 0.0) + open_value
-    realized_pnl = m.get("realized_proceeds", 0.0) - m.get("realized_cost", 0.0)
-    addlog(
-        f"[REPORT][strategy] buys={m.get('buys',0)} sells={m.get('sells',0)} realized_pnl=${realized_pnl:.2f} realized_roi={(realized_roi*100):.2f}% avg_trade_roi={(avg_trade_roi*100):.2f}% open_notes_value=${open_value:.2f} strategy_total_at_liq=${total_value_at_liq:.2f}",
-        verbose_int=1,
-        verbose_state=verbose,
-    )
-    rows = [
-        {
-            "window": "strategy",
-            "window_size": m.get("window_size", ""),
-            "buys": m.get("buys", 0),
-            "sells": m.get("sells", 0),
-            "gross_invested": m.get("gross_invested", 0.0),
-            "realized_cost": m.get("realized_cost", 0.0),
-            "realized_proceeds": m.get("realized_proceeds", 0.0),
-            "realized_pnl": realized_pnl,
-            "realized_roi": realized_roi,
-            "avg_trade_roi": avg_trade_roi,
-            "open_value_now": open_value,
-            "window_total_at_liq": total_value_at_liq,
-        }
-    ]
-
-    global_total_at_liq = wallet_cash + open_value
-    addlog(
-        f"[REPORT][GLOBAL] cash=${wallet_cash:.2f} open_value=${open_value:.2f} total_at_liq=${global_total_at_liq:.2f}",
-        verbose_int=1,
-        verbose_state=verbose,
-    )
-    j = runtime_state.get("jackpot", {})
-    coin_value = sum(
-        n.get("entry_amount", 0.0) * final_price for n in j.get("notes_open", [])
-    )
-    jackpot_total = j.get("pool_usd", 0.0) + coin_value
-    if j.get("enabled"):
-        addlog(
-            f"[REPORT][JACKPOT] drips=${j.get('drips',0.0):.2f} buys={j.get('buys',0)} sells={j.get('sells',0)} realized_pnl=${j.get('realized_pnl',0.0):.2f} pool_left=${j.get('pool_usd',0.0):.2f} coin_value={coin_value:.2f} total={jackpot_total:.2f}",
-            verbose_int=1,
-            verbose_state=verbose,
-        )
-    addlog(
-        f"Final Value (USD): ${summary['total_value']:.2f}",
-        verbose_int=1,
-        verbose_state=verbose,
-    )
-
-    root = resolve_path("")
-    logs_dir = root / "logs"
-    logs_dir.mkdir(parents=True, exist_ok=True)
-    ts = datetime.now().strftime("%Y%m%d_%H%M%S")
-    csv_path = logs_dir / f"sim_report_{ledger}_{ts}.csv"
-    json_path = logs_dir / f"sim_report_{ledger}_{ts}.json"
-    with csv_path.open("w", newline="", encoding="utf-8") as f_csv:
-        writer = csv.DictWriter(
-            f_csv,
-            fieldnames=[
-                "window",
-                "window_size",
-                "buys",
-                "sells",
-                "gross_invested",
-                "realized_cost",
-                "realized_proceeds",
-                "realized_pnl",
-                "realized_roi",
-                "avg_trade_roi",
-                "open_value_now",
-                "window_total_at_liq",
-            ],
-        )
-        writer.writeheader()
-        writer.writerows(rows)
-        if j.get("enabled"):
-            f_csv.write("\n")
-            f_csv.write(
-                "jackpot_drips,jackpot_buys,jackpot_sells,jackpot_realized_pnl,jackpot_pool_left,jackpot_coin_value,jackpot_total\n"
-            )
-            f_csv.write(
-                f"{j.get('drips',0.0)},{j.get('buys',0)},{j.get('sells',0)},{j.get('realized_pnl',0.0)},{j.get('pool_usd',0.0)},{coin_value},{jackpot_total}\n"
-            )
-    json_data = {
-        "windows": rows,
-        "global": {
-            "cash": wallet_cash,
-            "open_value_now": open_value,
-            "total_at_liq": global_total_at_liq,
-        },
-    }
-    if j.get("enabled"):
-        json_data["jackpot"] = {
-            "drips": j.get("drips", 0.0),
-            "buys": j.get("buys", 0),
-            "sells": j.get("sells", 0),
-            "realized_pnl": j.get("realized_pnl", 0.0),
-            "pool_left": j.get("pool_usd", 0.0),
-            "coin_value": coin_value,
-            "total": jackpot_total,
-        }
-    with json_path.open("w", encoding="utf-8") as f_json:
-        json.dump(json_data, f_json, indent=2)
-    if viz:
-        import matplotlib.pyplot as plt
-
-        times = pd.to_datetime(df[ts_col], unit="s")
-        plt.figure()
-        plt.plot(times, df["close"], label="Close", color="gray", zorder=1)
-        # --- Plot buys (single block, no duplication) ---
-        if buy_points:
-            b_t, b_p = zip(*buy_points)
-            plt.scatter(
-                pd.to_datetime(b_t, unit="s"),
-                b_p,
-                marker="o", color="g", label="Buy", zorder=2,
-            )
-
-
-        # --- Plot sells (normal vs flat) ---
-        if sell_points:
-            times_normal = [t for t, p, m in sell_points if m == "normal"]
-            prices_normal = [p for t, p, m in sell_points if m == "normal"]
-            times_flat   = [t for t, p, m in sell_points if m == "flat"]
-            prices_flat  = [p for t, p, m in sell_points if m == "flat"]
-
-            if times_normal:
-                plt.scatter(
-                    pd.to_datetime(times_normal, unit="s"),
-                    prices_normal,
-                    marker="o", color="r", label="Sell", zorder=2,
-                )
-            if times_flat:
-                plt.scatter(
-                    pd.to_datetime(times_flat, unit="s"),
-                    prices_flat,
-                    marker="o", color="orange", label="Flat Sell", zorder=2,
-                )
-
-
-        plt.xlabel("Time")
-        plt.ylabel("Price")
-        plt.legend()
-        plt.tight_layout()
+        ax1.set_title("Price with Trades")
+        ax1.set_xlabel("Candles (Index)")
+        ax1.set_ylabel("Price")
+        ax1.legend(loc="upper left")
+        ax1.grid(True)
         plt.show()
 
-    save_ledger(
-        ledger,
-        ledger_obj,
-        sim=True,
-        final_tick=total - 1,
-        summary=summary,
-        tag=ledger_cfg["tag"],
-    )
-    default_path = root / "data" / "tmp" / "simulation" / f"{ledger}.json"
-    sim_path = root / "data" / "tmp" / f"simulation_{ledger}.json"
-    if default_path.exists() and default_path != sim_path:
-        sim_path.parent.mkdir(parents=True, exist_ok=True)
-        shutil.copyfile(default_path, sim_path)
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--time", type=str, default="1m")
+    parser.add_argument("--viz", action="store_true", help="Enable visualization")
+    args = parser.parse_args()
+
+    run_simulation(timeframe=args.time, viz=args.viz)
+
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
## Summary
- Replace buy evaluator with mini-bot pressure logic
- Implement proportional sell evaluator for normal and flat sells
- Simplify simulation engine to drive trades via new evaluators

## Testing
- `pytest`
- `python -m systems.sim_engine --time 1d`


------
https://chatgpt.com/codex/tasks/task_e_68a236ca3f3083268c7ad76f177a23c3