### PR TITLE
Enable partial note selling

### DIFF
--- a/systems/live_engine.py
+++ b/systems/live_engine.py
@@ -139,11 +139,9 @@ def _run_iteration(
             open_notes=open_notes,
             runtime_state=state,
         )
-        for order in sell_orders:
-            note = order["note"]
-            amt = order["sell_amount"]
-            mode = order.get("sell_mode", "normal")
-            entry_price = note.get("entry_price", 0.0)
+        for note in sell_orders:
+            amt = note.get("partial_sell", 0.0)
+            mode = note.get("sell_mode", "normal")
             result = execute_sell(
                 None,
                 pair_code=ledger_cfg["kraken_pair"],
@@ -153,30 +151,14 @@ def _run_iteration(
                 verbose=state.get("verbose", 0),
             )
             if result and not result.get("error"):
-                if amt >= note.get("entry_amount", 0.0) - 1e-9:
-                    note["sell_mode"] = mode
-                    apply_sell(
-                        ledger=ledger_obj,
-                        note=note,
-                        t=t,
-                        result=result,
-                        state=state,
-                    )
-                else:
-                    partial = note.copy()
-                    partial["entry_amount"] = amt
-                    partial["entry_usdt"] = amt * entry_price
-                    partial["sell_mode"] = mode
-                    ledger_obj.open_note(partial)
-                    apply_sell(
-                        ledger=ledger_obj,
-                        note=partial,
-                        t=t,
-                        result=result,
-                        state=state,
-                    )
-                    note["entry_amount"] -= amt
-                    note["entry_usdt"] -= amt * entry_price
+                note["sell_mode"] = mode
+                apply_sell(
+                    ledger=ledger_obj,
+                    note=note,
+                    t=t,
+                    result=result,
+                    state=state,
+                )
 
         ctx_j = {
             "ledger": ledger_obj,

--- a/systems/scripts/trade_apply.py
+++ b/systems/scripts/trade_apply.py
@@ -61,16 +61,14 @@ def apply_sell(
     state: Dict[str, Any],
 ) -> Dict[str, Any]:
     exit_price = result.get("avg_price", 0.0)
-    exit_usdt = result.get("filled_amount", 0.0) * exit_price
-    note["exit_price"] = exit_price
-    note["exit_usdt"] = exit_usdt
-    if t is not None:
-        note["exit_idx"] = t
-    if result.get("timestamp") is not None:
-        note["exit_ts"] = result.get("timestamp")
-    entry_usdt = note.get("entry_usdt", 0.0)
-    note["gain"] = exit_usdt - entry_usdt
-    note["gain_pct"] = (note["gain"] / entry_usdt) if entry_usdt else 0.0
-    ledger.close_note(note)
+    sell_amount = result.get("filled_amount", 0.0)
+    ledger.apply_sell(
+        note,
+        sell_amount=sell_amount,
+        price=exit_price,
+        t=t,
+        timestamp=result.get("timestamp"),
+    )
+    exit_usdt = sell_amount * exit_price
     state["capital"] = state.get("capital", 0.0) + exit_usdt
     return note


### PR DESCRIPTION
## Summary
- allow selling a percentage of each note by setting `partial_sell` on notes
- track remaining amounts and sell history in the ledger, closing only when depleted
- update engines to execute fractional note sells and ledger bookkeeping

## Testing
- `python -m py_compile systems/scripts/evaluate_sell.py systems/scripts/ledger.py systems/scripts/trade_apply.py systems/sim_engine.py systems/live_engine.py`
- `python - <<'PY'
from systems.sim_engine import run_simulation
run_simulation(ledger='Kris_Ledger', verbose=0, timeframe='30d', viz=False)
PY`
- `nl -ba data/tmp/simulation/Kris_Ledger.json | sed -n '190,250p'`


------
https://chatgpt.com/codex/tasks/task_e_68a3c3ffa6c88326b35094904dfbb0cc