### PR TITLE
Add brain runner mode with exhaustion stats

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -4,21 +4,31 @@ from __future__ import annotations
 
 import argparse
 
-from systems import sim_engine
+from systems import sim_engine, brain_runner
+from systems.brains import list_brains
 
 
 def main() -> None:
     parser = argparse.ArgumentParser(description="WindowSurfer discovery bot")
-    parser.add_argument("--mode", required=True, help="Mode to run (sim)")
+    parser.add_argument("--mode", required=True, help="Mode to run (sim or brain)")
     parser.add_argument(
         "--time",
         default="1m",
-        help="Time window for simulation (e.g. '3m' for three months)",
+        help="Time window (e.g. '3m' for three months)",
     )
+    parser.add_argument("--brain", help="Brain to run in --mode brain")
     args = parser.parse_args()
 
-    if args.mode.lower() == "sim":
+    mode = args.mode.lower()
+    if mode == "sim":
         sim_engine.run_simulation(timeframe=args.time)
+    elif mode == "brain":
+        if not args.brain:
+            print("Available brains:")
+            for name in list_brains():
+                print("-", name)
+            return
+        brain_runner.run(args.brain, timeframe=args.time, viz=True)
     else:
         raise ValueError(f"Unknown mode: {args.mode}")
 

--- a/systems/brain_runner.py
+++ b/systems/brain_runner.py
@@ -1,0 +1,249 @@
+from __future__ import annotations
+
+import json
+import math
+import os
+import re
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+
+from .brains import load_brain
+
+# ===================== Parameters =====================
+WINDOW_STEP = 2
+SLOPE_WIN = 12
+
+# ===================== Helpers (copied from sim_engine) =====================
+_INTERVAL_RE = re.compile(r'[_\-]((\d+)([smhdw]))(?=\.|_|$)', re.I)
+
+UNIT_SECONDS = {
+    's': 1,
+    # interpret 'm' as months (~30 days)
+    'm': 30 * 24 * 3600,
+    'h': 3600,
+    'd': 86400,
+    'w': 604800,
+}
+
+def parse_timeframe(tf: str) -> timedelta | None:
+    """Parse strings like '12h', '3d', '6w', '3m' into timedelta."""
+    if not tf:
+        return None
+    m = re.match(r'(?i)^\s*(\d+)\s*([smhdw])\s*$', tf)
+    if not m:
+        return None
+    n, u = int(m.group(1)), m.group(2).lower()
+    return timedelta(seconds=n * UNIT_SECONDS[u])
+
+def infer_candle_seconds_from_filename(path: str) -> int | None:
+    """Try to infer candle interval from filename like *_1h.csv, *_15m.csv, *_1d.csv."""
+    m = _INTERVAL_RE.search(os.path.basename(path))
+    if not m:
+        return None
+    n, u = int(m.group(2)), m.group(3).lower()
+    return n * UNIT_SECONDS[u]
+
+def apply_time_filter(df: pd.DataFrame, delta: timedelta, file_path: str, warmup: int) -> pd.DataFrame:
+    if delta is None:
+        return df
+    if 'timestamp' in df.columns:
+        ts = df['timestamp']
+        ts_max = float(ts.iloc[-1])
+        is_ms = ts_max > 1e12
+        to_seconds = (ts / 1000.0) if is_ms else ts
+        cutoff = (datetime.now(timezone.utc).timestamp() - delta.total_seconds())
+        mask = to_seconds >= cutoff
+        return df.loc[mask]
+    for col in ('datetime','date','time'):
+        if col in df.columns:
+            try:
+                dt = pd.to_datetime(df[col], utc=True, errors='coerce')
+                cutoff_dt = pd.Timestamp.utcnow() - delta
+                mask = dt >= cutoff_dt
+                return df.loc[mask]
+            except Exception:
+                pass
+    sec = infer_candle_seconds_from_filename(file_path) or 3600
+    need = int(max(warmup + 1, delta.total_seconds() // sec))
+    if need <= 0 or need >= len(df):
+        return df
+    return df.iloc[-need:]
+
+# ===================== Trend Helper =====================
+def multi_window_vote(df, t, window_sizes, slope_thresh=0.001, range_thresh=0.05):
+    """Return (-1,0,1) decision with confidence using multi-window slope direction."""
+    votes, strengths = [], []
+    for W in window_sizes:
+        if t - W < 0:
+            continue
+        sub = df.iloc[t - W:t]
+        closes = sub["close"].values
+        x = np.arange(len(closes))
+        slope = float(np.polyfit(x, closes, 1)[0]) if len(closes) > 1 else 0.0
+        rng = float(sub["close"].max() - sub["close"].min())
+        if abs(slope) < slope_thresh or rng < range_thresh:
+            continue
+        direction = 1 if slope > 0 else -1
+        votes.append(direction)
+        strengths.append(abs(slope) * rng)
+    score = sum(votes)
+    confidence = (sum(strengths) / max(1, len(strengths))) if strengths else 0.0
+    if score >= 2:
+        return 1, confidence, score
+    if score <= -2:
+        return -1, confidence, score
+    return 0, confidence, score
+
+# ===================== Runner =====================
+def run(brain_name: str, timeframe: str, viz: bool = True) -> dict[str, float]:
+    file_path = "data/sim/SOLUSD_1h.csv"
+    df = pd.read_csv(file_path)
+
+    brain = load_brain(brain_name)
+
+    delta = parse_timeframe(timeframe)
+    if delta is not None:
+        df = apply_time_filter(df, delta, file_path, brain.warmup())
+    df = df.reset_index(drop=True)
+    df["candle_index"] = range(len(df))
+
+    brain.prepare(df)
+
+    trend_state: list[int] = []
+    angles: list[float] = []
+    for t in range(len(df)):
+        decision, _, _ = multi_window_vote(df, t, window_sizes=[8, 12, 24, 48])
+        if decision == 1:
+            trend_state.append(1)
+        elif decision == -1:
+            trend_state.append(-1)
+        else:
+            trend_state.append(0)
+        if t >= SLOPE_WIN:
+            sub = df["close"].iloc[t - SLOPE_WIN + 1 : t + 1]
+            slope = float(np.polyfit(np.arange(len(sub)), sub, 1)[0]) if len(sub) > 1 else 0.0
+            angle = math.degrees(math.atan(slope))
+        else:
+            angle = 0.0
+        angles.append(angle)
+
+    for t in range(brain.warmup(), len(df), WINDOW_STEP):
+        brain.step(df, t)
+
+    pts = brain.overlays()
+
+    stats = brain.compute_stats(df, trend_state, angles)
+
+    run_id = datetime.utcnow().strftime("%Y%m%d_%H%M%S")
+    out_dir = Path("data/out") / run_id
+    out_dir.mkdir(parents=True, exist_ok=True)
+    with open(out_dir / "brain_stats.json", "w") as f:
+        json.dump(stats, f, indent=2)
+
+    print("Brain statistics:")
+    for k, v in stats.items():
+        print(f"{k:40s} {v:.4f}")
+
+    if not viz:
+        return stats
+
+    fig, ax1 = plt.subplots(figsize=(12, 6))
+    ax1.plot(df["candle_index"], df["close"], lw=1, label="Close Price", color="blue")
+
+    artists = {
+        "exhaustion": None,
+        "reversals":  None,
+        "bottom4":    None,
+        "top5":       None,
+        "top6":       None,
+        "top7":       None,
+        "top8":       None,
+        "valley_w":   None,
+        "valley_e":   None,
+        "valley_r":   None,
+        "valley_t":   None,
+    }
+    state = {k: False for k in artists.keys()}
+
+    def ensure_artist(name: str):
+        if artists[name] is not None:
+            return
+        if name == "exhaustion":
+            xr, yr, sr = pts["exhaustion_red"]["x"], pts["exhaustion_red"]["y"], pts["exhaustion_red"]["s"]
+            xg, yg, sg = pts["exhaustion_green"]["x"], pts["exhaustion_green"]["y"], pts["exhaustion_green"]["s"]
+            h1 = ax1.scatter(xr, yr, s=sr, c="red", zorder=6, visible=False)
+            h2 = ax1.scatter(xg, yg, s=sg, c="green", zorder=6, visible=False)
+            artists[name] = (h1, h2)
+        elif name == "reversals":
+            artists[name] = ax1.scatter(
+                pts["reversal"]["x"], pts["reversal"]["y"], c="yellow", s=120, edgecolor="black", zorder=7, visible=False
+            )
+        elif name in ("bottom4","top5","top6","top7","top8","valley_w","valley_e","valley_r","valley_t"):
+            style = {
+                "bottom4": dict(c="cyan", marker="v", s=100, zorder=6),
+                "top5":    dict(c="orange", marker="s", s=110, zorder=6),
+                "top6":    dict(c="red", marker="*", s=140, zorder=6),
+                "top7":    dict(c="purple", marker="^", s=110, zorder=6),
+                "top8":    dict(c="magenta", marker="P", s=160, zorder=7),
+                "valley_w":dict(c="teal", marker="h", s=120, zorder=7),
+                "valley_e":dict(c="deepskyblue", marker="D", s=110, zorder=7),
+                "valley_r":dict(c="darkcyan", marker="s", s=100, zorder=7),
+                "valley_t":dict(c="turquoise", marker="P", s=150, zorder=8),
+            }[name]
+            artists[name] = ax1.scatter(pts[name]["x"], pts[name]["y"], visible=False, **style)
+
+    def set_visible(name: str, on: bool):
+        h = artists[name]
+        if h is None:
+            return
+        if isinstance(h, tuple):
+            for hh in h:
+                hh.set_visible(on)
+        else:
+            h.set_visible(on)
+
+    def toggle(name: str):
+        ensure_artist(name)
+        state[name] = not state[name]
+        set_visible(name, state[name])
+        print(f"[TOGGLE] {name} {'ON' if state[name] else 'OFF'}")
+        plt.draw()
+
+    def on_key(event):
+        k = (event.key or "").lower()
+        if k == "1":
+            toggle("exhaustion")
+        elif k == "2":
+            toggle("reversals")
+        elif k == "3" or k == "r":
+            toggle("valley_r")
+        elif k == "4":
+            toggle("bottom4")
+        elif k == "5":
+            toggle("top5")
+        elif k == "6":
+            toggle("top6")
+        elif k == "7":
+            toggle("top7")
+        elif k == "8":
+            toggle("top8")
+        elif k == "w":
+            toggle("valley_w")
+        elif k == "e":
+            toggle("valley_e")
+        elif k == "t":
+            toggle("valley_t")
+
+    ax1.set_title("Price with Exhaustion + Predictors (Keys 1–2,3,4–8; Letters W/E/R/T)")
+    ax1.set_xlabel("Candles (Index)")
+    ax1.set_ylabel("Price")
+    ax1.grid(True)
+
+    fig.canvas.mpl_connect("key_press_event", on_key)
+    plt.show()
+
+    return stats

--- a/systems/brains/__init__.py
+++ b/systems/brains/__init__.py
@@ -4,8 +4,10 @@ REGISTRY = {
     "exhaustion": ExhaustionBrain,
 }
 
+def list_brains() -> list[str]:
+    return sorted(REGISTRY.keys())
+
 def load_brain(name: str):
-    cls = REGISTRY.get(name)
-    if not cls:
+    if name not in REGISTRY:
         raise ValueError(f"Unknown brain: {name}")
-    return cls()
+    return REGISTRY[name]()

--- a/systems/brains/base.py
+++ b/systems/brains/base.py
@@ -2,25 +2,33 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Dict, List, Any
 
+import pandas as pd
+
+
 @dataclass
-class Signal:
-    t: int
-    price: float
-    tag: str
-    meta: dict
+class Overlay:
+    x: List[int]
+    y: List[float]
+    s: List[float] | None = None
+    c: str | None = None
 
 
 class Brain:
     name: str = "base"
 
-    def warmup(self) -> int:
+    def prepare(self, df: pd.DataFrame) -> None:  # pragma: no cover - interface
         raise NotImplementedError
 
-    def prepare(self, df) -> None:
+    def step(self, df: pd.DataFrame, t: int) -> None:  # pragma: no cover - interface
         raise NotImplementedError
 
-    def step(self, df, t: int) -> None:
+    def warmup(self) -> int:  # pragma: no cover - interface
         raise NotImplementedError
 
-    def overlays(self) -> Dict[str, Dict[str, List[Any]]]:
+    def overlays(self) -> Dict[str, Dict[str, List[Any]]]:  # pragma: no cover - interface
+        raise NotImplementedError
+
+    def compute_stats(
+        self, df: pd.DataFrame, trend_state: List[int], slopes: List[float]
+    ) -> Dict[str, float]:  # pragma: no cover - interface
         raise NotImplementedError

--- a/systems/brains/exhaustion.py
+++ b/systems/brains/exhaustion.py
@@ -65,6 +65,7 @@ class ExhaustionBrain(Brain):
         self._last_idx = defaultdict(lambda: -10)
         self._have_hl = False
         self._meta_done = False
+        self._cluster_events: list[tuple[int, int, str]] = []  # (t, strength, color)
 
     def warmup(self) -> int:
         return WINDOW_SIZE - 1
@@ -100,6 +101,7 @@ class ExhaustionBrain(Brain):
             self._pts["exhaustion_red"]["x"].append(x)
             self._pts["exhaustion_red"]["y"].append(y)
             self._pts["exhaustion_red"]["s"].append(size)
+            self._cluster_events.append((t, cluster_strength, "red"))
         elif decision == -1:  # BUY exhaustion
             self._recent_sells.append(t)
             cluster_strength = sum(1 for idx in self._recent_sells if t - idx <= CLUSTER_WINDOW)
@@ -107,6 +109,7 @@ class ExhaustionBrain(Brain):
             self._pts["exhaustion_green"]["x"].append(x)
             self._pts["exhaustion_green"]["y"].append(y)
             self._pts["exhaustion_green"]["s"].append(size)
+            self._cluster_events.append((t, cluster_strength, "green"))
 
         # Key 2: Reversals (yellow) on color flip
         if self._last_exh is not None and decision != 0 and decision != self._last_exh:
@@ -252,3 +255,71 @@ class ExhaustionBrain(Brain):
                     j += 1
             self._meta_done = True
         return self._pts
+
+    # ===================== Stats =====================
+    def compute_stats(
+        self, df: pd.DataFrame, trend_state: list[int], slopes: list[float]
+    ) -> dict[str, float]:
+        TREND_MIN_LEN = 50
+        POST_FLIP_WINDOW = 92
+
+        n = len(trend_state)
+        segments: list[tuple[int, int, int]] = []  # (dir, start, end)
+        if n:
+            start = 0
+            cur = trend_state[0]
+            for i in range(1, n):
+                if trend_state[i] != cur:
+                    segments.append((cur, start, i - 1))
+                    start = i
+                    cur = trend_state[i]
+            segments.append((cur, start, n - 1))
+
+        up_durations, down_durations = [], []
+        up_bubbles, down_bubbles = [], []
+
+        for dir_, s, e in segments:
+            length = e - s + 1
+            if dir_ == 1:
+                if length >= TREND_MIN_LEN:
+                    up_durations.append(length - TREND_MIN_LEN)
+                max_strength = 0
+                for t, strength, color in self._cluster_events:
+                    if s <= t <= e and color == "red" and strength > max_strength:
+                        max_strength = strength
+                up_bubbles.append(max_strength)
+            elif dir_ == -1:
+                if length >= TREND_MIN_LEN:
+                    down_durations.append(length - TREND_MIN_LEN)
+                max_strength = 0
+                for t, strength, color in self._cluster_events:
+                    if s <= t <= e and color == "green" and strength > max_strength:
+                        max_strength = strength
+                down_bubbles.append(max_strength)
+
+        def _avg(vals):
+            return float(np.mean(vals)) if vals else 0.0
+
+        angles = slopes
+        down_deltas, up_deltas = [], []
+        for i in range(1, n):
+            if trend_state[i - 1] == -1 and trend_state[i] != -1:
+                angle_flip = angles[i]
+                window = angles[i + 1 : i + 1 + POST_FLIP_WINDOW]
+                if len(window) > 0:
+                    down_deltas.append(float(np.mean([a - angle_flip for a in window])))
+            if trend_state[i - 1] == 1 and trend_state[i] != 1:
+                angle_flip = angles[i]
+                window = angles[i + 1 : i + 1 + POST_FLIP_WINDOW]
+                if len(window) > 0:
+                    up_deltas.append(float(np.mean([a - angle_flip for a in window])))
+
+        stats = {
+            "avg_uptrend_duration_past50": _avg(up_durations),
+            "avg_downtrend_duration_past50": _avg(down_durations),
+            "avg_down_slope_angle_delta_post_flip_92": _avg(down_deltas),
+            "avg_up_slope_angle_delta_post_flip_92": _avg(up_deltas),
+            "avg_max_pressure_up_bubble": _avg(up_bubbles),
+            "avg_max_pressure_down_bubble": _avg(down_bubbles),
+        }
+        return stats


### PR DESCRIPTION
## Summary
- extend brain framework with overlay model and stats interface
- add ExhaustionBrain statistics including pressure bubble metrics
- create brain runner CLI and brain mode in bot

## Testing
- `python -m py_compile bot.py systems/brain_runner.py systems/brains/__init__.py systems/brains/base.py systems/brains/exhaustion.py`
- `MPLBACKEND=Agg python bot.py --mode brain --time 3m`
- `MPLBACKEND=Agg python bot.py --mode brain --brain exhaustion --time 3m`


------
https://chatgpt.com/codex/tasks/task_e_68a8fb0331448326b4c8b84c6cb12754