### PR TITLE
Normalize view mode to use --account and optional timeframe filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,21 +11,21 @@ subsystem based on `--mode`:
 
 | Mode | Module | Description |
 |------|--------|-------------|
-| `fetch`  | `systems.fetch.run_fetch` | Sync hourly candles from Binance (simulation) and Kraken (live) for a ledger. |
+| `fetch`  | `systems.fetch.run_fetch` | Sync hourly candles from Binance (simulation) and Kraken (live) for an account's ledger. |
 | `sim`    | `systems.sim_engine.run_simulation` | Backtest the strategy on historical data. |
 | `live`   | `systems.live_engine.run_live` | Execute the strategy on current market data; `--dry` runs once and exits. |
-| `wallet` | `systems.scripts.wallet.show_wallet` | Display Kraken balances for the ledger's quote asset. |
+| `wallet` | `systems.scripts.wallet.show_wallet` | Display Kraken balances for the account's quote asset. |
 
-Common options include `--ledger`, `-v/--verbose`, and `--log` to write
+Common options include `--account`, `-v/--verbose`, and `--log` to write
 local JSON logs under `data/logs/`.
 
 Examples:
 
 ```bash
-python bot.py --mode fetch --ledger Kris_Ledger
-python bot.py --mode sim --ledger Kris_Ledger -vv --time 7d
-python bot.py --mode live --ledger Kris_Ledger --dry
-python bot.py --mode wallet --ledger Kris_Ledger
+python bot.py --mode fetch --account Kris_Ledger
+python bot.py --mode sim --account Kris_Ledger -vv --time 7d
+python bot.py --mode live --account Kris_Ledger --dry
+python bot.py --mode wallet --account Kris_Ledger
 ```
 
 ## Architecture

--- a/bot.py
+++ b/bot.py
@@ -11,7 +11,7 @@ from systems.sim_engine import run_simulation
 from systems.scripts.wallet import show_wallet
 from systems.utils.addlog import init_logger, addlog
 from systems.utils.load_config import load_config
-from systems.utils.cli import build_parser, handle_legacy_args
+from systems.utils.cli import build_parser
 
 
 def main(argv: list[str] | None = None) -> None:
@@ -29,7 +29,6 @@ def main(argv: list[str] | None = None) -> None:
     )
 
     args = parser.parse_args(argv or sys.argv[1:])
-    args = handle_legacy_args(args)
     if not args.mode:
         parser.error("--mode is required")
     mode = args.mode.lower()
@@ -94,11 +93,11 @@ def main(argv: list[str] | None = None) -> None:
                 show_wallet(acct, m, verbose)
 
     elif mode == "view":
-        if not args.ledger:
-            addlog("Error: --ledger is required for view mode")
+        if not args.account:
+            addlog("Error: --account is required for view mode")
             sys.exit(1)
         from systems.scripts.view_log import view_log
-        view_log(args.ledger)
+        view_log(args.account, timeframe=args.time)
 
     else:
         parser.error(f"Unknown mode: {args.mode}")

--- a/systems/manual.py
+++ b/systems/manual.py
@@ -26,8 +26,8 @@ def _parse_args(argv: Optional[list[str]] = None):
     action.add_argument("--sell", action="store_true", help="Execute a sell")
     parser.add_argument("--usd", required=True, type=float, help="USD amount")
     args = parser.parse_args(argv)
-    if not args.ledger:
-        parser.error("--ledger is required")
+    if not args.account:
+        parser.error("--account is required")
     return args
 
 
@@ -35,9 +35,9 @@ def main(argv: Optional[list[str]] = None) -> None:
     args = _parse_args(argv)
 
     settings = load_settings()
-    ledger_cfg = settings.get("ledger_settings", {}).get(args.ledger)
+    ledger_cfg = settings.get("ledger_settings", {}).get(args.account)
     if ledger_cfg is None:
-        raise SystemExit(f"[ERROR] Ledger '{args.ledger}' not found in settings")
+        raise SystemExit(f"[ERROR] Account '{args.account}' not found in settings")
 
     if args.usd <= 0:
         raise SystemExit("[ERROR] --usd must be positive")
@@ -55,12 +55,12 @@ def main(argv: Optional[list[str]] = None) -> None:
 
     coin_amt = args.usd / price
     coin_str = _coin_label(tag)
-    path_new = resolve_path(f"data/ledgers/{args.ledger}.json")
+    path_new = resolve_path(f"data/ledgers/{args.account}.json")
     legacy_path = resolve_path(f"data/ledgers/{file_tag}.json") if file_tag else None
     if legacy_path and legacy_path.exists() and not path_new.exists():
         legacy_path.rename(path_new)
 
