### PR TITLE
Add brain runner mode with exhaustion stats

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -4,21 +4,31 @@ from __future__ import annotations
 
 import argparse
 
-from systems import sim_engine
+from systems import sim_engine, brain_runner
+from systems.brains import list_brains
 
 
 def main() -> None:
     parser = argparse.ArgumentParser(description="WindowSurfer discovery bot")
-    parser.add_argument("--mode", required=True, help="Mode to run (sim)")
+    parser.add_argument("--mode", required=True, help="Mode to run (sim or brain)")
     parser.add_argument(
         "--time",
         default="1m",
-        help="Time window for simulation (e.g. '3m' for three months)",
+        help="Time window (e.g. '3m' for three months)",
     )
+    parser.add_argument("--brain", help="Brain to run in --mode brain")
     args = parser.parse_args()
 
-    if args.mode.lower() == "sim":
+    mode = args.mode.lower()
+    if mode == "sim":
         sim_engine.run_simulation(timeframe=args.time)
+    elif mode == "brain":
+        if not args.brain:
+            print("Available brains:")
+            for name in list_brains():
+                print("-", name)
+            return
+        brain_runner.run(args.brain, timeframe=args.time, viz=True)
     else:
         raise ValueError(f"Unknown mode: {args.mode}")
 

--- a/systems/brain_runner.py
+++ b/systems/brain_runner.py
@@ -1,0 +1,192 @@
+from __future__ import annotations
+
+import json
+import math
+import os
+import re
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+
+from .brains import load_brain
+
+# ===================== Parameters =====================
+WINDOW_STEP = 2
+SLOPE_WIN = 12
+
+# ===================== Helpers (copied from sim_engine) =====================
+_INTERVAL_RE = re.compile(r'[_\-]((\d+)([smhdw]))(?=\.|_|$)', re.I)
+
+UNIT_SECONDS = {
+    's': 1,
+    # interpret 'm' as months (~30 days)
+    'm': 30 * 24 * 3600,
+    'h': 3600,
+    'd': 86400,
+    'w': 604800,
+}
+
+def parse_timeframe(tf: str) -> timedelta | None:
+    """Parse strings like '12h', '3d', '6w', '3m' into timedelta."""
+    if not tf:
+        return None
+    m = re.match(r'(?i)^\s*(\d+)\s*([smhdw])\s*$', tf)
+    if not m:
+        return None
+    n, u = int(m.group(1)), m.group(2).lower()
+    return timedelta(seconds=n * UNIT_SECONDS[u])
+
+def infer_candle_seconds_from_filename(path: str) -> int | None:
+    """Try to infer candle interval from filename like *_1h.csv, *_15m.csv, *_1d.csv."""
+    m = _INTERVAL_RE.search(os.path.basename(path))
+    if not m:
+        return None
+    n, u = int(m.group(2)), m.group(3).lower()
+    return n * UNIT_SECONDS[u]
+
+def apply_time_filter(df: pd.DataFrame, delta: timedelta, file_path: str, warmup: int) -> pd.DataFrame:
+    if delta is None:
+        return df
+    if 'timestamp' in df.columns:
+        ts = df['timestamp']
+        ts_max = float(ts.iloc[-1])
+        is_ms = ts_max > 1e12
+        to_seconds = (ts / 1000.0) if is_ms else ts
+        cutoff = (datetime.now(timezone.utc).timestamp() - delta.total_seconds())
+        mask = to_seconds >= cutoff
+        return df.loc[mask]
+    for col in ('datetime','date','time'):
+        if col in df.columns:
+            try:
+                dt = pd.to_datetime(df[col], utc=True, errors='coerce')
+                cutoff_dt = pd.Timestamp.utcnow() - delta
+                mask = dt >= cutoff_dt
+                return df.loc[mask]
+            except Exception:
+                pass
+    sec = infer_candle_seconds_from_filename(file_path) or 3600
+    need = int(max(warmup + 1, delta.total_seconds() // sec))
+    if need <= 0 or need >= len(df):
+        return df
+    return df.iloc[-need:]
+
+# ===================== Trend Helper =====================
+def multi_window_vote(df, t, window_sizes, slope_thresh=0.001, range_thresh=0.05):
+    """Return (-1,0,1) decision with confidence using multi-window slope direction."""
+    votes, strengths = [], []
+    for W in window_sizes:
+        if t - W < 0:
+            continue
+        sub = df.iloc[t - W:t]
+        closes = sub["close"].values
+        x = np.arange(len(closes))
+        slope = float(np.polyfit(x, closes, 1)[0]) if len(closes) > 1 else 0.0
+        rng = float(sub["close"].max() - sub["close"].min())
+        if abs(slope) < slope_thresh or rng < range_thresh:
+            continue
+        direction = 1 if slope > 0 else -1
+        votes.append(direction)
+        strengths.append(abs(slope) * rng)
+    score = sum(votes)
+    confidence = (sum(strengths) / max(1, len(strengths))) if strengths else 0.0
+    if score >= 2:
+        return 1, confidence, score
+    if score <= -2:
+        return -1, confidence, score
+    return 0, confidence, score
+
+# ===================== Runner =====================
+def run(brain_name: str, timeframe: str, viz: bool = True) -> dict[str, dict]:
+    file_path = "data/sim/SOLUSD_1h.csv"
+    df = pd.read_csv(file_path)
+
+    brain = load_brain(brain_name)
+
+    delta = parse_timeframe(timeframe)
+    if delta is not None:
+        df = apply_time_filter(df, delta, file_path, brain.warmup())
+    df = df.reset_index(drop=True)
+    df["candle_index"] = range(len(df))
+
+    brain.prepare(df)
+
+    trend_state: list[int] = []
+    angles: list[float] = []
+    for t in range(len(df)):
+        decision, _, _ = multi_window_vote(df, t, window_sizes=[8, 12, 24, 48])
+        if decision == 1:
+            trend_state.append(1)
+        elif decision == -1:
+            trend_state.append(-1)
+        else:
+            trend_state.append(0)
+        if t >= SLOPE_WIN:
+            sub = df["close"].iloc[t - SLOPE_WIN + 1 : t + 1]
+            slope = float(np.polyfit(np.arange(len(sub)), sub, 1)[0]) if len(sub) > 1 else 0.0
+            angle = math.degrees(math.atan(slope))
+        else:
+            angle = 0.0
+        angles.append(angle)
+
+    for t in range(brain.warmup(), len(df), WINDOW_STEP):
+        brain.step(df, t)
+
+    pts = brain.overlays()
+
+    stats = brain.compute_stats(df, trend_state, angles)
+
+    run_id = datetime.utcnow().strftime("%Y%m%d_%H%M%S")
+    out_dir = Path("data/out") / run_id
+    out_dir.mkdir(parents=True, exist_ok=True)
+    with open(out_dir / "brain_stats.json", "w") as f:
+        json.dump(stats, f, indent=2)
+
+    print("Brain statistics:")
+    for k, info in stats.items():
+        val = info.get("value", 0.0)
+        trig = info.get("triggers", 0)
+        res = info.get("results", 0)
+        print(f"{k:40s} [{trig}/{res}] {val:.4f}")
+
+    if not viz:
+        return stats
+
+    fig, ax1 = plt.subplots(figsize=(12, 6))
+    ax1.plot(df["candle_index"], df["close"], lw=1, label="Close Price", color="blue")
+
+    # Exhaustion dots
+    xr, yr, sr = pts["exhaustion_red"]["x"], pts["exhaustion_red"]["y"], pts["exhaustion_red"]["s"]
+    xg, yg, sg = pts["exhaustion_green"]["x"], pts["exhaustion_green"]["y"], pts["exhaustion_green"]["s"]
+    ax1.scatter(xr, yr, s=sr, c="red", zorder=6)
+    ax1.scatter(xg, yg, s=sg, c="green", zorder=6)
+
+    # Reversals
+    ax1.scatter(
+        pts["reversal"]["x"], pts["reversal"]["y"], c="yellow", s=120, edgecolor="black", zorder=7
+    )
+
+    style = {
+        "bottom4": dict(c="cyan", marker="v", s=100, zorder=6),
+        "top5":    dict(c="orange", marker="s", s=110, zorder=6),
+        "top6":    dict(c="red", marker="*", s=140, zorder=6),
+        "top7":    dict(c="purple", marker="^", s=110, zorder=6),
+        "top8":    dict(c="magenta", marker="P", s=160, zorder=7),
+        "valley_w":dict(c="teal", marker="h", s=120, zorder=7),
+        "valley_e":dict(c="deepskyblue", marker="D", s=110, zorder=7),
+        "valley_r":dict(c="darkcyan", marker="s", s=100, zorder=7),
+        "valley_t":dict(c="turquoise", marker="P", s=150, zorder=8),
+    }
+    for name, st in style.items():
+        ax1.scatter(pts[name]["x"], pts[name]["y"], **st)
+
+    ax1.set_title("Price with Exhaustion + Predictors")
+    ax1.set_xlabel("Candles (Index)")
+    ax1.set_ylabel("Price")
+    ax1.grid(True)
+
+    plt.show()
+
+    return stats

--- a/systems/brains/__init__.py
+++ b/systems/brains/__init__.py
@@ -4,8 +4,10 @@ REGISTRY = {
     "exhaustion": ExhaustionBrain,
 }
 
+def list_brains() -> list[str]:
+    return sorted(REGISTRY.keys())
+
 def load_brain(name: str):
-    cls = REGISTRY.get(name)
-    if not cls:
+    if name not in REGISTRY:
         raise ValueError(f"Unknown brain: {name}")
-    return cls()
+    return REGISTRY[name]()

--- a/systems/brains/base.py
+++ b/systems/brains/base.py
@@ -2,25 +2,33 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Dict, List, Any
 
+import pandas as pd
+
+
 @dataclass
-class Signal:
-    t: int
-    price: float
-    tag: str
-    meta: dict
+class Overlay:
+    x: List[int]
+    y: List[float]
+    s: List[float] | None = None
+    c: str | None = None
 
 
 class Brain:
     name: str = "base"
 
-    def warmup(self) -> int:
+    def prepare(self, df: pd.DataFrame) -> None:  # pragma: no cover - interface
         raise NotImplementedError
 
-    def prepare(self, df) -> None:
+    def step(self, df: pd.DataFrame, t: int) -> None:  # pragma: no cover - interface
         raise NotImplementedError
 
-    def step(self, df, t: int) -> None:
+    def warmup(self) -> int:  # pragma: no cover - interface
         raise NotImplementedError
 
-    def overlays(self) -> Dict[str, Dict[str, List[Any]]]:
+    def overlays(self) -> Dict[str, Dict[str, List[Any]]]:  # pragma: no cover - interface
+        raise NotImplementedError
+
+    def compute_stats(
+        self, df: pd.DataFrame, trend_state: List[int], slopes: List[float]
+    ) -> Dict[str, Dict[str, Any]]:  # pragma: no cover - interface
         raise NotImplementedError


### PR DESCRIPTION
## Summary
- extend brain framework with overlay model and stats interface
- add ExhaustionBrain statistics including pressure bubble metrics and trigger/result counts
- create brain runner CLI and brain mode in bot with automatic overlay rendering

## Testing
- `python -m py_compile bot.py systems/brain_runner.py systems/brains/__init__.py systems/brains/base.py systems/brains/exhaustion.py`
- `MPLBACKEND=Agg python bot.py --mode brain --time 3m`
- `MPLBACKEND=Agg python bot.py --mode brain --brain exhaustion --time 3m`


------
https://chatgpt.com/codex/tasks/task_e_68a8fb0331448326b4c8b84c6cb12754