### PR TITLE
Show only exhaustion overlays for exhaustion brain

### DIFF
--- a/systems/brain_runner.py
+++ b/systems/brain_runner.py
@@ -135,6 +135,8 @@ def run(brain_name: str, timeframe: str, viz: bool = True) -> dict[str, float]:
         brain.step(df, t)
 
     pts = brain.overlays()
+    if brain_name == "exhaustion":
+        pts = {k: v for k, v in pts.items() if k.startswith("exhaustion")}
 
     stats = brain.compute_stats(df, trend_state, angles)
 

--- a/systems/sim_engine.py
+++ b/systems/sim_engine.py
@@ -115,6 +115,18 @@ def run_simulation(*, timeframe: str = "1m", brain_name: str = "exhaustion", viz
     if not viz:
         return
 
+    if brain_name == "exhaustion":
+        xr, yr, sr = pts["exhaustion_red"]["x"], pts["exhaustion_red"]["y"], pts["exhaustion_red"]["s"]
+        xg, yg, sg = pts["exhaustion_green"]["x"], pts["exhaustion_green"]["y"], pts["exhaustion_green"]["s"]
+        ax1.scatter(xr, yr, s=sr, c="red", zorder=6)
+        ax1.scatter(xg, yg, s=sg, c="green", zorder=6)
+        ax1.set_title("Price with Exhaustion overlays")
+        ax1.set_xlabel("Candles (Index)")
+        ax1.set_ylabel("Price")
+        ax1.grid(True)
+        plt.show()
+        return
+
     # ===================== Plot & Toggles (lazy create) =====================
     ax1.set_title("Price with Exhaustion + Predictors (Keys 1–2,3,4–8; Letters W/E/R/T)")
     ax1.set_xlabel("Candles (Index)")


### PR DESCRIPTION
## Summary
- Ensure brain runner only plots exhaustion overlays when `--brain exhaustion` is used
- Limit sim engine visualization to exhaustion markers for the exhaustion brain

## Testing
- `python -m py_compile bot.py systems/brain_runner.py systems/sim_engine.py systems/brains/__init__.py systems/brains/base.py systems/brains/exhaustion.py`
- `MPLBACKEND=Agg python bot.py --mode brain --brain exhaustion --time 1m`

------
https://chatgpt.com/codex/tasks/task_e_68a902a00c248326abc6c61a78b23e8d