### PR TITLE
Add normalized candle angle feature for trend scoring

### DIFF
--- a/systems/live_engine.py
+++ b/systems/live_engine.py
@@ -1,9 +1,24 @@
 from __future__ import annotations
 
 import time
+import numpy as np
 import pandas as pd
 
 from .metabrain.engine_utils import cache_all_brains, trade_all_brains
+
+
+WINDOW_SIZE = 24
+WINDOW_STEP = 2
+LOOKBACK = WINDOW_SIZE
+
+
+def normalized_angle(series: pd.Series, lookback: int) -> float:
+    """Return slope angle normalized to [-1,1] over the lookback."""
+    dy = series.iloc[-1] - series.iloc[0]
+    dx = lookback
+    angle = np.arctan2(dy, dx)
+    norm = angle / (np.pi / 4)
+    return max(-1.0, min(1.0, norm))
 
 
 def get_recent_candles(timeframe: str) -> pd.DataFrame:


### PR DESCRIPTION
## Summary
- compute normalized slope angles from price windows to quantify trend direction
- plot trend angle markers in simulation output
- expose angle utility in live engine for parity

## Testing
- `MPLBACKEND=Agg python - <<'PY'
from systems.sim_engine import run_simulation
run_simulation(timeframe='1w', viz=True)
PY`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab4cf28bd48326937020fce1d647df