### PR TITLE
feat: add email reporting system

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -27,6 +27,12 @@ def main(argv: list[str] | None = None) -> None:
         action="store_true",
         help="Enable visualization plotting",
     )
+    parser.add_argument(
+        "--period",
+        type=str,
+        default="daily",
+        help="Report period for email mode (daily|weekly|monthly|yearly|test)",
+    )
 
     args = parser.parse_args(argv or sys.argv[1:])
     if not args.mode:
@@ -98,6 +104,14 @@ def main(argv: list[str] | None = None) -> None:
             sys.exit(1)
         from systems.scripts.view_log import view_log
         view_log(args.account, timeframe=args.time)
+
+    elif mode == "email":
+        from systems.scripts.report import run_report
+
+        if not args.account:
+            addlog("Error: --account is required for email mode")
+            sys.exit(1)
+        run_report(args.account, args.period)
 
     else:
         parser.error(f"Unknown mode: {args.mode}")

--- a/settings/settings.json
+++ b/settings/settings.json
@@ -2,7 +2,14 @@
   "general_settings": {
     "max_note_usdt": 99999.0,
     "minimum_note_size": 10,
-    "simulation_capital": 1000
+    "simulation_capital": 1000,
+    "email": {
+      "enabled": true,
+      "daily": true,
+      "weekly": false,
+      "monthly": false,
+      "yearly": true
+    }
   },
   "coin_settings": {
     "default": {
@@ -35,10 +42,10 @@
       "is_live": false,
       "reporting": {
         "email": "kris@example.com",
-        "daily": false,
+        "daily": true,
         "weekly": false,
         "monthly": false,
-        "yearly": false
+        "yearly": true
       }
     }
   }

--- a/systems/scripts/report.py
+++ b/systems/scripts/report.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+"""Generate and email trading reports."""
+
+import argparse
+import json
+import smtplib
+import ssl
+from datetime import datetime
+from email.message import EmailMessage
+from pathlib import Path
+
+import yaml
+
+from systems.scripts.view_log import export_png
+from systems.scripts.ledger import load_ledger
+from systems.utils.addlog import addlog
+from systems.utils.config import load_settings
+
+
+def run_report(account: str, period: str) -> None:
+    """Create and email a report for ``account`` over ``period``."""
+
+    cfg = load_settings()
+    acct_cfg = cfg.get("accounts", {}).get(account)
+    if not acct_cfg or not acct_cfg.get("is_live", False):
+        addlog(f"[EMAIL][SKIP] {account} not live or unknown")
+        return
+
+    general_email = cfg.get("general_settings", {}).get("email", {})
+    acct_reporting = acct_cfg.get("reporting", {})
+
+    if period != "test":
+        if not (general_email.get("enabled") and general_email.get(period, False)):
+            addlog(f"[EMAIL][SKIP] {period} disabled")
+            return
+        if not acct_reporting.get(period, False):
+            addlog(f"[EMAIL][SKIP] {account} {period} disabled")
+            return
+        now = datetime.utcnow()
+        if period == "weekly" and now.weekday() != 0:
+            addlog("[EMAIL][SKIP] not start of week")
+            return
+        if period == "monthly" and now.day != 1:
+            addlog("[EMAIL][SKIP] not start of month")
+            return
+        if period == "yearly" and not (now.month == 1 and now.day == 1):
+            addlog("[EMAIL][SKIP] not start of year")
+            return
+
+    log_path = Path(f"data/logs/{account}.json")
+    if not log_path.exists():
+        addlog("[EMAIL][SKIP] no log")
+        return
+    events = json.loads(log_path.read_text())
+    if not events:
+        addlog("[EMAIL][SKIP] empty log")
+        return
+
+    out_dir = log_path.parent
+    out_dir.mkdir(parents=True, exist_ok=True)
+    png_path = out_dir / f"{account}_{period}.png"
+    export_png(log_path, png_path)
+
+    ledger = load_ledger(account)
+    last_price = events[-1].get("features", {}).get("close", 0.0)
+    summary = ledger.get_account_summary(last_price)
+    buys = sum(1 for e in events if e.get("decision") == "BUY")
+    sells = sum(1 for e in events if e.get("decision") == "SELL")
+    flats = sum(1 for e in events if e.get("decision") == "FLAT")
+    pnl = summary.get("realized_gain", 0.0)
+    capital = ledger.get_metadata().get("capital", 0.0)
+    roi = (pnl / capital) if capital else 0.0
+    open_notes = summary.get("open_notes", 0)
+
+    body = (
+        f"PnL: ${pnl:.2f}\n"
+        f"ROI: {roi*100:.2f}%\n"
+        f"Buys: {buys} Sells: {sells} Flats: {flats}\n"
+        f"Open notes: {open_notes}"
+    )
+
+    to_email = acct_reporting.get("email")
+    if not to_email:
+        addlog("[EMAIL][SKIP] no recipient")
+        return
+
+    key_path = Path("gmail_key.yaml")
+    if not key_path.exists():
+        addlog("[EMAIL][SKIP] no creds")
+        return
+    try:
+        creds = yaml.safe_load(key_path.read_text())
+    except Exception:
+        addlog("[EMAIL][SKIP] no creds")
+        return
+
+    msg = EmailMessage()
+    msg["Subject"] = f"{account} {period} report"
+    msg["From"] = creds.get("email")
+    msg["To"] = to_email
+    msg.set_content(body)
+    with png_path.open("rb") as fh:
+        msg.add_attachment(fh.read(), maintype="image", subtype="png", filename="report.png")
+
+    context = ssl.create_default_context()
+    try:
+        with smtplib.SMTP_SSL(creds["smtp_server"], creds["smtp_port"], context=context) as server:
+            server.login(creds["email"], creds["app_password"])
+            server.send_message(msg)
+        addlog(f"[EMAIL][SENT] {account} {period} report to {to_email}")
+    except Exception as exc:
+        addlog(f"[EMAIL][FAIL] {exc}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--account", required=True)
+    parser.add_argument(
+        "--period",
+        required=True,
+        choices=["daily", "weekly", "monthly", "yearly", "test"],
+    )
+    args = parser.parse_args()
+    run_report(args.account, args.period)
+
+
+if __name__ == "__main__":
+    main()

