### PR TITLE
Use months for time windows

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -10,7 +10,11 @@ from systems import sim_engine
 def main() -> None:
     parser = argparse.ArgumentParser(description="WindowSurfer discovery bot")
     parser.add_argument("--mode", required=True, help="Mode to run (sim)")
-    parser.add_argument("--time", default="1m", help="Time window for simulation")
+    parser.add_argument(
+        "--time",
+        default="1m",
+        help="Time window for simulation (e.g. '3m' for three months)",
+    )
     args = parser.parse_args()
 
     if args.mode.lower() == "sim":

--- a/systems/sim_engine.py
+++ b/systems/sim_engine.py
@@ -23,14 +23,15 @@ _INTERVAL_RE = re.compile(r'[_\-]((\d+)([smhdw]))(?=\.|_|$)', re.I)
 
 UNIT_SECONDS = {
     's': 1,
-    'm': 60,
+    # interpret 'm' as months (~30 days)
+    'm': 30 * 24 * 3600,
     'h': 3600,
     'd': 86400,
     'w': 604800,
 }
 
 def parse_timeframe(tf: str) -> timedelta | None:
-    """Parse strings like '12h', '3d', '6w' into timedelta."""
+    """Parse strings like '12h', '3d', '6w', '3m' into timedelta."""
     if not tf:
         return None
     m = re.match(r'(?i)^\s*(\d+)\s*([smhdw])\s*$', tf)
@@ -433,7 +434,12 @@ def run_simulation(*, timeframe: str = "1m", viz: bool = True) -> None:
 
 def main() -> None:
     p = argparse.ArgumentParser()
-    p.add_argument("--time", type=str, default="1m")
+    p.add_argument(
+        "--time",
+        type=str,
+        default="1m",
+        help="Time window (e.g. '3m' for three months)",
+    )
     p.add_argument("--viz", action="store_true")
     args = p.parse_args()
     run_simulation(timeframe=args.time, viz=args.viz)


### PR DESCRIPTION
## Summary
- interpret `--time` arguments using months instead of minutes
- document the new month-based timeframe in CLI help

## Testing
- `python -m pytest`
- `python bot.py --mode sim --time 1m`


------
https://chatgpt.com/codex/tasks/task_e_68a8f59f18b08326be6fbf3b288e8c72