### PR TITLE
Re-enable step size in exhaustion loop

### DIFF
--- a/systems/sim_engine.py
+++ b/systems/sim_engine.py
@@ -171,7 +171,7 @@ def run_simulation(*, timeframe: str = "1m", viz: bool = True) -> None:
         df.at[t, "angle"] = max(-1.0, min(1.0, norm))
 
     # Exhaustion bubbles
-    for t in range(EXHAUSTION_LOOKBACK, len(df)):
+    for t in range(EXHAUSTION_LOOKBACK, len(df), WINDOW_STEP):
         now_price = float(df["close"].iloc[t])
         past_price = float(df["close"].iloc[t - EXHAUSTION_LOOKBACK])
         end_idx = int(df["candle_index"].iloc[t])


### PR DESCRIPTION
## Summary
- Limit exhaustion bubble calculations to every WINDOW_STEP candles

## Testing
- `python systems/sim_engine.py --time 1m --viz`


------
https://chatgpt.com/codex/tasks/task_e_68ab5f5d01d883269bd2a413777dc631