### PR TITLE
Refactor engines for multi-account iteration and CLI

### DIFF
--- a/systems/fetch.py
+++ b/systems/fetch.py
@@ -13,91 +13,102 @@ if __package__ is None or __package__ == "":
 
 from systems.utils.addlog import addlog
 from systems.utils.load_config import load_config
-from systems.utils.resolve_symbol import resolve_symbols
+from systems.utils.resolve_symbol import resolve_symbols, to_tag
 from systems.scripts.fetch_candles import (
     fetch_binance_full_history_1h,
     fetch_kraken_last_n_hours_1h,
 )
 
 
-def run_fetch(account: str, market: str | None = None) -> None:
-    """Fetch candles for markets defined under ``account``."""
+def run_fetch(
+    account: str | None = None, market: str | None = None, all_accounts: bool = False
+) -> None:
+    """Fetch candles for configured accounts/markets."""
 
     cfg = load_config()
-    acct_cfg = cfg.get("accounts", {}).get(account)
-    if not acct_cfg:
-        addlog(
-            f"Error: Unknown account {account}",
-            verbose_int=1,
-            verbose_state=True,
-        )
-        raise SystemExit(1)
-    os.environ["WS_ACCOUNT"] = account
-    markets = acct_cfg.get("markets", {})
-    targets = [market] if market else list(markets.keys())
+    accounts = cfg.get("accounts", {})
+    targets = accounts.keys() if (all_accounts or not account) else [account]
 
-    client = ccxt.kraken(
-        {
-            "enableRateLimit": True,
-            "apiKey": acct_cfg.get("api_key", ""),
-            "secret": acct_cfg.get("api_secret", ""),
-        }
-    )
-
-    for m in targets:
-        symbols = resolve_symbols(client, m)
-        kraken_name = symbols["kraken_name"]
-        kraken_pair = symbols["kraken_pair"]
-        binance_name = symbols["binance_name"]
-
-        addlog(
-            f"[RESOLVE][{account}][{m}] KrakenName={kraken_name} KrakenPair={kraken_pair} BinanceName={binance_name}",
-            verbose_int=1,
-            verbose_state=True,
-        )
-
-        if "/" not in kraken_name:
+    for acct_name in targets:
+        acct_cfg = accounts.get(acct_name)
+        if not acct_cfg:
             addlog(
-                f"[ERROR] Kraken symbol missing '/' : {kraken_name}",
+                f"Error: Unknown account {acct_name}",
                 verbose_int=1,
                 verbose_state=True,
             )
-            raise SystemExit(1)
-        if "/" in binance_name:
+            continue
+        os.environ["WS_ACCOUNT"] = acct_name
+        client = ccxt.kraken(
+            {
+                "enableRateLimit": True,
+                "apiKey": acct_cfg.get("api_key", ""),
+                "secret": acct_cfg.get("api_secret", ""),
+            }
+        )
+        markets_cfg = acct_cfg.get("markets", {})
+        m_targets = [market] if market else list(markets_cfg.keys())
+        for m in m_targets:
+            if m not in markets_cfg:
+                continue
             addlog(
-                f"[ERROR] Binance symbol must not contain '/' : {binance_name}",
+                f"[RUN][{acct_name}][{m}]",
                 verbose_int=1,
                 verbose_state=True,
             )
-            raise SystemExit(1)
+            symbols = resolve_symbols(client, m)
+            kraken_name = symbols["kraken_name"]
+            kraken_pair = symbols["kraken_pair"]
+            binance_name = symbols["binance_name"]
 