-    ledger = load_ledger(args.ledger, tag=file_tag)
+    ledger = load_ledger(args.account, tag=file_tag)
     metadata = ledger.get_metadata()
 
     if args.buy:
@@ -71,7 +71,7 @@ def main(argv: Optional[list[str]] = None) -> None:
                 wallet_code=base,
                 price=price,
                 amount_usd=args.usd,
-                ledger_name=args.ledger,
+                ledger_name=args.account,
                 verbose=args.verbose,
             )
             if not result or result.get("error"):
@@ -89,9 +89,9 @@ def main(argv: Optional[list[str]] = None) -> None:
                 }
             )
             ledger.set_metadata(metadata)
-            save_ledger(args.ledger, ledger, tag=file_tag)
+            save_ledger(args.account, ledger, tag=file_tag)
         addlog(
-            f"[MANUAL BUY] {args.ledger} | {tag} | ${args.usd:.2f} → {coin_amt:.4f} {coin_str} @ ${price:.4f}",
+            f"[MANUAL BUY] {args.account} | {tag} | ${args.usd:.2f} → {coin_amt:.4f} {coin_str} @ ${price:.4f}",
             verbose_int=1,
             verbose_state=args.verbose,
         )
@@ -102,7 +102,7 @@ def main(argv: Optional[list[str]] = None) -> None:
                 pair_code=kraken_pair,
                 coin_amount=coin_amt,
                 price=price,
-                ledger_name=args.ledger,
+                ledger_name=args.account,
                 verbose=args.verbose,
             )
             if not result or result.get("error"):
@@ -121,11 +121,11 @@ def main(argv: Optional[list[str]] = None) -> None:
                 }
             )
             ledger.set_metadata(metadata)
-            save_ledger(args.ledger, ledger, tag=file_tag)
+            save_ledger(args.account, ledger, tag=file_tag)
         else:
             usd_total = args.usd
         addlog(
-            f"[MANUAL SELL] {args.ledger} | {tag} | {coin_amt:.4f} {coin_str} → ${usd_total:.2f} @ ${price:.4f}",
+            f"[MANUAL SELL] {args.account} | {tag} | {coin_amt:.4f} {coin_str} → ${usd_total:.2f} @ ${price:.4f}",
             verbose_int=1,
             verbose_state=args.verbose,
         )

--- a/systems/utils/cli.py
+++ b/systems/utils/cli.py
@@ -1,7 +1,5 @@
 import argparse
 
-from .addlog import addlog
-
 
 def build_parser() -> argparse.ArgumentParser:
     """Return a configured argument parser for WindowSurfer CLI tools."""
@@ -25,10 +23,6 @@ def build_parser() -> argparse.ArgumentParser:
         help="Run all configured accounts and their markets",
     )
     parser.add_argument(
-        "--ledger",
-        help=argparse.SUPPRESS,
-    )
-    parser.add_argument(
         "--dry",
         action="store_true",
         help="Run live mode once immediately and exit",
@@ -46,16 +40,3 @@ def build_parser() -> argparse.ArgumentParser:
         help="Enable log file output",
     )
     return parser
-
-
-def handle_legacy_args(args: argparse.Namespace) -> argparse.Namespace:
-    """Map deprecated ``--ledger`` flag to ``--account``."""
-    if getattr(args, "ledger", None):
-        addlog(
-            "[DEPRECATED] --ledger is deprecated; use --account",
-            verbose_int=1,
-            verbose_state=True,
-        )
-        if not getattr(args, "account", None):
-            args.account = args.ledger
-    return args

--- a/systems/utils/time.py
+++ b/systems/utils/time.py
@@ -28,6 +28,11 @@ def parse_cutoff(value: str) -> timedelta:
     raise ValueError("cutoff unit must be one of h,d,w,m,y")
 
 
+def parse_duration(value: str) -> timedelta:
+    """Return a ``timedelta`` parsed from shorthand like ``'1m'`` or ``'7d'``."""
+    return parse_cutoff(value)
+
+
 def parse_relative_time(value: str) -> tuple[float, float]:
     """Return (start_ts, end_ts) parsed from a relative time string."""
     delta = parse_cutoff(value)


### PR DESCRIPTION
## Summary
- Drop deprecated `--ledger` flag across CLI and docs; all modes now use `--account`
- Add optional `--time` filter to view mode with `parse_duration`
- Update manual trading script and README for `--account` usage

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `PYTHONPATH=. pytest`
- `python bot.py --mode view --account Kris_Ledger --time 1m` *(no log found)*

------
https://chatgpt.com/codex/tasks/task_e_68a61fa0c49c832682f4318ab28cfb99