### PR TITLE
Add multi-account and market iteration with CLI --all flag

### DIFF
--- a/systems/fetch.py
+++ b/systems/fetch.py
@@ -35,6 +35,7 @@ def run_fetch(account: str, market: str | None = None) -> None:
             verbose_state=True,
         )
         raise SystemExit(1)
+    os.environ["WS_ACCOUNT"] = account
     markets = acct_cfg.get("markets", {})
     targets = [market] if market else list(markets.keys())
 

--- a/systems/live_engine.py
+++ b/systems/live_engine.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 """Live engine mirroring the simulation strategy."""
 
+import os
 import time
 from datetime import datetime, timezone
 from pathlib import Path
@@ -39,6 +40,7 @@ def _run_iteration(
     for acct_name, acct_cfg in cfg.get("accounts", {}).items():
         if account_filter and acct_name != account_filter:
             continue
+        os.environ["WS_ACCOUNT"] = acct_name
         for market, strategy_cfg in acct_cfg.get("markets", {}).items():
             if market_filter and market != market_filter:
                 continue
@@ -182,6 +184,7 @@ def run_live(*, account: str, market: str | None = None, dry: bool = False, verb
     for acct_name, acct_cfg in cfg.get("accounts", {}).items():
         if account and acct_name != account:
             continue
+        os.environ["WS_ACCOUNT"] = acct_name
         for mkt, strat in acct_cfg.get("markets", {}).items():
             if market and mkt != market:
                 continue

--- a/systems/sim_engine.py
+++ b/systems/sim_engine.py
@@ -53,6 +53,7 @@ def run_simulation(
             verbose_state=verbose,
         )
         raise SystemExit(1)
+    os.environ["WS_ACCOUNT"] = account
     strategy_cfg = acct_cfg.get("markets", {}).get(market)
     if not strategy_cfg:
         addlog(

--- a/systems/utils/cli.py
+++ b/systems/utils/cli.py
@@ -18,6 +18,11 @@ def build_parser() -> argparse.ArgumentParser:
         help="Specific market symbol to operate on (default: all for account)",
     )
     parser.add_argument(
+        "--all",
+        action="store_true",
+        help="Run all configured accounts and their markets",
+    )
+    parser.add_argument(
         "--ledger",
         help="[DEPRECATED] use --account instead",
     )


### PR DESCRIPTION
## Summary
- add `--all` CLI flag and deprecate `--ledger`
- iterate accounts and markets in bot entrypoint with new environment key handling
- load Kraken keys per account via WS_ACCOUNT and update engines

## Testing
- `python -m py_compile systems/utils/cli.py systems/scripts/kraken_utils.py systems/live_engine.py systems/sim_engine.py systems/fetch.py bot.py`


------
https://chatgpt.com/codex/tasks/task_e_68a5163223908326b6b79ca9ec2c39fb