### PR TITLE
Apply investment fraction to buy sizing

### DIFF
--- a/systems/scripts/evaluate_buy.py
+++ b/systems/scripts/evaluate_buy.py
@@ -177,7 +177,8 @@ def evaluate_buy(
     max_sz = float(limits.get("max_note_usdt", capital))
     min_sz = float(limits.get("min_note_size", 0.0))
 
-    raw = capital * fraction
+    inv_frac = strategy.get("investment_fraction", 1.0)
+    raw = capital * fraction * inv_frac
     size_usd = min(raw, capital, max_sz)
     if size_usd != raw:
         addlog(


### PR DESCRIPTION
## Summary
- Use `investment_fraction` from strategy to scale buy size after pressure calculations

## Testing
- `pytest`
- Custom script verifying buy size scaling for investment_fraction 1.0, 0.5, and 0.0


------
https://chatgpt.com/codex/tasks/task_e_68a3d84b63a8832688a6c2801beb2b0d