### PR TITLE
Refactor test mode to use account and market

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -73,10 +73,10 @@ def main(argv: list[str] | None = None) -> None:
     elif mode == "test":
         from systems.scripts.test_mode import run_test
 
-        if not args.account:
-            addlog("Error: --account is required for test mode")
+        if not args.account or not args.market:
+            addlog("Error: --account and --market are required for test mode")
             sys.exit(1)
-        exit_code = run_test(args.account)
+        exit_code = run_test(args.account, args.market)
         sys.exit(exit_code)
 
     elif mode == "wallet":

--- a/systems/scripts/account_book.py
+++ b/systems/scripts/account_book.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+"""Lightweight in-memory book for open notes during testing."""
+
+from typing import Dict, List
+
+
+class AccountBook:
+    """Track open and closed notes for account validation."""
+
+    def __init__(self) -> None:
+        self.open_notes: List[Dict] = []
+        self.closed_notes: List[Dict] = []
+
+    def open_note(self, note: Dict) -> None:
+        """Register a new open note."""
+        self.open_notes.append(note)
+
+    def close_note(self, note: Dict) -> None:
+        """Move ``note`` from open to closed."""
+        if note in self.open_notes:
+            self.open_notes.remove(note)
+            self.closed_notes.append(note)
+
+    def get_open_notes(self) -> List[Dict]:
+        """Return a copy of open notes."""
+        return list(self.open_notes)


### PR DESCRIPTION
## Summary
- drop ledger parsing from test mode
- add AccountBook context stub and validate account/market
- require market arg in bot CLI for test mode

## Testing
- `python bot.py --mode test --account Kris --market DOGE/USD` (fails: kraken GET https://api.kraken.com/0/public/Assets)
- `python bot.py --mode test --account Foo --market DOGE/USD`
- `python bot.py --mode test --account Kris --market LTC/USD`


------
https://chatgpt.com/codex/tasks/task_e_68a65fd1e0888326a8a5d9533e5145a1