### PR TITLE
Add trade test mode and account live flag

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -65,6 +65,14 @@ def main(argv: list[str] | None = None) -> None:
             verbose=args.verbose,
         )
 
+    elif mode == "test":
+        from systems.scripts.trade_test import run_trade_test
+
+        if not args.account:
+            addlog("Error: --account is required for test mode")
+            sys.exit(1)
+        run_trade_test(args.account)
+
     elif mode == "wallet":
         accounts_cfg = cfg.get("accounts", {})
         targets = accounts_cfg.keys() if run_all else [args.account]

--- a/settings/settings.json
+++ b/settings/settings.json
@@ -32,6 +32,7 @@
       "kraken_name": "SOL/USD",
       "kraken_pair": "SOLUSD",
       "binance_name": "SOLUSDT",
+      "is_live": false,
       "reporting": {
         "email": "kris@example.com",
         "daily": false,

--- a/systems/live_engine.py
+++ b/systems/live_engine.py
@@ -38,6 +38,10 @@ def _run_iteration(
         if account_filter and acct_name != account_filter:
             continue
 
+        if not acct_cfg.get("is_live", False):
+            print(f"[SKIP] {acct_name} (is_live = false)")
+            continue
+
         client = ccxt.kraken(
             {
                 "enableRateLimit": True,
@@ -231,6 +235,9 @@ def run_live(
     for acct_name in targets:
         acct_cfg = cfg.get("accounts", {}).get(acct_name)
         if not acct_cfg:
+            continue
+        if not acct_cfg.get("is_live", False):
+            print(f"[SKIP] {acct_name} (is_live = false)")
             continue
         for mkt, strat in acct_cfg.get("markets", {}).items():
             if market and mkt != market:

--- a/systems/scripts/trade_test.py
+++ b/systems/scripts/trade_test.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+"""Utility to run a safe trade test for a configured account."""
+
+from systems.utils.config import load_settings
+from systems.scripts.fetch_candles import fetch_kraken_last_n_hours_1h
+from systems.scripts.ledger import load_ledger, save_ledger
+from systems.scripts.execution_handler import execute_buy, execute_sell
+from systems.utils.resolve_symbol import resolve_symbols
+import ccxt
+
+
+def run_trade_test(account: str) -> None:
+    """Execute a dry run of buy/sell operations for ``account``."""
+
+    cfg = load_settings()
+    acct_cfg = cfg.get("accounts", {}).get(account)
+    if not acct_cfg:
+        print(f"[ERROR] Unknown account {account}")
+        return
+
+    print(f"[TEST] Running trade test for {account}")
+
+    client = ccxt.kraken({"enableRateLimit": True})
+    for market, strat_cfg in acct_cfg.get("markets", {}).items():
+        symbols = resolve_symbols(client, market)
+        kraken_name = symbols["kraken_name"]
+        kraken_pair = symbols["kraken_pair"]
+
+        print(f"[TEST] Pulling 720h candles for {kraken_name}")
+        df = fetch_kraken_last_n_hours_1h(kraken_name, n=720)
+        if df.empty:
+            print(f"[FAIL] No candles fetched for {kraken_name}")
+            continue
+        print(f"[PASS] Candles OK ({len(df)} rows)")
+
+        ledger_name = f"{account}_{market.replace('/', '_')}"
+        ledger_obj = load_ledger(ledger_name, tag=market.replace("/", "_"))
+        save_ledger(ledger_name, ledger_obj, tag=market.replace("/", "_"))
+        print(f"[PASS] Ledger load/save OK")
+
+        price = float(df.iloc[-1]["close"])
+        amt_usd = 10.0
+
+        print(f"[TEST] Executing dummy BUY {amt_usd} at ~${price}")
+        buy_res = execute_buy(
+            None,
+            pair_code=kraken_pair,
+            price=price,
+            amount_usd=amt_usd,
+            ledger_name=ledger_name,
+            wallet_code=acct_cfg.get("wallet_code"),
+            verbose=1,
+        )
+        if not buy_res or buy_res.get("error"):
+            print(f"[FAIL] Buy failed: {buy_res}")
+            continue
+        print(f"[PASS] Buy OK: {buy_res}")
+
+        print(f"[TEST] Executing dummy SELL")
+        sell_res = execute_sell(
+            None,
+            pair_code=kraken_pair,
+            coin_amount=buy_res.get("filled_amount", 0.0),
+            price=price,
+            ledger_name=ledger_name,
+            verbose=1,
+        )
+        if not sell_res or sell_res.get("error"):
+            print(f"[FAIL] Sell failed: {sell_res}")
+        else:
+            print(f"[PASS] Sell OK: {sell_res}")
+
+    print(f"[DONE] Trade test for {account}")
+

--- a/systems/utils/cli.py
+++ b/systems/utils/cli.py
@@ -8,8 +8,8 @@ def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="WindowSurfer command line interface")
     parser.add_argument(
         "--mode",
-        choices=["fetch", "sim", "live", "wallet", "view"],
-        help="Execution mode: fetch, sim, live, wallet, or view",
+        choices=["fetch", "sim", "live", "wallet", "view", "test"],
+        help="Execution mode: fetch, sim, live, wallet, view, or test",
     )
     parser.add_argument(
         "--account",


### PR DESCRIPTION
## Summary
- add `is_live` flag to account settings and default to false
- add trade test mode with dummy buy/sell cycle
- skip non-live accounts in live engine and expose test mode via CLI

## Testing
- `python -m py_compile bot.py systems/live_engine.py systems/utils/cli.py systems/scripts/trade_test.py`
- `pytest --ignore=systems/scripts/trade_test.py`
- `python bot.py --mode test --account Kris_Ledger`


------
https://chatgpt.com/codex/tasks/task_e_68a619c5ee348326998acdf04bc36a14