-        file_tag = m.replace("/", "_")
-
-        # Binance full history -> SIM
-        df_sim = fetch_binance_full_history_1h(binance_name)
-        sim_path = f"data/sim/{account}_{file_tag}_1h.csv"
-        tmp_sim = sim_path + ".tmp"
-        os.makedirs(os.path.dirname(sim_path), exist_ok=True)
-        df_sim.to_csv(tmp_sim, index=False)
-        os.replace(tmp_sim, sim_path)
-
-        # Kraken last 720 -> LIVE
-        df_live = fetch_kraken_last_n_hours_1h(kraken_name, n=720)
-        live_path = f"data/live/{account}_{file_tag}_1h.csv"
-        tmp_live = live_path + ".tmp"
-        os.makedirs(os.path.dirname(live_path), exist_ok=True)
-        df_live.to_csv(tmp_live, index=False)
-        os.replace(tmp_live, live_path)
-        rows = len(df_live)
-        if rows < 720:
             addlog(
-                f"[FETCH][WARN] {account} {kraken_name} returned {rows} rows (<720) from kraken",
+                f"[RESOLVE][{acct_name}][{m}] KrakenName={kraken_name} KrakenPair={kraken_pair} BinanceName={binance_name}",
                 verbose_int=1,
                 verbose_state=True,
             )
 
-        addlog(
-            f"[FETCH][{account}][{kraken_name}] saved sim/live candles",
-            verbose_int=1,
-            verbose_state=True,
-        )
+            if "/" not in kraken_name:
+                addlog(
+                    f"[ERROR] Kraken symbol missing '/' : {kraken_name}",
+                    verbose_int=1,
+                    verbose_state=True,
+                )
+                raise SystemExit(1)
+            if "/" in binance_name:
+                addlog(
+                    f"[ERROR] Binance symbol must not contain '/' : {binance_name}",
+                    verbose_int=1,
+                    verbose_state=True,
+                )
+                raise SystemExit(1)
+
+            tag = to_tag(kraken_name)
+
+            # Binance full history -> SIM
+            df_sim = fetch_binance_full_history_1h(binance_name)
+            sim_path = f"data/sim/{tag}_1h.csv"
+            tmp_sim = sim_path + ".tmp"
+            os.makedirs(os.path.dirname(sim_path), exist_ok=True)
+            df_sim.to_csv(tmp_sim, index=False)
+            os.replace(tmp_sim, sim_path)
+
+            # Kraken last 720 -> LIVE
+            df_live = fetch_kraken_last_n_hours_1h(kraken_name, n=720)
+            live_path = f"data/live/{tag}_1h.csv"
+            tmp_live = live_path + ".tmp"
+            os.makedirs(os.path.dirname(live_path), exist_ok=True)
+            df_live.to_csv(tmp_live, index=False)
+            os.replace(tmp_live, live_path)
+            rows = len(df_live)
+            if rows < 720:
+                addlog(
+                    f"[FETCH][WARN] {acct_name} {kraken_name} returned {rows} rows (<720) from kraken",
+                    verbose_int=1,
+                    verbose_state=True,
+                )
+
+            addlog(
+                f"[FETCH][{acct_name}][{kraken_name}] saved sim/live candles",
+                verbose_int=1,
+                verbose_state=True,
+            )

--- a/systems/utils/cli.py
+++ b/systems/utils/cli.py
@@ -1,5 +1,7 @@
 import argparse
 
+from .addlog import addlog
+
 
 def build_parser() -> argparse.ArgumentParser:
     """Return a configured argument parser for WindowSurfer CLI tools."""
@@ -49,3 +51,16 @@ def build_parser() -> argparse.ArgumentParser:
         help="Enable Telegram alerts",
     )
     return parser
+
+
+def handle_legacy_args(args: argparse.Namespace) -> argparse.Namespace:
+    """Map deprecated ``--ledger`` flag to ``--account``."""
+    if getattr(args, "ledger", None):
+        addlog(
+            "[DEPRECATED] --ledger is deprecated; use --account",
+            verbose_int=1,
+            verbose_state=True,
+        )
+        if not getattr(args, "account", None):
+            args.account = args.ledger
+    return args


### PR DESCRIPTION
## Summary
- Add CLI options for account/market iteration with legacy --ledger mapping
- Iterate fetch, sim, and live engines across configured accounts and markets with per-run logging
- Simplify bot entrypoint to forward account, market, and --all flags to engines

## Testing
- `python bot.py --mode sim --account Travis --market SOL/USDC --time 1d -v` *(fails: Network is unreachable)*
- `python bot.py --mode fetch --account Travis --market SOL/USDC -v` *(fails: Network is unreachable)*
- `python bot.py --mode live --account Travis --market SOL/USDC --dry -v` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a531dc00b083269a067f35f3dd2019