### PR TITLE
Require both buy and sell in test mode lookback

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -76,7 +76,7 @@ def main(argv: list[str] | None = None) -> None:
         if not args.account or not args.market:
             addlog("Error: --account and --market are required for test mode")
             sys.exit(1)
-        exit_code = run_test(args.account, args.market)
+        exit_code = run_test(args.account, args.market, args.time)
         sys.exit(exit_code)
 
     elif mode == "wallet":

--- a/systems/scripts/test_mode.py
+++ b/systems/scripts/test_mode.py
@@ -18,12 +18,12 @@ from systems.utils.config import (
     load_coin_settings,
     load_account_settings,
     load_keys,
-    resolve_coin_config,
-    resolve_account_market,
 )
+from systems.utils.time import parse_duration
 
-def run_test(account: str, market: str) -> int:
-    """Validate ``account``/``market`` without mutating state or placing orders."""
+
+def run_test(account: str, market: str, lookback: str | None = None) -> int:
+    """Run a short in-memory backtest requiring at least one BUY and SELL."""
 
     general = load_general()
     coin_settings = load_coin_settings()
@@ -35,49 +35,69 @@ def run_test(account: str, market: str) -> int:
         print(f"[TEST][FAIL] Account={account}\nReason: Unknown account")
         return 1
     if market not in acct_cfg.get("market settings", {}):
-        print(f"[TEST][FAIL] Account={account}\nReason: Unknown market {market}")
+        print(
+            f"[TEST][FAIL] Account={account} Market={market}\nReason: Unknown market"
+        )
         return 1
 
+    lookback = lookback or "72h"
     try:
-        strategy_cfg = {
-            **resolve_coin_config(market, coin_settings),
-            **resolve_account_market(account, market, accounts_cfg),
+        delta = parse_duration(lookback)
+    except Exception:
+        print(
+            f"[TEST][FAIL] Account={account} Market={market}\nReason: Invalid lookback '{lookback}'"
+        )
+        return 1
+
+    end_ts = int(time.time())
+    start_ts = end_ts - int(delta.total_seconds())
+
+    df = fetch_candles(market, start_ts, end_ts, source="kraken")
+    if df.empty:
+        print(
+            f"[TEST][FAIL] Account={account} Market={market}\nReason: No recent candles in lookback"
+        )
+        return 1
+
+    keypair = keys.get(account, {})
+    client = ccxt.kraken(
+        {
+            "enableRateLimit": True,
+            "apiKey": keypair.get("api_key", ""),
+            "secret": keypair.get("api_secret", ""),
         }
+    )
 
-        keypair = keys.get(account, {})
-        client = ccxt.kraken(
-            {
-                "enableRateLimit": True,
-                "apiKey": keypair.get("api_key", ""),
-                "secret": keypair.get("api_secret", ""),
-            }
-        )
+    runtime_state = build_runtime_state(
+        general,
+        coin_settings,
+        accounts_cfg,
+        account,
+        market,
+        mode="sim",
+        client=client,
+        prev={"verbose": 0},
+    )
+    runtime_state["mode"] = "test"
+    strategy_cfg = runtime_state.get("strategy", {})
 
-        now = int(time.time())
-        start = now - 3 * 3600
-        df = fetch_candles(market, start, now, source="kraken")
-        if df.empty:
-            raise RuntimeError("No recent candles fetched")
+    window = int(strategy_cfg.get("window_size", 0))
+    ctx: dict[str, Any] = {"account": AccountBook()}
+    saw_buy = 0
+    saw_sell = 0
 
-        runtime_state = build_runtime_state(
-            general,
-            coin_settings,
-            accounts_cfg,
-            account,
-            market,
-            mode="sim",
-            client=client,
-            prev={"verbose": 0},
-        )
-        runtime_state["mode"] = "test"
-        strategy_cfg = runtime_state.get("strategy", {})
-
-        window_size = int(strategy_cfg.get("window_size", 0))
-        t = max(0, len(df) - window_size)
-
-        ctx: dict[str, Any] = {"account": AccountBook()}
-        decision = "HOLD"
+    for t in range(window, len(df)):
         buy_res = evaluate_buy(ctx, t, df, cfg=strategy_cfg, runtime_state=runtime_state)
+        if buy_res:
+            saw_buy += 1
+            candle = df.iloc[t]
+            note = {
+                "entry_price": float(candle["close"]),
+                "size": float(buy_res.get("size_usd", 0.0)),
+                "created_ts": int(candle.get("timestamp", end_ts)),
+            }
+            ctx["account"].open_note(note)
+
         sell_res = evaluate_sell(
             ctx,
             t,
@@ -86,30 +106,37 @@ def run_test(account: str, market: str) -> int:
             open_notes=ctx["account"].get_open_notes(),
             runtime_state=runtime_state,
         )
-        if buy_res:
-            decision = "BUY"
-        elif sell_res:
-            decision = "SELL"
+        if sell_res:
+            saw_sell += len(sell_res)
+            for note in sell_res:
+                ctx["account"].close_note(note)
 
-        features = runtime_state.get("last_features", {}).get("strategy", {})
-        slope = features.get("slope", 0.0)
-        vol = features.get("volatility", 0.0)
+    features = runtime_state.get("last_features", {}).get("strategy", {})
+    slope = features.get("slope", 0.0)
+    vol = features.get("volatility", 0.0)
 
-        os.environ["WS_ACCOUNT"] = account
-        base, quote = market.split("/")
+    os.environ["WS_ACCOUNT"] = account
+    base, quote = market.split("/")
+    try:
         balances = get_kraken_balance(quote)
-        quote_bal = float(balances.get(quote.upper(), 0.0))
-        base_bal = float(balances.get(base.upper(), 0.0))
+    except Exception:
+        balances = {}
+    quote_bal = float(balances.get(quote.upper(), 0.0))
+    base_bal = float(balances.get(base.upper(), 0.0))
 
-        print(f"[TEST][PASS] Account={account} Market={market}")
-        print(f"Balances: {quote.upper()}={quote_bal:.2f} {base.upper()}={base_bal:.2f}")
-        print(
-            f"Decision: {decision} (slope={slope:.2f} vol={vol:.2f})"
-        )
-        return 0
+    passed = saw_buy > 0 and saw_sell > 0
+    prefix = "[TEST][PASS]" if passed else "[TEST][FAIL]"
+    print(f"{prefix} Account={account} Market={market}")
+    print(f"Balances: {quote.upper()}={quote_bal:.2f} {base.upper()}={base_bal:.2f}")
+    print(f"Summary: buys={saw_buy} sells={saw_sell} lookback={lookback}")
+    if not passed:
+        reason = []
+        if saw_buy == 0:
+            reason.append("no BUY in lookback")
+        if saw_sell == 0:
+            reason.append("no SELL in lookback")
+        print("Reason: " + ", ".join(reason))
+    print(f"Last candle: slope={slope:.2f} vol={vol:.2f}")
 
-    except Exception as exc:  # pragma: no cover - best effort logging
-        print(
-            f"[TEST][FAIL] Account={account} Market={market}\nReason: {exc}"
-        )
-        return 1
+    return 0 if passed else 1
+


### PR DESCRIPTION
## Summary
- expand test mode to backtest over a configurable lookback window and require at least one BUY and SELL
- accept `--time` argument when running bot in test mode

## Testing
- `python bot.py --mode test --account Kris --market DOGE/USD --time 7d -v` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a67453b2f48326805ef53aa0d4f9b1