### PR TITLE
Add slope decay and bubble size exhaustion tests

### DIFF
--- a/systems/tests/truth_exhaustion.py
+++ b/systems/tests/truth_exhaustion.py
@@ -44,6 +44,33 @@ QUESTIONS = [
             else None
         ),
     ),
+    (
+        "Slope decay: after long uptrend, 64-candle slope weakens after exhaustion?",
+        lambda t, df, ctx: (
+            slope(df["close"].iloc[t - 64 : t]) > 0
+            and slope(df["close"].iloc[t : t + 64])
+            < slope(df["close"].iloc[t - 64 : t])
+            if (
+                ctx["is_exhaustion"][t]
+                and ctx["pressure_len"][t] > 8
+                and t >= 64
+                and t + 64 < len(df)
+            )
+            else None
+        ),
+    ),
+    (
+        "Bubble size: larger exhaustion bubble → higher reversal chance?",
+        lambda t, df, ctx: (
+            slope(df["close"].iloc[t : t + 64]) < 0
+            if (
+                ctx["is_exhaustion"][t]
+                and ctx["pressure_len"][t] > 12
+                and t + 64 < len(df)
+            )
+            else None
+        ),
+    ),
 ]
 
 


### PR DESCRIPTION
## Summary
- add slope decay question to exhaustion tests to verify momentum loss
- add bubble size truth test tying large bubbles to reversal probability

## Testing
- `python -m systems.tests.truth_exhaustion`


------
https://chatgpt.com/codex/tasks/task_e_68a8dc6224e88326bfe6379563b06741