### PR TITLE
Add ledger test mode

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -65,12 +65,13 @@ def main(argv: list[str] | None = None) -> None:
         )
 
     elif mode == "test":
-        from systems.scripts.trade_test import run_trade_test
+        from systems.scripts.test_mode import run_test
 
-        if not args.account:
-            addlog("Error: --account is required for test mode")
+        if not args.ledger:
+            addlog("Error: --ledger is required for test mode")
             sys.exit(1)
-        run_trade_test(args.account)
+        exit_code = run_test(args.ledger)
+        sys.exit(exit_code)
 
     elif mode == "wallet":
         accounts_cfg = cfg.get("accounts", {})

--- a/systems/scripts/test_mode.py
+++ b/systems/scripts/test_mode.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+"""Safe ledger validation without placing trades."""
+
+import os
+import time
+from typing import Any
+
+import ccxt
+
+from systems.scripts.fetch_candles import fetch_candles
+from systems.scripts.kraken_utils import get_kraken_balance
+from systems.scripts.ledger import Ledger
+from systems.scripts.evaluate_buy import evaluate_buy
+from systems.scripts.evaluate_sell import evaluate_sell
+from systems.scripts.runtime_state import build_runtime_state
+from systems.utils.load_config import load_config
+
+
+def _parse_ledger_name(name: str) -> tuple[str, str, str, str] | None:
+    parts = name.split("_")
+    if len(parts) < 3:
+        return None
+    account = parts[0]
+    base = parts[1]
+    quote = parts[2]
+    market = f"{base}/{quote}"
+    return account, base, quote, market
+
+
+def run_test(ledger: str) -> int:
+    """Validate ``ledger`` without mutating state or placing orders."""
+
+    parsed = _parse_ledger_name(ledger)
+    if not parsed:
+        print(f"[TEST][FAIL] Ledger={ledger}\nReason: Invalid ledger name")
+        return 1
+
+    account, base, quote, market = parsed
+
+    try:
+        cfg = load_config()
+        acct_cfg = cfg.get("accounts", {}).get(account)
+        if not acct_cfg:
+            raise ValueError(f"Unknown account '{account}'")
+        strat_cfg = acct_cfg.get("markets", {}).get(market)
+        if not strat_cfg:
+            raise ValueError(f"Unknown market '{market}'")
+
+        client = ccxt.kraken(
+            {
+                "enableRateLimit": True,
+                "apiKey": acct_cfg.get("api_key", ""),
+                "secret": acct_cfg.get("api_secret", ""),
+            }
+        )
+
+        now = int(time.time())
+        start = now - 3 * 3600
+        df = fetch_candles(market, start, now, source="kraken")
+        if df.empty:
+            raise RuntimeError("No recent candles fetched")
+
+        runtime_state = build_runtime_state(
+            cfg,
+            market,
+            strat_cfg,
+            mode="sim",
+            client=client,
+            prev={"verbose": 0},
+        )
+        runtime_state["mode"] = "test"
+
+        window_size = int(runtime_state.get("strategy", {}).get("window_size", 0))
+        t = max(0, len(df) - window_size)
+
+        ctx: dict[str, Any] = {"ledger": Ledger()}
+        decision = "HOLD"
+        buy_res = evaluate_buy(ctx, t, df, cfg=strat_cfg, runtime_state=runtime_state)
+        sell_res = evaluate_sell(
+            ctx,
+            t,
+            df,
+            cfg=strat_cfg,
+            open_notes=ctx["ledger"].get_open_notes(),
+            runtime_state=runtime_state,
+        )
+        if buy_res:
+            decision = "BUY"
+        elif sell_res:
+            decision = "SELL"
+
+        features = runtime_state.get("last_features", {}).get("strategy", {})
+        slope = features.get("slope", 0.0)
+        vol = features.get("volatility", 0.0)
+
+        os.environ["WS_ACCOUNT"] = account
+        balances = get_kraken_balance(quote)
+        quote_bal = float(balances.get(quote.upper(), 0.0))
+        base_bal = float(balances.get(base.upper(), 0.0))
+
+        print(f"[TEST][PASS] Ledger={ledger}")
+        print(
+            f"Balances: {quote.upper()}={quote_bal:.2f} {base.upper()}={base_bal:.2f}"
+        )
+        print(
+            f"Decision: {decision} (slope={slope:.2f} vol={vol:.2f})"
+        )
+        return 0
+
+    except Exception as exc:  # pragma: no cover - best effort logging
+        print(f"[TEST][FAIL] Ledger={ledger}\nReason: {exc}")
+        return 1

--- a/systems/utils/cli.py
+++ b/systems/utils/cli.py
@@ -18,6 +18,10 @@ def build_parser() -> argparse.ArgumentParser:
         help="Specific market symbol to operate on (default: all for account)",
     )
     parser.add_argument(
+        "--ledger",
+        help="Ledger name to validate in test mode",
+    )
+    parser.add_argument(
         "--all",
         action="store_true",
         help="Run all configured accounts and their markets",


### PR DESCRIPTION
## Summary
- extend CLI with a `--ledger` option and dispatch it in `bot.py`
- add `test_mode.run_test` to validate a ledger without trading

## Testing
- `python -m py_compile bot.py systems/utils/cli.py systems/scripts/test_mode.py`
- `PYTHONPATH=. pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a640e9a86c83269a86bfb045ca6a8e