### PR TITLE
Add truth test harness for exhaustion pressure

### DIFF
--- a/systems/tests/truth_exhaustion.py
+++ b/systems/tests/truth_exhaustion.py
@@ -21,26 +21,43 @@ TAG = "SOLUSD"
 QUESTIONS = [
     (
         "Does exhaustion after long pressure → reversal?",
-        lambda t, df, ctx: ctx["is_exhaustion"][t]
-        and slope(df["close"].iloc[t : t + 6]) < 0,
+        lambda t, df, ctx: (
+            slope(df["close"].iloc[t : t + 6]) < 0
+            if ctx["is_exhaustion"][t]
+            else None
+        ),
+    ),
+    (
+        "Do long gaps without exhaustion align with trending?",
+        lambda t, df, ctx: (
+            abs(slope(df["close"].iloc[max(0, t - 12) : t])) > 0.01
+            if ctx["since_exhaustion"][t] >= 24
+            else None
+        ),
     ),
 ]
 
 
 def build_context(df):
-    """Precompute exhaustion markers and streak lengths."""
+    """Precompute exhaustion markers and streak / gap lengths."""
     streak = [0] * len(df)
     for i in range(1, len(df)):
-        if df["close"].iloc[i] > df["close"].iloc[i - 1]:
-            streak[i] = streak[i - 1] + 1
-        else:
-            streak[i] = 0
+        streak[i] = streak[i - 1] + 1 if df["close"].iloc[i] > df["close"].iloc[i - 1] else 0
 
     is_exhaustion = [False] * len(df)
     for i in range(1, len(df)):
         is_exhaustion[i] = streak[i - 1] >= 5 and df["close"].iloc[i] < df["close"].iloc[i - 1]
 
-    return {"streak": streak, "is_exhaustion": is_exhaustion}
+    since_exhaustion = [0] * len(df)
+    last = -1
+    for i in range(len(df)):
+        if is_exhaustion[i]:
+            since_exhaustion[i] = 0
+            last = i
+        else:
+            since_exhaustion[i] = i - last if last != -1 else i + 1
+
+    return {"streak": streak, "is_exhaustion": is_exhaustion, "since_exhaustion": since_exhaustion}
 
 
 def main(timeframe: str, vis: bool) -> None:
@@ -48,9 +65,11 @@ def main(timeframe: str, vis: bool) -> None:
         run_simulation(timeframe=timeframe, viz=True)
         return
 
-    df = load_candles(TAG, timeframe)
+    file_path = f"data/sim/{TAG}_1h.csv"
+    df = load_candles(file_path, timeframe)
     results = run_truth(df, QUESTIONS, build_context)
-    print(percent_results(results))
+    for q, pct in percent_results(results).items():
+        print(f"{q} = {pct:.0f}%")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add `utils_truth` with helpers to load candles, calculate slopes, compute percentages and run truth checks
- implement `truth_exhaustion` test with questions and context for exhaustion pressure

## Testing
- `python systems/tests/truth_exhaustion.py --time 6m`
- `python systems/tests/truth_exhaustion.py --time 6m --vis`

------
https://chatgpt.com/codex/tasks/task_e_68a8d23c745883269fa6e191eea4720f