### PR TITLE
Implement dynamic sell sizing for flat and all exits

### DIFF
--- a/settings/settings.json
+++ b/settings/settings.json
@@ -34,8 +34,8 @@
       "max_pressure": 10.0,
 
       "sell_trigger": 1,
-      "flat_sell_count": 1,
-      "all_sell_count": 99,
+      "flat_sell_percent": 0.25,
+      "all_sell_count": 10,
 
       "strong_move_threshold": 0.15,
       "range_min": 0.08,

--- a/systems/scripts/evaluate_sell.py
+++ b/systems/scripts/evaluate_sell.py
@@ -60,7 +60,8 @@ def evaluate_sell(
     buy_trigger = strategy.get("buy_trigger", 0.0)
 
     if sell_p >= max_p and window_notes:
-        k = min(strategy.get("all_sell_count", n_notes), n_notes)
+        all_count = strategy.get("all_sell_count", n_notes)
+        k = min(all_count, n_notes)
         if k <= 0:
             return []
         results = window_notes[:k]
@@ -68,8 +69,7 @@ def evaluate_sell(
             n["sell_mode"] = "all"
         pressures["sell"][window_name] = 0.0
         addlog(
-            f"[SELL][{window_name} {window_size}] mode=all count={k}/{n_notes} "
-            f"pressure={sell_p:.1f}/{max_p:.1f}",
+            f"[SELL][{window_name} {window_size}] mode=all count={k}/{n_notes}",
             verbose_int=1,
             verbose_state=verbose,
         )
@@ -102,7 +102,8 @@ def evaluate_sell(
     )
     if slope_cls == 0 and sell_p >= sell_trigger:
         if window_notes:
-            k = min(strategy.get("flat_sell_count", 0), n_notes)
+            flat_percent = strategy.get("flat_sell_percent", 0.0)
+            k = int(round(n_notes * flat_percent))
             if k <= 0:
                 return []
             results = window_notes[:k]
@@ -111,7 +112,7 @@ def evaluate_sell(
             pressures["sell"][window_name] = 0.0
             addlog(
                 f"[SELL][{window_name} {window_size}] mode=flat count={k}/{n_notes} "
-                f"pressure={sell_p:.1f}/{max_p:.1f}",
+                f"flat_percent={flat_percent:.2%}",
                 verbose_int=1,
                 verbose_state=verbose,
             )

--- a/systems/scripts/runtime_state.py
+++ b/systems/scripts/runtime_state.py
@@ -44,7 +44,7 @@ def build_runtime_state(
         "buy_trigger": 3.0,
         "sell_trigger": 10.0,
         "flat_sell_percent": 0.25,
-        "all_sell_percent": 1.0,
+        "all_sell_count": 99,
         "max_pressure": 10.0,
         "strong_move_threshold": 0.15,
         "range_min": 0.08,


### PR DESCRIPTION
## Summary
- Sell eval uses `flat_sell_percent` to scale with open notes
- `all_sell_count` controls fixed-size exits when max pressure hits
- Refresh strategy defaults and sample settings for new config

## Testing
- `python -m py_compile systems/scripts/evaluate_sell.py systems/scripts/runtime_state.py`


------
https://chatgpt.com/codex/tasks/task_e_68a3d2f80ee4832680fcf4966b722de5