### PR TITLE
feat: add trading log viewer

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -82,6 +82,13 @@ def main(argv: list[str] | None = None) -> None:
         )
     elif mode == "wallet":
         show_wallet(args.ledger, verbose)
+    elif mode == "view":
+        if not args.ledger:
+            addlog("Error: --ledger is required for view mode")
+            sys.exit(1)
+        from systems.scripts.view_log import view_log
+
+        view_log(args.ledger)
     else:
         parser.error(f"Unknown mode: {args.mode}")
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ ccxt
 pyyaml
 optuna
 matplotlib
+mplcursors

--- a/systems/scripts/view_log.py
+++ b/systems/scripts/view_log.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+"""Plot structured trading logs with hover annotations."""
+
+import argparse
+import json
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import mplcursors
+import pandas as pd
+
+
+def view_log(ledger_name: str) -> None:
+    """Render a scatter plot of decisions from ``ledger_name`` log."""
+
+    log_path = Path(f"data/logs/{ledger_name}.json")
+    if not log_path.exists():
+        print(f"[ERROR] No log found at {log_path}")
+        return
+
+    with log_path.open() as f:
+        events = json.load(f)
+
+    if not events:
+        print(f"[EMPTY] {ledger_name} log has no entries")
+        return
+
+    times = pd.to_datetime([e["timestamp"] for e in events])
+    prices: list[float | None] = []
+    colors: list[str] = []
+    annotations: list[str] = []
+
+    for e in events:
+        decision = e["decision"]
+        trades = e.get("trades") or []
+        price = trades[0].get("price") if trades else None
+        prices.append(price)
+        colors.append(
+            "green"
+            if decision == "BUY"
+            else "red"
+            if decision == "SELL"
+            else "orange"
+            if decision == "FLAT"
+            else "gray"
+        )
+        features = e.get("features", {})
+        annotations.append(
+            f"{e['timestamp']}\n"
+            f"Decision: {decision}\n"
+            f"Slope: {features.get('slope')}\n"
+            f"Volatility: {features.get('volatility')}\n"
+            f"BuyP: {features.get('buy_pressure')} | "
+            f"SellP: {features.get('sell_pressure')}"
+        )
+
+    fig, ax = plt.subplots()
+    sc = ax.scatter(times, prices, c=colors, marker="o")
+
+    cursor = mplcursors.cursor(sc, hover=True)
+
+    @cursor.connect("add")
+    def on_hover(sel):
+        sel.annotation.set(text=annotations[sel.index])
+
+    ax.set_title(f"Trading Decisions for {ledger_name}")
+    ax.set_xlabel("Time")
+    ax.set_ylabel("Price (USDT)")
+    plt.xticks(rotation=45)
+    plt.tight_layout()
+    plt.show()
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--ledger", required=True)
+    args = parser.parse_args()
+    view_log(args.ledger)
+

--- a/systems/utils/cli.py
+++ b/systems/utils/cli.py
@@ -6,8 +6,8 @@ def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="WindowSurfer command line interface")
     parser.add_argument(
         "--mode",
-        choices=["fetch", "sim", "live", "wallet"],
-        help="Execution mode: fetch, sim, live, or wallet",
+        choices=["fetch", "sim", "live", "wallet", "view"],
+        help="Execution mode: fetch, sim, live, wallet, or view",
     )
     parser.add_argument(
         "--ledger",


### PR DESCRIPTION
## Summary
- add `systems/scripts/view_log.py` to visualize structured trading logs with matplotlib and tooltips
- expose new `--mode view` in CLI and bot entrypoint
- include `mplcursors` in requirements

## Testing
- `pip install mplcursors` *(fails: Could not connect to proxy)*
- `python -m py_compile systems/scripts/view_log.py systems/utils/cli.py bot.py`
- `python systems/scripts/view_log.py --ledger Kris_Ledger` *(fails: ModuleNotFoundError: No module named 'mplcursors')*
- `python bot.py --mode view --ledger Kris_Ledger` *(fails: ModuleNotFoundError: No module named 'mplcursors')*

------
https://chatgpt.com/codex/tasks/task_e_68a60fa4bd6c83269fdcffc89910b0f7