### PR TITLE
Plot "all" sells in simulation visualization

### DIFF
--- a/systems/sim_engine.py
+++ b/systems/sim_engine.py
@@ -389,6 +389,8 @@ def run_simulation(
             prices_normal = [p for t, p, m in sell_points if m == "normal"]
             times_flat   = [t for t, p, m in sell_points if m == "flat"]
             prices_flat  = [p for t, p, m in sell_points if m == "flat"]
+            times_all   = [t for t, p, m in sell_points if m == "all"]
+            prices_all  = [p for t, p, m in sell_points if m == "all"]
 
             if times_normal:
                 plt.scatter(
@@ -401,6 +403,12 @@ def run_simulation(
                     pd.to_datetime(times_flat, unit="s"),
                     prices_flat,
                     marker="o", color="orange", label="Flat Sell", zorder=2,
+                )
+            if times_all:
+                plt.scatter(
+                    pd.to_datetime(times_all, unit="s"),
+                    prices_all,
+                    marker="x", color="red", label="All Sell", zorder=3,
                 )
 
 


### PR DESCRIPTION
## Summary
- show sells using `sell_mode="all"` in simulation charts
- plot "all" sells with red `x` marker and legend entry

## Testing
- `python bot.py --mode sim --ledger Kris_Ledger --time 1000d`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a3c162e3d48326b3c98daab7fc2076