### PR TITLE
Show all decision events in log viewer

### DIFF
--- a/systems/scripts/view_log.py
+++ b/systems/scripts/view_log.py
@@ -27,7 +27,7 @@ def view_log(ledger_name: str) -> None:
         return
 
     times = pd.to_datetime([e["timestamp"] for e in events])
-    prices: list[float | None] = []
+    prices: list[float] = []
     colors: list[str] = []
     annotations: list[str] = []
 
@@ -35,16 +35,24 @@ def view_log(ledger_name: str) -> None:
         decision = e["decision"]
         trades = e.get("trades") or []
         price = trades[0].get("price") if trades else None
+
+        # fallback to 0 so we always plot something
+        if price is None:
+            price = 0.0
+
         prices.append(price)
-        colors.append(
-            "green"
-            if decision == "BUY"
-            else "red"
-            if decision == "SELL"
-            else "orange"
-            if decision == "FLAT"
-            else "gray"
-        )
+
+        if decision == "BUY":
+            colors.append("green")
+        elif decision == "SELL":
+            colors.append("red")
+        elif decision == "FLAT":
+            colors.append("orange")
+        elif decision == "HOLD":
+            colors.append("gray")
+        else:
+            colors.append("yellow")  # catch unexpected cases
+
         features = e.get("features", {})
         annotations.append(
             f"{e['timestamp']}\n"


### PR DESCRIPTION
## Summary
- Plot every decision event in `view_log` even when no trade price exists
- Assign colors for BUY/SELL/FLAT/HOLD/unknown to visualize all cycles

## Testing
- `python bot.py --mode view --account Kris_Ledger --time 1m --viz`
- `python -m py_compile systems/scripts/view_log.py`


------
https://chatgpt.com/codex/tasks/task_e_68a62e56e15883268514de7400439936