### PR TITLE
Normalize candle filenames

### DIFF
--- a/systems/fetch.py
+++ b/systems/fetch.py
@@ -13,7 +13,7 @@ if __package__ is None or __package__ == "":
 
 from systems.utils.addlog import addlog
 from systems.utils.load_config import load_config
-from systems.utils.resolve_symbol import resolve_symbols, to_tag
+from systems.utils.resolve_symbol import resolve_symbols, candle_filename
 from systems.scripts.fetch_candles import (
     fetch_binance_full_history_1h,
     fetch_kraken_last_n_hours_1h,
@@ -82,11 +82,9 @@ def run_fetch(
                 )
                 raise SystemExit(1)
 
-            tag = to_tag(kraken_name)
-
             # Binance full history -> SIM
             df_sim = fetch_binance_full_history_1h(binance_name)
-            sim_path = f"data/sim/{tag}_1h.csv"
+            sim_path = candle_filename(acct_name, m)
             tmp_sim = sim_path + ".tmp"
             os.makedirs(os.path.dirname(sim_path), exist_ok=True)
             df_sim.to_csv(tmp_sim, index=False)
@@ -94,7 +92,7 @@ def run_fetch(
 
             # Kraken last 720 -> LIVE
             df_live = fetch_kraken_last_n_hours_1h(kraken_name, n=720)
-            live_path = f"data/live/{tag}_1h.csv"
+            live_path = candle_filename(acct_name, m, live=True)
             tmp_live = live_path + ".tmp"
             os.makedirs(os.path.dirname(live_path), exist_ok=True)
             df_live.to_csv(tmp_live, index=False)

--- a/systems/sim_engine.py
+++ b/systems/sim_engine.py
@@ -32,6 +32,7 @@ from systems.utils.resolve_symbol import (
     resolve_symbols,
     to_tag,
     sim_path_csv,
+    candle_filename,
 )
 from systems.utils.time import parse_cutoff as parse_timeframe
 
@@ -66,8 +67,15 @@ def _run_single_sim(
     ledger_name = f"{account}_{file_tag}"
     base, _ = split_tag(tag)
     coin = base.upper()
-    csv_path = sim_path_csv(tag)
+    csv_path = candle_filename(account, market)
     if not Path(csv_path).exists():
+        legacy = sim_path_csv(tag)
+        if Path(legacy).exists():
+            addlog(
+                f"[DEPRECATED] Found legacy file {legacy}, use {csv_path}",
+                verbose_int=1,
+                verbose_state=verbose,
+            )
         print(
             f"[ERROR] Missing data file: {csv_path}. Run: python bot.py --mode fetch --account {account} --market {market}"
         )

--- a/systems/utils/resolve_symbol.py
+++ b/systems/utils/resolve_symbol.py
@@ -24,6 +24,14 @@ def resolve_symbols(client: ccxt.Exchange, config_name: str) -> dict[str, str]:
     }
 
 
+def candle_filename(account: str, market: str, live: bool = False) -> str:
+    """Return canonical candle CSV path for ``account``/``market``."""
+
+    base = f"{account}_{market.replace('/', '_')}_1h.csv"
+    folder = "data/live" if live else "data/sim"
+    return f"{folder}/{base}"
+
+
 # ---------------------------------------------------------------------------
 # Legacy helpers retained for compatibility
 


### PR DESCRIPTION
## Summary
- add helper to build standard candle filenames
- store fetched candles using `account_market_1h.csv` naming
- load candles via helper and warn about deprecated legacy files

## Testing
- `python bot.py --mode fetch --account Kris` *(fails: Network is unreachable)*
- `python bot.py --mode sim --account Kris --market BTC/USD` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a534d5da048326ab2c9ff63762eeb1