### PR TITLE
feat: switch sells to count-based knobs

### DIFF
--- a/settings/settings.json
+++ b/settings/settings.json
@@ -34,8 +34,8 @@
       "max_pressure": 10.0,
 
       "sell_trigger": 1,
-      "flat_sell_percent": 0.25,
-      "all_sell_percent": 1.0,
+      "flat_sell_count": 1,
+      "all_sell_count": 99,
 
       "strong_move_threshold": 0.15,
       "range_min": 0.08,


### PR DESCRIPTION
## Summary
- switch sell evaluator to flat/all note counts instead of percentages
- add `flat_sell_count` and `all_sell_count` knobs in settings
- simplify sell logging and drop partial/percent-based branches

## Testing
- `python bot.py --mode sim --ledger Kris_Ledger -v --time 1m`
- `python bot.py --mode sim --ledger Kris_Ledger -v --time 1m --viz`


------
https://chatgpt.com/codex/tasks/task_e_68a3c68eb50883269b9b80839cb0b66c