### PR TITLE
Add truth test harness utilities and exhaustion script

### DIFF
--- a/systems/tests/truth_exhaustion.py
+++ b/systems/tests/truth_exhaustion.py
@@ -8,32 +8,48 @@ import sys
 sys.path.append(os.path.dirname(os.path.dirname(os.path.dirname(__file__))))
 
 from systems.sim_engine import run_simulation
-from systems.tests.utils_truth import load_candles, slope, percent_results
+from systems.tests.utils_truth import (
+    load_candles,
+    slope,
+    percent_results,
+    run_truth,
+)
 
 TAG = "SOLUSD"
 
+
 QUESTIONS = [
-    ("Is 5-candle slope positive?",
-     lambda df, i: slope(df['close'].iloc[max(0, i-4):i+1]) > 0),
-    ("Is close above previous close?",
-     lambda df, i: True if i == 0 else df['close'].iloc[i] > df['close'].iloc[i-1]),
+    (
+        "Does exhaustion after long pressure → reversal?",
+        lambda t, df, ctx: ctx["is_exhaustion"][t]
+        and slope(df["close"].iloc[t : t + 6]) < 0,
+    ),
 ]
 
 
-def run_truth(timeframe: str, vis: bool) -> None:
+def build_context(df):
+    """Precompute exhaustion markers and streak lengths."""
+    streak = [0] * len(df)
+    for i in range(1, len(df)):
+        if df["close"].iloc[i] > df["close"].iloc[i - 1]:
+            streak[i] = streak[i - 1] + 1
+        else:
+            streak[i] = 0
+
+    is_exhaustion = [False] * len(df)
+    for i in range(1, len(df)):
+        is_exhaustion[i] = streak[i - 1] >= 5 and df["close"].iloc[i] < df["close"].iloc[i - 1]
+
+    return {"streak": streak, "is_exhaustion": is_exhaustion}
+
+
+def main(timeframe: str, vis: bool) -> None:
     if vis:
         run_simulation(timeframe=timeframe, viz=True)
         return
 
     df = load_candles(TAG, timeframe)
-    results = {q: [] for q, _ in QUESTIONS}
-    for i in range(len(df)):
-        for q, fn in QUESTIONS:
-            try:
-                results[q].append(bool(fn(df, i)))
-            except Exception:
-                results[q].append(False)
-
+    results = run_truth(df, QUESTIONS, build_context)
     print(percent_results(results))
 
 
@@ -42,4 +58,5 @@ if __name__ == "__main__":
     parser.add_argument("--time", default="1m")
     parser.add_argument("--vis", action="store_true", default=False)
     args = parser.parse_args()
-    run_truth(args.time, args.vis)
+    main(args.time, args.vis)
+

--- a/systems/tests/utils_truth.py
+++ b/systems/tests/utils_truth.py
@@ -1,17 +1,28 @@
 import pandas as pd
 import numpy as np
 
-from systems.sim_engine import parse_timeframe, apply_time_filter
+from systems.sim_engine import parse_timeframe, apply_time_filter, WINDOW_SIZE
 
 
-def load_candles(tag: str, timeframe: str):
+def load_candles(tag: str, timeframe: str) -> pd.DataFrame:
     """Load CSV candles for a market tag and apply timeframe filtering."""
     file_path = f"data/sim/{tag}_1h.csv"
     df = pd.read_csv(file_path)
+
+    # Apply timeframe filtering to maintain sim/live parity.
     delta = parse_timeframe(timeframe)
     if delta is not None:
-        df = apply_time_filter(df, delta, file_path)
-    return df.reset_index(drop=True)
+        df_filtered = apply_time_filter(df, delta, file_path)
+        # If no rows survive (e.g. historical data far in the past),
+        # fall back to a simple tail slice to ensure we have data.
+        if not df_filtered.empty:
+            df = df_filtered
+        else:
+            df = df.tail(WINDOW_SIZE)
+
+    df = df.reset_index(drop=True)
+    df["candle_index"] = np.arange(len(df))
+    return df
 
 
 def slope(series) -> float:
@@ -22,11 +33,44 @@ def slope(series) -> float:
     return float(np.polyfit(x, series, 1)[0])
 
 
-def percent_results(results_dict: dict) -> str:
-    """Format boolean result lists as percentage strings."""
+def percent_results(results: dict) -> str:
+    """Format hits/total pairs into percentage strings."""
     lines = []
-    for question, hits in results_dict.items():
-        total = len(hits)
-        pct = (sum(hits) / total * 100) if total else 0.0
+    for question, (hits, total) in results.items():
+        pct = (hits / total * 100) if total else 0.0
         lines.append(f"{question} = {pct:.0f}%")
     return "\n".join(lines)
+
+
+def run_truth(df: pd.DataFrame, questions, context_fn) -> dict:
+    """Iterate candles and evaluate truth-check functions.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        Candle data frame.
+    questions : List[Tuple[str, Callable]]
+        Sequence of (question, fn) pairs where fn(t, df, ctx) -> bool.
+    context_fn : Callable
+        Function computing reusable context from the dataframe.
+
+    Returns
+    -------
+    dict
+        Mapping question -> (hits, total).
+    """
+
+    ctx = context_fn(df)
+    results = {q: [0, 0] for q, _ in questions}
+
+    for t in range(len(df)):
+        for q, fn in questions:
+            try:
+                hit = bool(fn(t, df, ctx))
+            except Exception:
+                hit = False
+            if hit:
+                results[q][0] += 1
+            results[q][1] += 1
+
+    return {q: (h, tot) for q, (h, tot) in results.items()}


### PR DESCRIPTION
## Summary
- Add reusable truth-test utilities with candle loading, slope calculation and results formatter
- Introduce run_truth framework to iterate questions over candles
- Provide an exhaustion truth-check script with context precomputation and optional visualization

## Testing
- `python -m py_compile systems/tests/utils_truth.py systems/tests/truth_exhaustion.py`
- `python systems/tests/truth_exhaustion.py --time 6m`


------
https://chatgpt.com/codex/tasks/task_e_68a8cfbc70c0832686ed66b195562580