--- a/systems/scripts/view_log.py
+++ b/systems/scripts/view_log.py
@@ -14,6 +14,59 @@ import pandas as pd
 from systems.utils.time import parse_duration
 
 
+def export_png(log_path: Path, out_path: Path) -> None:
+    """Render ``log_path`` events to a PNG chart at ``out_path``."""
+
+    if not log_path.exists():
+        print(f"[ERROR] No log found at {log_path}")
+        return
+
+    with log_path.open() as f:
+        events = json.load(f)
+
+    if not events:
+        print(f"[EMPTY] {log_path.stem} log has no entries")
+        return
+
+    times = pd.to_datetime([e["timestamp"] for e in events])
+    prices: list[float] = []
+    colors: list[str] = []
+
+    for e in events:
+        decision = e.get("decision")
+        trades = e.get("trades") or []
+        if trades:
+            price = trades[0].get("price")
+        else:
+            price = e.get("features", {}).get("close")
+        if price is None:
+            price = 0.0
+
+        prices.append(price)
+
+        if decision == "BUY":
+            colors.append("green")
+        elif decision == "SELL":
+            colors.append("red")
+        elif decision == "FLAT":
+            colors.append("orange")
+        elif decision == "HOLD":
+            colors.append("gray")
+        else:
+            colors.append("yellow")
+
+    plt.switch_backend("Agg")
+    fig, ax = plt.subplots()
+    ax.scatter(times, prices, c=colors, marker="o")
+    ax.set_title(f"Trading Decisions for {log_path.stem}")
+    ax.set_xlabel("Time")
+    ax.set_ylabel("Price (USDT)")
+    plt.xticks(rotation=45)
+    plt.tight_layout()
+    fig.savefig(out_path, format="png")
+    plt.close(fig)
+
+
 def view_log(account_name: str, timeframe: str | None = None) -> None:
     """Render a scatter plot of decisions from ``account_name`` log."""
 

--- a/systems/utils/cli.py
+++ b/systems/utils/cli.py
@@ -6,8 +6,8 @@ def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="WindowSurfer command line interface")
     parser.add_argument(
         "--mode",
-        choices=["fetch", "sim", "live", "wallet", "view", "test"],
-        help="Execution mode: fetch, sim, live, wallet, view, or test",
+        choices=["fetch", "sim", "live", "wallet", "view", "test", "email"],
+        help="Execution mode: fetch, sim, live, wallet, view, test, or email",
     )
     parser.add_argument(
         "--account",


### PR DESCRIPTION
## Summary
- add global email schedule settings
- export trading logs to PNG for reports
- implement email report script with summary and scheduling
- wire up email mode to bot CLI

## Testing
- `python -m systems.scripts.report --account Kris_Ledger --period test`
- `python bot.py --mode email --account Kris_Ledger --period test -v`


------
https://chatgpt.com/codex/tasks/task_e_68a640f0f3948326bcf1c48dde28d43e