### PR TITLE
Split CLI entrypoints for simulations, live trading, and tests

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -1,0 +1,122 @@
+"""Command line entry point for WindowSurfer."""
+
+from __future__ import annotations
+
+import os
+import sys
+
+from systems.fetch import run_fetch
+from systems.live_engine import run_live
+from systems.sim_engine import run_simulation
+from systems.scripts.wallet import show_wallet
+from systems.utils.addlog import init_logger, addlog
+from systems.utils.load_config import load_config
+from systems.utils.cli import build_parser
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = build_parser()
+    parser.add_argument(
+        "--time",
+        type=str,
+        default=None,
+        help="How far back to simulate (e.g. 1m, 7d, 1y)",
+    )
+    parser.add_argument(
+        "--viz",
+        action="store_true",
+        help="Enable visualization plotting",
+    )
+    parser.add_argument(
+        "--period",
+        type=str,
+        default="daily",
+        help="Report period for email mode (daily|weekly|monthly|yearly|test)",
+    )
+
+    args = parser.parse_args(argv or sys.argv[1:])
+    if not args.mode:
+        parser.error("--mode is required")
+    mode = args.mode.lower()
+    os.environ["WS_MODE"] = mode
+    init_logger(
+        logging_enabled=args.log,
+        verbose_level=args.verbose,
+    )
+
+    verbose = args.verbose
+    cfg = load_config()
+    run_all = args.all or not args.account
+
+    if mode == "fetch":
+        run_fetch(account=args.account, market=args.market, all_accounts=run_all)
+
+    elif mode == "sim":
+        run_simulation(
+            account=args.account,
+            market=args.market,
+            all_accounts=run_all,
+            verbose=args.verbose,
+            timeframe=args.time,
+            viz=args.viz,
+        )
+
+    elif mode == "live":
+        run_live(
+            account=args.account,
+            market=args.market,
+            all_accounts=run_all,
+            dry=args.dry,
+            verbose=args.verbose,
+        )
+
+    elif mode == "test":
+        from systems.scripts.test_mode import run_test
+
+        if not args.account or not args.market:
+            addlog("Error: --account and --market are required for test mode")
+            sys.exit(1)
+        exit_code = run_test(args.account, args.market, args.time)
+        sys.exit(exit_code)
+
+    elif mode == "wallet":
+        accounts_cfg = cfg.get("accounts", {})
+        targets = accounts_cfg.keys() if run_all else [args.account]
+        for acct in targets:
+            acct_cfg = accounts_cfg.get(acct)
+            if not acct_cfg:
+                addlog(
+                    f"[ERROR] Unknown account {acct}",
+                    verbose_int=1,
+                    verbose_state=True,
+                )
+                continue
+            os.environ["WS_ACCOUNT"] = acct
+            markets_cfg = acct_cfg.get("markets", {})
+            m_targets = [args.market] if args.market else markets_cfg.keys()
+            for m in m_targets:
+                if m not in markets_cfg:
+                    continue
+                show_wallet(acct, m, verbose)
+
+    elif mode == "view":
+        if not args.account:
+            addlog("Error: --account is required for view mode")
+            sys.exit(1)
+        from systems.scripts.view_log import view_log
+        view_log(args.account, timeframe=args.time)
+
+    elif mode == "email":
+        from systems.scripts.report import run_report
+
+        if not args.account:
+            addlog("Error: --account is required for email mode")
+            sys.exit(1)
+        run_report(args.account, args.period)
+
+    else:
+        parser.error(f"Unknown mode: {args.mode}")
+
+
+if __name__ == "__main__":
+    main()

--- a/graph.py
+++ b/graph.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+"""Minimal plotting utilities for ledgers and candles."""
+
+import json
+from pathlib import Path
+
+import matplotlib.pyplot as plt  # type: ignore
+import pandas as pd
+
+
+def plot(ledger_path: str, candles_path: str) -> None:
+    """Plot candle close prices with optional trade markers."""
+    df = pd.read_csv(candles_path)
+    plt.plot(df["timestamp"], df["close"], label="Close", color="blue")
+    try:
+        with open(ledger_path, "r", encoding="utf-8") as f:
+            ledger = json.load(f)
+        for note in ledger.get("closed_notes", []):
+            if "created_ts" in note and "entry_price" in note:
+                plt.scatter(note["created_ts"], note["entry_price"], color="green", marker="^")
+            if "exit_ts" in note and "exit_price" in note:
+                plt.scatter(note["exit_ts"], note["exit_price"], color="red", marker="v")
+    except FileNotFoundError:
+        pass
+    plt.legend()
+    plt.tight_layout()
+    plt.show()

--- a/live.py
+++ b/live.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""CLI entry point for live trading loop."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Optional
+
+
+def _normalize_market(market: str) -> str:
+    if "/" in market:
+        return market
+    market = market.upper()
+    for quote in ("USDT", "USDC", "USD", "EUR", "GBP"):
+        if market.endswith(quote):
+            base = market[: -len(quote)]
+            return f"{base}/{quote}"
+    return market
+
+
+def main(argv: Optional[list[str]] = None) -> None:
+    parser = argparse.ArgumentParser(description="Run live trading loop")
+    parser.add_argument("--account", required=True, help="Account name")
+    parser.add_argument("--market", required=True, help="Market symbol e.g. DOGEUSD")
+    parser.add_argument("--graph", action="store_true", help="Plot ledger after run")
+    args = parser.parse_args(argv)
+
+    from systems.live_engine import run_live
+
+    run_live(account=args.account, market=_normalize_market(args.market))
+
+    if args.graph:
+        ledger_path = Path("data/ledgers") / f"{args.account}_{args.market}.json"
+        candles_path = Path("data/live") / f"{args.market}.csv"
+        try:
+            import graph
+            graph.plot(str(ledger_path), str(candles_path))
+        except Exception as exc:  # pragma: no cover - plotting best effort
+            print(f"[WARN] Plotting failed: {exc}")
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/sim.py
+++ b/sim.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""CLI entry point for running historical simulations."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Optional
+
+
+def _normalize_market(market: str) -> str:
+    """Convert markets like ``DOGEUSD`` to ``DOGE/USD``."""
+    if "/" in market:
+        return market
+    market = market.upper()
+    for quote in ("USDT", "USDC", "USD", "EUR", "GBP"):
+        if market.endswith(quote):
+            base = market[: -len(quote)]
+            return f"{base}/{quote}"
+    return market
+
+
+def _ensure_candles(account: str, market: str) -> Path:
+    """Ensure candle CSV exists for ``market``.
+
+    If the canonical file is missing, attempt to fetch it using the
+    ``systems.scripts.fetch_candles`` helpers.
+    """
+    # Default location as per new layout
+    candles_dir = Path("data/candles/sim")
+    csv_path = candles_dir / f"{market}.csv"
+
+    # Backwards compatibility with previous layout
+    if not csv_path.exists():
+        candles_dir = Path("data/sim")
+        csv_path = candles_dir / f"{market}.csv"
+
+    if csv_path.exists():
+        return csv_path
+
+    from systems.scripts.fetch_candles import fetch_binance_full_history_1h
+
+    # Best effort symbol normalisation for Binance
+    symbol = market.upper()
+    if symbol.endswith("USD"):
+        symbol = symbol + "T"
+    df = fetch_binance_full_history_1h(symbol)
+    candles_dir.mkdir(parents=True, exist_ok=True)
+    df.to_csv(csv_path, index=False)
+    return csv_path
+
+
+def main(argv: Optional[list[str]] = None) -> None:
+    parser = argparse.ArgumentParser(description="Run historical simulation")
+    parser.add_argument("--account", required=True, help="Account name")
+    parser.add_argument("--market", required=True, help="Market symbol e.g. DOGEUSD")
+    parser.add_argument("--time", dest="timeframe", default="1m", help="Lookback window")
+    parser.add_argument("--viz", action="store_true", help="Enable plotting")
+    args = parser.parse_args(argv)
+
+    csv_path = _ensure_candles(args.account, args.market)
+
+    from systems.sim_engine import run_simulation
+
+    run_simulation(
+        account=args.account,
+        market=_normalize_market(args.market),
+        timeframe=args.timeframe,
+        viz=args.viz,
+    )
+
+    ledger_name = f"{args.account}_{args.market}"
+    source = Path("data/ledgers") / f"{ledger_name}.json"
+    dest = Path("ledger_simulation.json")
+    if source.exists():
+        dest.write_text(source.read_text())
+
+    if args.viz:
+        try:
+            import graph
+            graph.plot(str(dest), str(csv_path))
+        except Exception as exc:  # pragma: no cover - plotting best effort
+            print(f"[WARN] Plotting failed: {exc}")
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/systems/scripts/candle_loader.py
+++ b/systems/scripts/candle_loader.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+"""Shared candle loading utilities for sim and live engines."""
+
+from pathlib import Path
+from typing import Tuple
+
+import pandas as pd
+
+from systems.utils.addlog import addlog
+from systems.utils.resolve_symbol import (
+    candle_filename,
+    sim_path_csv,
+    live_path_csv,
+    to_tag,
+)
+
+
+def load_candles_df(
+    account: str,
+    market: str,
+    *,
+    live: bool = False,
+    verbose: int = 0,
+) -> Tuple[pd.DataFrame, int]:
+    """Return normalised candles for ``account``/``market``.
+
+    Parameters
+    ----------
+    account: str
+        Account name used for the candle filename.
+    market: str
+        Market pair in CCXT format, e.g. ``"SOL/USD"``.
+    live: bool, optional
+        If ``True``, load from ``data/live`` else ``data/sim``.
+    verbose: int, optional
+        Verbosity level forwarded to ``addlog``.
+
+    Returns
+    -------
+    Tuple[pd.DataFrame, int]
+        Normalised dataframe and number of duplicate rows removed.
+    """
+
+    csv_path = candle_filename(account, market, live=live)
+    if not Path(csv_path).exists():
+        tag = to_tag(market)
+        legacy = live_path_csv(tag) if live else sim_path_csv(tag)
+        if Path(legacy).exists():
+            addlog(
+                f"[DEPRECATED] Found legacy file {legacy}, use {csv_path}",
+                verbose_int=1,
+                verbose_state=verbose,
+            )
+        raise FileNotFoundError(
+            f"Missing data file: {csv_path}. Run: python bot.py --mode fetch --account {account} --market {market}"
+        )
+
+    df = pd.read_csv(csv_path)
+
+    ts_col = next(
+        (c for c in df.columns if str(c).lower() in ("timestamp", "time", "date")),
+        None,
+    )
+    if ts_col is None:
+        raise ValueError(f"No timestamp column in {csv_path}")
+
+    df[ts_col] = pd.to_numeric(df[ts_col], errors="coerce")
+    df = df.dropna(subset=[ts_col])
+    before = len(df)
+    df = df.sort_values(ts_col).drop_duplicates(subset=[ts_col], keep="last").reset_index(drop=True)
+    removed = before - len(df)
+
+    if ts_col != "timestamp":
+        df = df.rename(columns={ts_col: "timestamp"})
+
+    return df, removed
+

--- a/systems/scripts/execution_handler.py
+++ b/systems/scripts/execution_handler.py
@@ -1,0 +1,344 @@
+import time
+import requests
+import hashlib
+import hmac
+import base64
+from urllib.parse import urlencode
+
+from systems.scripts.kraken_utils import load_kraken_keys
+from systems.scripts.kraken_utils import get_live_price
+from systems.utils.addlog import addlog
+from systems.utils.resolve_symbol import split_tag
+from systems.utils.quote_norm import norm_quote
+from systems.scripts.trade_apply import apply_buy
+
+
+def fetch_price_data(symbol: str) -> dict:
+    resp = requests.get(
+        f"https://api.kraken.com/0/public/Ticker?pair={symbol}", timeout=10
+    )
+    result = resp.json().get("result", {})
+    return next(iter(result.values()), {})
+
+
+def now_utc_timestamp() -> int:
+    return int(time.time())
+
+
+
+def _kraken_request(endpoint: str, data: dict, api_key: str, api_secret: str) -> dict:
+    url_path = f"/0/private/{endpoint}"
+    url = f"https://api.kraken.com{url_path}"
+
+    nonce = str(int(time.time() * 1000))
+    data["nonce"] = nonce
+
+    post_data = urlencode(data)
+    encoded = (nonce + post_data).encode()
+    message = url_path.encode() + hashlib.sha256(encoded).digest()
+
+    signature = hmac.new(base64.b64decode(api_secret), message, hashlib.sha512)
+    sig_digest = base64.b64encode(signature.digest())
+
+    headers = {
+        "API-Key": api_key,
+        "API-Sign": sig_digest.decode()
+    }
+
+    resp = requests.post(url, headers=headers, data=data, timeout=10)
+    result = resp.json()
+    if "error" in result and result["error"]:
+        raise Exception(f"Kraken API error: {result['error']}")
+    return result
+
+def place_order(
+    order_type: str,
+    pair_code: str,
+    fiat_symbol: str,
+    amount: float,
+    ledger_name: str,
+    wallet_code: str,
+    verbose: int = 0,
+) -> dict:
+    api_key, api_secret = load_kraken_keys()
+    balance_resp = _kraken_request("Balance", {}, api_key, api_secret).get("result", {})
+    balance = {k: float(v) for k, v in balance_resp.items()}
+
+    price_data = fetch_price_data(pair_code)
+    price = float(price_data.get("c", [0])[0])
+    coin_amount = round(amount / price, 8)
+    usd_amount = coin_amount * price
+
+    if order_type.lower() == "buy":
+        available_usd = float(balance.get(fiat_symbol, 0.0))
+        addlog(f"[DEBUG] Balance: {balance}", verbose_int=1, verbose_state=verbose)
+        addlog(f"[DEBUG] Using fiat_symbol = {fiat_symbol}", verbose_int=1, verbose_state=verbose)
+        addlog(
+            f"[DEBUG] available_usd = {available_usd} | trying to spend = {amount}",
+            verbose_int=1,
+            verbose_state=verbose,
+        )
+        if available_usd < amount:
+            addlog(
+                f"[SKIP] Insufficient {fiat_symbol}",
+                verbose_int=1,
+                verbose_state=verbose,
+            )
+            return {}
+        addlog(
+            f"[BUY ATTEMPT] {fiat_symbol} available: ${available_usd:.2f}, attempting to buy ${amount:.2f}",
+            verbose_int=3,
+            verbose_state=verbose,
+        )
+    else:
+        addlog(
+            f"[SELL ATTEMPT] Attempting to sell ${usd_amount:.2f} worth of {pair_code}",
+            verbose_int=3,
+            verbose_state=verbose,
+        )
+
+    try:
+        order_resp = _kraken_request(
+            "AddOrder",
+            {
+                "pair": pair_code,
+                "type": order_type,
+                "ordertype": "market",
+                "volume": coin_amount,
+                "trades": True,
+            },
+            api_key,
+            api_secret,
+        )
+    except Exception as e:
+        err_msg = str(e)
+        if "EOrder:Insufficient funds" in err_msg:
+            addlog(
+                "[SKIP] Kraken rejected order — insufficient funds",
+                verbose_int=1,
+                verbose_state=verbose,
+            )
+            return {}
+        raise
+
+    txid_list = order_resp.get("result", {}).get("txid")
+    txid = txid_list[0] if txid_list else None
+    if not txid:
+        raise Exception(f"{order_type.capitalize()} order failed — no txid returned")
+
+    if order_type.lower() == "buy":
+        post_balance = _kraken_request("Balance", {}, api_key, api_secret).get("result", {})
+        new_fiat_balance = float(post_balance.get(fiat_symbol, 0.0))
+        spent = float(balance.get(fiat_symbol, 0.0)) - new_fiat_balance
+        if spent < amount * 0.8:
+            for code, prev_amt in balance.items():
+                if code == fiat_symbol:
+                    continue
+                drop = float(prev_amt) - float(post_balance.get(code, 0.0))
+                if drop > amount * 0.8:
+                    addlog(
+                        f"[ERROR] Fiat mismatch: {code} decreased instead of {fiat_symbol}",
+                        verbose_int=1,
+                        verbose_state=verbose,
+                    )
+                    break
+            else:
+                addlog(
+                    f"[ERROR] Fiat mismatch: {fiat_symbol} balance unchanged after buy",
+                    verbose_int=1,
+                    verbose_state=verbose,
+                )
+
+    return {
+        "txid": txid,
+        "volume": coin_amount,
+        "price": price,
+        "filled_amount": coin_amount,
+        "avg_price": price,
+        "timestamp": now_utc_timestamp(),
+    }
+
+def execute_buy(
+    client,
+    *,
+    pair_code: str,
+    price: float,
+    amount_usd: float,
+    ledger_name: str,
+    wallet_code: str,
+    verbose: int = 0,
+) -> dict:
+    """Place a real buy order and normalise the result structure.
+
+    Parameters are kept for API compatibility; ``client`` and ``price`` are
+    currently unused as ``place_order`` pulls pricing from Kraken directly.
+    """
+
+    expected_raw = "USDC" if ledger_name.upper().endswith("USDC") else "USD"
+    _, fiat_symbol = split_tag(pair_code)
+    got_raw = fiat_symbol
+    exp = norm_quote(expected_raw)
+    got = norm_quote(got_raw)
+    if exp != got:
+        addlog(
+            f"[DEBUG][QUOTE_RAW] expected_raw={expected_raw} got_raw={got_raw}",
+            verbose_int=1,
+            verbose_state=verbose,
+        )
+        addlog(
+            f"[ABORT][QUOTE_MISMATCH] ledger={ledger_name} expected={exp} got={got} pair={pair_code}",
+            verbose_int=1,
+            verbose_state=verbose,
+        )
+        return {
+            "error": "QUOTE_MISMATCH",
+            "expected": exp,
+            "got": got,
+            "pair": pair_code,
+        }
+
+    result = place_order(
+        "buy",
+        pair_code,
+        fiat_symbol,
+        amount_usd,
+        ledger_name,
+        wallet_code,
+        verbose,
+    )
+    if (
+        not result
+        or result.get("filled_amount", 0) <= 0
+        or result.get("price", 0) <= 0
+        or not result.get("txid")
+        or not result.get("timestamp")
+    ):
+        addlog(
+            f"[SKIP] Trade result invalid — not logging to ledger for {ledger_name}",
+            verbose_int=1,
+            verbose_state=verbose,
+        )
+        return
+    return {
+        "filled_amount": result.get("filled_amount", 0.0),
+        "avg_price": result.get("price", 0.0),
+        "timestamp": result.get("timestamp"),
+    }
+
+
+def process_buy_signal(
+    *,
+    buy_signal: dict,
+    ledger,
+    t: int,
+    runtime_state: dict,
+    pair_code: str,
+    price: float,
+    ledger_name: str,
+    wallet_code: str,
+    verbose: int = 0,
+):
+    """Execute a buy and record it, setting the rebound gate on success."""
+
+    result = execute_buy(
+        None,
+        pair_code=pair_code,
+        price=price,
+        amount_usd=buy_signal.get("size_usd", 0.0),
+        ledger_name=ledger_name,
+        wallet_code=wallet_code,
+        verbose=verbose,
+    )
+    if not result or result.get("error"):
+        return result
+
+    note = apply_buy(
+        ledger=ledger,
+        window_name=buy_signal.get("window_name", ""),
+        t=t,
+        meta=buy_signal,
+        result=result,
+        state=runtime_state,
+    )
+
+    window_name = note.get("window_name")
+    unlock_p = buy_signal.get("unlock_p")
+    if window_name and unlock_p is not None:
+        runtime_state.setdefault("buy_unlock_p", {})[window_name] = unlock_p
+
+    msg = (
+        f"[BUY][EXECUTED][{window_name} {note.get('window_size')}] "
+        f"qty={note.get('entry_amount'):.6f} at ${note.get('entry_price'):.4f} "
+        f"spend=${note.get('entry_usdt'):.2f} target=${note.get('target_price'):.4f} "
+        f"p={note.get('p_buy'):.3f} note_id={note.get('id')}"
+    )
+    addlog(msg, verbose_int=1, verbose_state=verbose)
+
+    return result
+
+
+def execute_sell(
+    client,
+    *,
+    pair_code: str,
+    coin_amount: float,
+    price: float | None = None,
+    ledger_name: str,
+    verbose: int = 0,
+) -> dict:
+    """Place a real sell order and normalise the result structure.
+
+    ``price`` is optional and, if absent, the current live price is fetched to
+    estimate USD notional.
+    """
+    sell_price = price if price is not None else get_live_price(pair_code)
+    usd_amount = coin_amount * sell_price
+    _, fiat_symbol = split_tag(pair_code)
+    expected_raw = "USDC" if ledger_name.upper().endswith("USDC") else "USD"
+    got_raw = fiat_symbol
+    exp = norm_quote(expected_raw)
+    got = norm_quote(got_raw)
+    if exp != got:
+        addlog(
+            f"[DEBUG][QUOTE_RAW] expected_raw={expected_raw} got_raw={got_raw}",
+            verbose_int=1,
+            verbose_state=verbose,
+        )
+        addlog(
+            f"[ABORT][QUOTE_MISMATCH] ledger={ledger_name} expected={exp} got={got} pair={pair_code}",
+            verbose_int=1,
+            verbose_state=verbose,
+        )
+        return {
+            "error": "QUOTE_MISMATCH",
+            "expected": exp,
+            "got": got,
+            "pair": pair_code,
+        }
+    result = place_order(
+        "sell",
+        pair_code,
+        fiat_symbol,
+        usd_amount,
+        ledger_name,
+        "",
+        verbose,
+    )
+    if (
+        not result
+        or result.get("filled_amount", 0) <= 0
+        or result.get("price", 0) <= 0
+        or not result.get("txid")
+        or not result.get("timestamp")
+    ):
+        addlog(
+            f"[SKIP] Trade result invalid — not logging to ledger for {ledger_name}",
+            verbose_int=1,
+            verbose_state=verbose,
+        )
+        return
+    return {
+        "filled_amount": result.get("filled_amount", 0.0),
+        "avg_price": result.get("price", 0.0),
+        "timestamp": result.get("timestamp"),
+    }

--- a/systems/scripts/fetch_candles.py
+++ b/systems/scripts/fetch_candles.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+"""Unified candle fetching utilities."""
+
+import os
+import time
+from typing import List
+
+import ccxt
+import pandas as pd
+
+from systems.utils.config import resolve_path
+
+COLUMNS = ["timestamp", "open", "high", "low", "close", "volume"]
+
+
+def _fetch_kraken(symbol: str, start_ms: int, end_ms: int) -> List[List]:
+    exchange = ccxt.kraken({"enableRateLimit": True})
+    limit = min(720, int((end_ms - start_ms) // 3600000) + 1)
+    ohlcv = exchange.fetch_ohlcv(symbol, timeframe="1h", since=start_ms, limit=limit)
+    return [row for row in ohlcv if row and start_ms <= row[0] <= end_ms]
+
+
+def _fetch_binance(symbol: str, start_ms: int, end_ms: int) -> List[List]:
+    """Forward pagination with simple retries."""
+
+    exchange = ccxt.binance({"enableRateLimit": True})
+    rows: List[List] = []
+    limit = 1000
+    page_idx = 0
+    verbose = os.environ.get("FETCH_DEBUG", "0") == "1"
+    MAX_EMPTY_RETRY = 3
+    PARTIAL_RETRY_ON_LEN_LT = limit
+    SLEEP_ON_RETRY_SEC = 0.5
+
+    since = start_ms
+    last_progress_ts: int | None = None
+
+    def _vprint(msg: str) -> None:
+        if verbose:
+            print(msg)
+
+    while since <= end_ms:
+        page = exchange.fetch_ohlcv(symbol, timeframe="1h", since=since, limit=limit) or []
+        page_len = len(page)
+
+        empty_retries = 0
+        while page_len == 0 and empty_retries < MAX_EMPTY_RETRY:
+            _vprint(
+                f"[FETCH][BINANCE] page={page_idx} since={since} EMPTY (retry {empty_retries+1}/{MAX_EMPTY_RETRY})"
+            )
+            time.sleep(SLEEP_ON_RETRY_SEC)
+            page = exchange.fetch_ohlcv(symbol, timeframe="1h", since=since, limit=limit) or []
+            page_len = len(page)
+            empty_retries += 1
+
+        if page_len == 0:
+            _vprint(f"[FETCH][BINANCE] floor or no data at since={since} → stop")
+            break
+
+        did_partial_retry = False
+        if page_len < PARTIAL_RETRY_ON_LEN_LT:
+            _vprint(
+                f"[FETCH][BINANCE] page={page_idx} got {page_len}/{limit} rows → partial, retrying once"
+            )
+            time.sleep(SLEEP_ON_RETRY_SEC)
+            page2 = exchange.fetch_ohlcv(symbol, timeframe="1h", since=since, limit=limit) or []
+            if len(page2) > page_len:
+                page = page2
+                page_len = len(page)
+                did_partial_retry = True
+
+        first_ts = page[0][0]
+        last_ts = page[-1][0]
+        filtered = [r for r in page if start_ms <= r[0] <= end_ms]
+        rows.extend(filtered)
+        page_idx += 1
+
+        _vprint(
+            f"[FETCH][BINANCE] page={page_idx:05d} since={since} first={first_ts} last={last_ts} rows={page_len} total={len(rows)}"
+            f"{' (partial→retry improved)' if did_partial_retry else ''}"
+        )
+
+        next_since = last_ts + 1
+        if last_progress_ts is not None and next_since <= last_progress_ts:
+            _vprint(
+                f"[FETCH][BINANCE] no progress (next_since={next_since} <= last_progress={last_progress_ts}) → stop"
+            )
+            break
+        last_progress_ts = next_since
+        since = next_since
+
+    return rows
+
+
+def _rows_to_df(rows: List[List], start_ts: int, end_ts: int) -> pd.DataFrame:
+    df = pd.DataFrame(rows, columns=COLUMNS)
+    if not df.empty:
+        df["timestamp"] = (
+            pd.to_datetime(df["timestamp"], unit="ms", utc=True).astype("int64") // 1_000_000_000
+        )
+        df["timestamp"] = (df["timestamp"] // 3600) * 3600
+        df = df[(df["timestamp"] >= start_ts) & (df["timestamp"] <= end_ts)]
+        df[COLUMNS] = df[COLUMNS].apply(pd.to_numeric, errors="coerce")
+        df = df.dropna(subset=["timestamp"])
+    return df
+
+
+def fetch_kraken_range(symbol: str, start_ts: int, end_ts: int) -> pd.DataFrame:
+    """Fetch Kraken candles between ``start_ts`` and ``end_ts`` (seconds)."""
+    rows = _fetch_kraken(symbol, int(start_ts * 1000), int(end_ts * 1000))
+    return _rows_to_df(rows, start_ts, end_ts)
+
+
+def fetch_candles(symbol: str, start: int, end: int, source: str) -> pd.DataFrame:
+    """Fetch candles for ``symbol`` between ``start`` and ``end`` from ``source``.
+
+    Parameters
+    ----------
+    symbol: str
+        Market symbol understood by the exchange (e.g., ``"SOL/USD"``).
+    start: int
+        Start timestamp in seconds since epoch.
+    end: int
+        End timestamp in seconds since epoch.
+    source: str
+        ``"kraken"`` or ``"binance"``.
+    """
+
+    src = source.lower()
+    if src == "kraken":
+        rows = _fetch_kraken(symbol, int(start * 1000), int(end * 1000))
+    elif src == "binance":
+        rows = _fetch_binance(symbol, int(start * 1000), int(end * 1000))
+    else:
+        raise ValueError(f"Unknown source '{source}'")
+    return _rows_to_df(rows, start, end)
+
+
+def fetch_binance_full_history_1h(symbol: str) -> pd.DataFrame:
+    """Return all available Binance 1h candles for ``symbol``."""
+    now = int(time.time())
+    end_ts = (now // 3600 - 1) * 3600
+    rows = _fetch_binance(symbol, 0, end_ts * 1000)
+    return _rows_to_df(rows, 0, end_ts)
+
+
+def fetch_kraken_last_n_hours_1h(symbol: str, n: int = 720) -> pd.DataFrame:
+    """Return up to ``n`` latest Kraken 1h candles for ``symbol``."""
+    now = int(time.time())
+    end_ts = (now // 3600 - 1) * 3600
+    start_ts = end_ts - (n - 1) * 3600
+    rows = _fetch_kraken(symbol, start_ts * 1000, end_ts * 1000)
+    return _rows_to_df(rows, start_ts, end_ts)
+
+
+def load_coin_csv(coin: str) -> pd.DataFrame:
+    """Load historical candles for ``coin`` from ``data/raw``."""
+
+    root = resolve_path("")
+    path = root / "data" / "raw" / f"{coin.upper()}.csv"
+    if not path.exists():  # pragma: no cover - file presence check
+        raise FileNotFoundError(f"Candle file not found: {path}")
+    return pd.read_csv(path)
+

--- a/systems/scripts/kraken_utils.py
+++ b/systems/scripts/kraken_utils.py
@@ -1,0 +1,88 @@
+import os
+import requests
+from pathlib import Path
+import yaml
+
+from systems.utils.addlog import addlog
+from systems.utils.price_fetcher import get_price
+
+KRAKEN_API_URL = "https://api.kraken.com"
+
+
+# --- Authentication -------------------------------------------------------
+
+def load_kraken_keys(path: str = "kraken.yaml") -> tuple[str, str]:
+    """Load Kraken API key/secret using WS_ACCOUNT or fallback YAML."""
+    account = os.environ.get("WS_ACCOUNT")
+    if account:
+        try:
+            from systems.utils.load_config import load_config
+
+            cfg = load_config()
+            acct = cfg.get("accounts", {}).get(account, {})
+            key = acct.get("api_key")
+            secret = acct.get("api_secret")
+            if key and secret:
+                return key, secret
+        except Exception:
+            pass
+
+    file = Path(path)
+    if not file.exists():
+        raise FileNotFoundError("Missing kraken.yaml in project root")
+
+    with file.open("r", encoding="utf-8") as f:
+        data = yaml.safe_load(f)
+
+    kraken = data.get("kraken")
+    if not kraken or "api_key" not in kraken or "api_secret" not in kraken:
+        raise ValueError("Malformed kraken.yaml: missing 'kraken.api_key' or 'api_secret'")
+
+    return kraken["api_key"], kraken["api_secret"]
+
+
+def get_live_price(kraken_pair: str) -> float:
+    """Return the current best ask price for ``kraken_pair``."""
+    pair = kraken_pair.replace("/", "")
+    try:
+        resp = requests.get(
+            f"{KRAKEN_API_URL}/0/public/Ticker", params={"pair": pair}, timeout=10
+        )
+        data = resp.json()
+        result = next(iter(data.get("result", {}).values()), {})
+        ask = result.get("a", [None])[0]
+        return float(ask) if ask is not None else 0.0
+    except Exception:
+        return 0.0
+
+
+def get_kraken_balance(fiat_code: str, verbose: int = 0) -> dict:
+    """Return Kraken balances converted to ``fiat_code`` for logging."""
+    from systems.scripts.execution_handler import _kraken_request
+
+    api_key, api_secret = load_kraken_keys()
+    result = _kraken_request("Balance", {}, api_key, api_secret).get("result", {})
+
+    fiat_code = fiat_code.upper()
+    fiat_code_symbol = fiat_code[1:] if fiat_code.startswith("Z") else fiat_code
+
+    fiat_balances = {}
+    for asset, amount in result.items():
+        amount = float(amount)
+        if asset.upper() == fiat_code:
+            fiat_balances[asset] = amount
+        else:
+            price = get_price(f"{asset}{fiat_code_symbol}")
+            if price:
+                fiat_balances[asset] = amount * price
+
+    addlog(
+        f"[INFO] Kraken balance fetched ({fiat_code_symbol}): {fiat_balances}",
+        verbose_int=3,
+        verbose_state=verbose,
+    )
+
+    return {k: float(v) for k, v in result.items()}
+
+
+

--- a/systems/scripts/ledger.py
+++ b/systems/scripts/ledger.py
@@ -1,0 +1,213 @@
+from __future__ import annotations
+
+"""Simple in-memory ledger for simulations and live trading."""
+
+import json
+from typing import Dict, List
+
+from systems.utils.config import resolve_path, load_settings, load_ledger_config
+
+
+class Ledger:
+    """Track raw trade state and compute summary metrics on demand."""
+
+    def __init__(self) -> None:
+        self.open_notes: List[Dict] = []
+        self.closed_notes: List[Dict] = []
+        self.metadata: Dict = {}
+
+    # Basic note management -------------------------------------------------
+    def open_note(self, note: Dict) -> None:
+        """Register a newly opened note.
+
+        Notes may contain additional metadata such as:
+
+        ``p_buy``            – window position at entry
+        ``unlock_p``         – bounce threshold to re-enable buys
+        ``target_price``     – price at which the note should be sold
+        ``target_roi``       – expected ROI at target price
+        ``window_name``      – name of the window configuration
+        ``window_size``      – size of the evaluation window
+        ``created_idx/ts``   – creation index or timestamp
+
+        These fields are stored verbatim and are not interpreted by the
+        ledger itself but are useful for downstream analysis and evaluation.
+        """
+        self.open_notes.append(note)
+
+    def close_note(self, note: Dict) -> None:
+        """Move ``note`` from open to closed."""
+        if note not in self.open_notes:
+            return
+        self.open_notes.remove(note)
+        self.closed_notes.append(note)
+
+    def set_metadata(self, metadata: Dict) -> None:
+        """Merge ``metadata`` into the ledger metadata."""
+        if not isinstance(metadata, dict):
+            return
+        self.metadata.update(metadata)
+
+    def get_metadata(self) -> Dict:
+        return dict(self.metadata)
+
+    # Accessors -------------------------------------------------------------
+    def get_open_notes(self) -> List[Dict]:
+        return list(self.open_notes)
+
+    def get_active_notes(self) -> List[Dict]:
+        return self.get_open_notes()
+
+    def get_closed_notes(self) -> List[Dict]:
+        return list(self.closed_notes)
+
+    def get_total_liquid_value(self, final_price: float) -> float:
+        """Return all value assuming open notes liquidate at ``final_price``."""
+        open_value = sum(
+            n.get("entry_amount", 0) for n in self.get_open_notes()
+        ) * final_price
+        realised = sum(
+            n.get("entry_amount", 0)
+            * (n.get("exit_price", 0) - n.get("entry_price", 0))
+            for n in self.get_closed_notes()
+        )
+        return open_value + realised
+
+    # Summary ---------------------------------------------------------------
+    def get_account_summary(self, final_price: float) -> dict:
+        open_amount = sum(n.get("entry_amount", 0) for n in self.get_open_notes())
+        open_value = open_amount * final_price
+        realised = sum(
+            n.get("entry_amount", 0)
+            * (n.get("exit_price", 0) - n.get("entry_price", 0))
+            for n in self.get_closed_notes()
+        )
+        total_value = open_value + realised
+
+        return {
+            "final_price": round(final_price, 8),
+            "open_coin_amount": round(open_amount, 8),
+            "open_value": round(open_value, 2),
+            "realized_gain": round(realised, 2),
+            "total_value": round(total_value, 2),
+            "closed_notes": len(self.get_closed_notes()),
+            "open_notes": len(self.get_open_notes()),
+        }
+
+    # Persistence -----------------------------------------------------------
+    @staticmethod
+    def load_ledger(
+        ledger_name: str, *, tag: str | None = None, sim: bool = False
+    ) -> "Ledger":
+        """Load a ledger for ``ledger_name``.
+
+        If a legacy ledger file named after ``tag`` exists, it will be
+        migrated to the ``ledger_name`` convention on first load.
+        """
+
+        root = resolve_path("")
+        ledger = Ledger()
+
+        if sim:
+            out_dir = root / "data" / "tmp" / "simulation"
+        else:
+            out_dir = root / "data" / "ledgers"
+
+        out_path = out_dir / f"{ledger_name}.json"
+
+        if tag and not out_path.exists():
+            legacy_path = out_dir / f"{tag}.json"
+            if legacy_path.exists():
+                legacy_path.rename(out_path)
+
+        if out_path.exists():
+            with out_path.open("r", encoding="utf-8") as f:
+                data = json.load(f)
+            ledger.open_notes = data.get("open_notes", [])
+            ledger.closed_notes = data.get("closed_notes", [])
+            ledger.metadata = data.get("metadata", {})
+        return ledger
+
+
+def load_ledger(
+    ledger_name: str, *, tag: str | None = None, sim: bool = False
+) -> "Ledger":
+    """Public wrapper to load a ledger from disk."""
+
+    return Ledger.load_ledger(ledger_name, tag=tag, sim=sim)
+
+
+def save_ledger(
+    ledger_name: str,
+    ledger: "Ledger" | dict,
+    *,
+    sim: bool = False,
+    final_tick: int | None = None,
+    summary: dict | None = None,
+    tag: str | None = None,
+) -> None:
+    """Persist ``ledger`` data to the canonical ledger directory."""
+
+    root = resolve_path("")
+
+    if sim:
+        out_dir = root / "data" / "tmp" / "simulation"
+    else:
+        out_dir = root / "data" / "ledgers"
+
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_path = out_dir / f"{ledger_name}.json"
+
+    if tag and not out_path.exists():
+        legacy_path = out_dir / f"{tag}.json"
+        if legacy_path.exists():
+            legacy_path.rename(out_path)
+
+    if isinstance(ledger, Ledger):
+        ledger_data = {
+            "open_notes": ledger.get_open_notes(),
+            "closed_notes": ledger.get_closed_notes(),
+        }
+
+        if final_tick is not None:
+            ledger_data["final_tick"] = final_tick
+
+        if summary:
+            ledger_data["closed_notes_count"] = summary.get("closed_notes")
+            ledger_data["open_notes_count"] = summary.get("open_notes")
+            ledger_data["realized_gain"] = summary.get("realized_gain")
+            ledger_data["final_value"] = summary.get("total_value")
+
+        metadata = ledger.get_metadata()
+        if metadata:
+            ledger_data["metadata"] = metadata
+    else:
+        ledger_data = ledger
+
+    with out_path.open("w", encoding="utf-8") as f:
+        json.dump(ledger_data, f, indent=2)
+
+def init_ledger(
+    ledger_name: str,
+    *,
+    tag: str | None = None,
+    sim: bool = False,
+) -> Ledger:
+    """Load ``ledger_name`` and ensure its file exists on disk."""
+
+    ledger = load_ledger(ledger_name, tag=tag, sim=sim)
+    save_ledger(ledger_name, ledger, tag=tag, sim=sim)
+    return ledger
+
+
+def resolve_ledger_config(ledger_name: str | None) -> Dict:
+    """Return configuration dictionary for ``ledger_name``.
+
+    If ``ledger_name`` is ``None``, the first ledger defined in settings is
+    returned. Mirrors previous inline logic previously in ``bot.py``.
+    """
+
+    settings = load_settings()
+    if ledger_name:
+        return load_ledger_config(ledger_name)
+    return next(iter(settings.get("ledger_settings", {}).values()))

--- a/systems/scripts/runtime_state.py
+++ b/systems/scripts/runtime_state.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+from systems.utils.resolve_symbol import resolve_symbols
+from systems.utils.config import (
+    resolve_coin_config,
+    resolve_account_market,
+)
+
+
+def build_runtime_state(
+    general: Dict[str, Any],
+    coin_settings: Dict[str, Any],
+    accounts_cfg: Dict[str, Any],
+    account: str,
+    symbol: str,
+    mode: str,
+    *,
+    client,
+    prev: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    """Build and refresh runtime state for engines."""
+
+    prev = prev or {}
+    coin_cfg = resolve_coin_config(symbol, coin_settings)
+    acct_mkt_cfg = resolve_account_market(account, symbol, accounts_cfg)
+    knobs = {**coin_cfg, **acct_mkt_cfg}
+
+    limits = prev.get(
+        "limits",
+        {
+            "min_note_size": float(general.get("minimum_note_size", 0.0)),
+            "max_note_usdt": float(general.get("max_note_usdt", float("inf"))),
+        },
+    )
+
+    defaults = {
+        "window_size": 24,
+        "window_step": 2,
+        "buy_trigger": 3.0,
+        "sell_trigger": 10.0,
+        "flat_sell_percent": 0.25,
+        "all_sell_count": 99,
+        "max_pressure": 10.0,
+        "strong_move_threshold": 0.15,
+        "range_min": 0.08,
+        "volume_skew_bias": 0.4,
+        "flat_band_deg": 10.0,
+    }
+    strategy = {**defaults, **knobs}
+
+    buy_unlock_p = prev.get("buy_unlock_p", {})
+    verbose = prev.get("verbose", 0)
+
+    symbols = resolve_symbols(client, symbol)
+    if mode == "sim":
+        capital = float(general.get("simulation_capital", 0.0))
+    elif mode == "live":
+        quote = symbols["kraken_name"].split("/")[1]
+        balance = client.fetch_balance().get("free", {})
+        capital = float(balance.get(quote, 0.0))
+    else:
+        capital = prev.get("capital", 0.0)
+
+    state = {
+        "capital": capital,
+        "buy_unlock_p": buy_unlock_p,
+        "verbose": verbose,
+        "limits": limits,
+        "strategy": strategy,
+    }
+
+    state.update(symbols)
+
+    state.setdefault("pressures", prev.get("pressures", {"buy": {}, "sell": {}}))
+    state.setdefault("last_features", prev.get("last_features", {}))
+
+    return state

--- a/systems/scripts/trade_apply.py
+++ b/systems/scripts/trade_apply.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+
+def paper_execute_buy(price: float, amount_usd: float, *, timestamp: Optional[int] = None) -> Dict[str, float | int | None]:
+    filled = amount_usd / price if price else 0.0
+    return {"filled_amount": filled, "avg_price": price, "timestamp": timestamp}
+
+
+def paper_execute_sell(price: float, coin_amount: float, *, timestamp: Optional[int] = None) -> Dict[str, float | int | None]:
+    return {"filled_amount": coin_amount, "avg_price": price, "timestamp": timestamp}
+
+
+def apply_buy(
+    *,
+    ledger,
+    window_name: str,
+    t: int,
+    meta: Dict[str, Any],
+    result: Dict[str, Any],
+    state: Dict[str, Any],
+) -> Dict[str, Any]:
+    note = {
+        "id": f"{window_name}-{t}",
+        "entry_idx": t,
+        "entry_price": result.get("avg_price", 0.0),
+        "entry_amount": result.get("filled_amount", 0.0),
+        "entry_usdt": result.get("filled_amount", 0.0) * result.get("avg_price", 0.0),
+        "window_name": meta.get("window_name"),
+        "window_size": meta.get("window_size"),
+        "p_buy": meta.get("p_buy"),
+        "target_price": meta.get("target_price"),
+        "target_roi": meta.get("target_roi"),
+        "unlock_p": meta.get("unlock_p"),
+    }
+    if "created_idx" in meta:
+        note["created_idx"] = meta["created_idx"]
+    if result.get("timestamp") is not None:
+        note["created_ts"] = result.get("timestamp")
+    elif "created_ts" in meta:
+        note["created_ts"] = meta["created_ts"]
+
+    # Merge any additional metadata (e.g. note kind)
+    for k, v in meta.items():
+        if k not in note:
+            note[k] = v
+
+    ledger.open_note(note)
+    cost = result.get("filled_amount", 0.0) * result.get("avg_price", 0.0)
+    state["capital"] = state.get("capital", 0.0) - cost
+    # Persist remaining capital on the ledger for live-mode parity
+    try:
+        ledger.set_metadata({"capital": state.get("capital", 0.0)})
+    except AttributeError:
+        pass
+    return note
+
+
+def apply_sell(
+    *,
+    ledger,
+    note: Dict[str, Any],
+    t: int | None,
+    result: Dict[str, Any],
+    state: Dict[str, Any],
+) -> Dict[str, Any]:
+    exit_price = result.get("avg_price", 0.0)
+    exit_usdt = result.get("filled_amount", 0.0) * exit_price
+    note["exit_price"] = exit_price
+    note["exit_usdt"] = exit_usdt
+    if t is not None:
+        note["exit_idx"] = t
+    if result.get("timestamp") is not None:
+        note["exit_ts"] = result.get("timestamp")
+    entry_usdt = note.get("entry_usdt", 0.0)
+    note["gain"] = exit_usdt - entry_usdt
+    note["gain_pct"] = (note["gain"] / entry_usdt) if entry_usdt else 0.0
+    ledger.close_note(note)
+    state["capital"] = state.get("capital", 0.0) + exit_usdt
+    # Persist capital back to ledger after the sale
+    try:
+        ledger.set_metadata({"capital": state.get("capital", 0.0)})
+    except AttributeError:
+        pass
+    return note

--- a/systems/scripts/wallet.py
+++ b/systems/scripts/wallet.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+"""Wallet helper functions."""
+
+from systems.utils.addlog import addlog
+from systems.utils.resolve_symbol import split_tag, resolve_symbols, to_tag
+from systems.utils.load_config import load_config
+from .kraken_utils import get_kraken_balance
+import ccxt
+
+
+def show_wallet(account: str, market: str | None, verbose: int = 0) -> None:
+    """Display Kraken wallet balances for the given account and market."""
+
+    cfg = load_config()
+    acct_cfg = cfg.get("accounts", {}).get(account)
+    if not acct_cfg:
+        addlog(
+            f"[ERROR] Unknown account {account}",
+            verbose_int=1,
+            verbose_state=verbose,
+        )
+        return
+    markets = acct_cfg.get("markets", {})
+    market_symbol = market or next(iter(markets.keys()), None)
+    if not market_symbol or market_symbol not in markets:
+        addlog(
+            f"[ERROR] Market {market_symbol} not configured for account {account}",
+            verbose_int=1,
+            verbose_state=verbose,
+        )
+        return
+
+    client = ccxt.kraken({"enableRateLimit": True})
+    symbols = resolve_symbols(client, market_symbol)
+    tag = to_tag(symbols["kraken_name"])
+    _, quote_asset = split_tag(tag)
+    balances = get_kraken_balance(quote_asset, verbose)
+
+    if verbose >= 1:
+        addlog("[WALLET] Kraken Balance", verbose_int=1, verbose_state=verbose)
+        addlog(str(balances), verbose_int=2, verbose_state=verbose)
+        for asset, amount in balances.items():
+            val = float(amount)
+            if val == 0:
+                continue
+            fmt = f"{val:.2f}" if val > 1 else f"{val:.6f}"
+            if asset.upper() == quote_asset.upper():
+                addlog(f"{asset}: ${fmt}", verbose_int=1, verbose_state=verbose)
+            else:
+                addlog(f"{asset}: {fmt}", verbose_int=1, verbose_state=verbose)

--- a/systems/utils/cli.py
+++ b/systems/utils/cli.py
@@ -1,0 +1,47 @@
+import argparse
+import sys
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Return a configured argument parser for WindowSurfer CLI tools."""
+
+    if any(arg.startswith("--ledger") for arg in sys.argv[1:]):
+        raise SystemExit("[ERROR] --ledger is no longer supported. Use --account instead.")
+
+    parser = argparse.ArgumentParser(description="WindowSurfer command line interface")
+    parser.add_argument(
+        "--mode",
+        choices=["fetch", "sim", "live", "wallet", "view", "test", "email"],
+        help="Execution mode: fetch, sim, live, wallet, view, test, or email",
+    )
+    parser.add_argument(
+        "--account",
+        help="Account name defined in account_settings.json",
+    )
+    parser.add_argument(
+        "--market",
+        help="Specific market symbol to operate on (default: all for account)",
+    )
+    parser.add_argument(
+        "--all",
+        action="store_true",
+        help="Run all configured accounts and their markets",
+    )
+    parser.add_argument(
+        "--dry",
+        action="store_true",
+        help="Run live mode once immediately and exit",
+    )
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        action="count",
+        default=0,
+        help="Increase verbosity level (use -v or -vv)",
+    )
+    parser.add_argument(
+        "--log",
+        action="store_true",
+        help="Enable log file output",
+    )
+    return parser

--- a/systems/utils/config.py
+++ b/systems/utils/config.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+"""Basic configuration utilities and path helpers."""
+
+from pathlib import Path
+import json
+import sys
+from typing import Any, Dict
+
+import ccxt
+
+from systems.utils.addlog import addlog
+from systems.utils.resolve_symbol import resolve_symbols, to_tag
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[2]
+_SETTINGS_CACHE: Dict[str, Any] | None = None
+_GENERAL_CACHE: Dict[str, Any] | None = None
+_ACCOUNTS_CACHE: Dict[str, Any] | None = None
+_COIN_CACHE: Dict[str, Any] | None = None
+_KEYS_CACHE: Dict[str, Any] | None = None
+
+
+def resolve_path(rel_path: str) -> Path:
+    """Return an absolute path for ``rel_path`` from the project root."""
+    return _PROJECT_ROOT / rel_path
+
+
+def load_settings(*, reload: bool = False) -> Dict[str, Any]:
+    """Load ``settings/settings.json`` with optional caching."""
+    global _SETTINGS_CACHE
+    if _SETTINGS_CACHE is None or reload:
+        settings_path = resolve_path("settings/settings.json")
+        with settings_path.open("r", encoding="utf-8") as fh:
+            _SETTINGS_CACHE = json.load(fh)
+    return _SETTINGS_CACHE
+
+
+def load_general(*, reload: bool = False) -> Dict[str, Any]:
+    """Return the ``general_settings`` block from ``settings/settings.json``."""
+    global _GENERAL_CACHE
+    if _GENERAL_CACHE is None or reload:
+        data = load_settings(reload=reload)
+        _GENERAL_CACHE = data.get("general_settings", {})
+    return _GENERAL_CACHE
+
+
+def _missing_config() -> None:
+    print(
+        "[CONFIG][ERROR] Missing settings/account_settings.json or settings/coin_settings.json"
+    )
+    sys.exit(1)
+
+
+def load_account_settings(*, reload: bool = False) -> Dict[str, Any]:
+    """Load account configuration from ``settings/account_settings.json``."""
+    global _ACCOUNTS_CACHE
+    if _ACCOUNTS_CACHE is None or reload:
+        path = resolve_path("settings/account_settings.json")
+        if not path.exists():
+            _missing_config()
+        with path.open("r", encoding="utf-8") as fh:
+            _ACCOUNTS_CACHE = json.load(fh).get("accounts", {})
+    return _ACCOUNTS_CACHE
+
+
+def load_coin_settings(*, reload: bool = False) -> Dict[str, Any]:
+    """Load per-coin strategy defaults from ``settings/coin_settings.json``."""
+    global _COIN_CACHE
+    if _COIN_CACHE is None or reload:
+        path = resolve_path("settings/coin_settings.json")
+        if not path.exists():
+            _missing_config()
+        with path.open("r", encoding="utf-8") as fh:
+            _COIN_CACHE = json.load(fh).get("coin_settings", {})
+    return _COIN_CACHE
+
+
+def load_keys(*, reload: bool = False) -> Dict[str, Any]:
+    """Load API keys from ``settings/keys.json`` (best-effort)."""
+    global _KEYS_CACHE
+    if _KEYS_CACHE is None or reload:
+        path = resolve_path("settings/keys.json")
+        if not path.exists():
+            _KEYS_CACHE = {}
+        else:
+            with path.open("r", encoding="utf-8") as fh:
+                _KEYS_CACHE = json.load(fh)
+    return _KEYS_CACHE
+
+
+def resolve_coin_config(symbol: str, coin_settings: dict) -> dict:
+    d = dict(coin_settings.get("default", {}))
+    d.update(coin_settings.get(symbol, {}))
+    return d
+
+
+def resolve_account_market(account: str, symbol: str, accounts_cfg: dict) -> dict:
+    return (
+        accounts_cfg.get(account, {}).get("market settings", {}).get(symbol, {})
+    )
+
+
+def load_ledger_config(ledger_name: str) -> Dict[str, Any]:
+    """Deprecated ledger loader retained for backward compatibility."""
+    raise ValueError("load_ledger_config is deprecated; use load_config")
+
+
+def resolve_ccxt_symbols_by_coin(coin: str) -> tuple[str, str]:
+    """Return Kraken and Binance symbols for ``coin`` based on configured markets."""
+    from systems.utils.load_config import load_config
+
+    cfg = load_config()
+    client = ccxt.kraken({"enableRateLimit": True})
+    coin_up = coin.upper()
+    for acct in cfg.get("accounts", {}).values():
+        for market in acct.get("markets", {}).keys():
+            symbols = resolve_symbols(client, market)
+            tag = to_tag(symbols["kraken_name"])
+            base = symbols["kraken_name"].split("/")[0].upper()
+            if base.startswith(coin_up):
+                addlog(
+                    f"[CONFIG] coin={coin_up} resolved using tag={tag}",
+                    verbose_int=1,
+                    verbose_state=True,
+                )
+                return symbols["kraken_name"], symbols["binance_name"]
+    msg = f"[ERROR] No market maps coin={coin_up} to exchange symbols"
+    addlog(msg, verbose_int=1, verbose_state=True)
+    raise ValueError(msg)

--- a/systems/utils/load_config.py
+++ b/systems/utils/load_config.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+"""Unified configuration loader for accounts and strategy settings."""
+
+from typing import Any, Dict
+
+from systems.utils.config import (
+    load_general,
+    load_account_settings,
+    load_coin_settings,
+    load_keys,
+    resolve_coin_config,
+    resolve_account_market,
+)
+
+_CONFIG_CACHE: Dict[str, Any] | None = None
+
+
+def load_config(*, reload: bool = False) -> Dict[str, Any]:
+    """Load accounts and strategy settings from JSON files.
+
+    Returns
+    -------
+    dict
+        Dictionary with ``accounts`` and ``general_settings`` entries.
+    """
+    global _CONFIG_CACHE
+    if _CONFIG_CACHE is None or reload:
+        general = load_general(reload=reload)
+        coin_settings = load_coin_settings(reload=reload)
+        accounts_cfg = load_account_settings(reload=reload)
+        keys = load_keys(reload=reload)
+
+        accounts: Dict[str, Any] = {}
+        for acct_name, acct_cfg in accounts_cfg.items():
+            merged_markets: Dict[str, Any] = {}
+            for market in acct_cfg.get("market settings", {}).keys():
+                coin_cfg = resolve_coin_config(market, coin_settings)
+                acct_mkt_cfg = resolve_account_market(acct_name, market, accounts_cfg)
+                merged_markets[market] = {**coin_cfg, **acct_mkt_cfg}
+            accounts[acct_name] = {
+                "api_key": keys.get(acct_name, {}).get("api_key", ""),
+                "api_secret": keys.get(acct_name, {}).get("api_secret", ""),
+                "is_live": acct_cfg.get("is_live", False),
+                "reporting": acct_cfg.get("reporting", {}),
+                "markets": merged_markets,
+            }
+        _CONFIG_CACHE = {"accounts": accounts, "general_settings": general}
+    return _CONFIG_CACHE

--- a/systems/utils/quote_norm.py
+++ b/systems/utils/quote_norm.py
@@ -1,0 +1,10 @@
+NORM_MAP = {
+    "ZUSD": "USD",
+    "ZEUR": "EUR",
+    "ZGBP": "GBP",
+    "ZJPY": "JPY",
+}
+
+def norm_quote(q: str) -> str:
+    q = (q or "").upper()
+    return NORM_MAP.get(q, q)

--- a/systems/utils/resolve_symbol.py
+++ b/systems/utils/resolve_symbol.py
@@ -1,0 +1,67 @@
+"""Helpers for resolving exchange symbols and tag conversions."""
+
+from __future__ import annotations
+
+import ccxt
+
+
+def resolve_symbols(client: ccxt.Exchange, config_name: str) -> dict[str, str]:
+    """Return exchange identifiers for ``config_name`` using CCXT."""
+
+    markets = client.load_markets()
+
+    if config_name not in markets:
+        raise RuntimeError(f"[ERROR] Invalid trading pair: {config_name}")
+
+    m = markets[config_name]
+
+    return {
+        "kraken_name": m["symbol"],
+        "kraken_pair": m["id"],
+        "binance_name": (
+            f"{m['base']}USDT" if m["quote"] == "USD" else f"{m['base']}{m['quote']}"
+        ),
+    }
+
+
+def candle_filename(account: str, market: str, live: bool = False) -> str:
+    """Return canonical candle CSV path for ``account``/``market``."""
+
+    base = f"{account}_{market.replace('/', '_')}_1h.csv"
+    folder = "data/live" if live else "data/sim"
+    return f"{folder}/{base}"
+
+
+# ---------------------------------------------------------------------------
+# Legacy helpers retained for compatibility
+
+def to_tag(symbol: str) -> str:
+    """Normalize exchange symbol to uppercase tag without separators."""
+    return symbol.replace("/", "").replace(" ", "").upper()
+
+
+def sim_path_csv(tag: str) -> str:
+    """Return canonical SIM CSV path for ``tag``."""
+    return f"data/sim/{tag}_1h.csv"
+
+
+def live_path_csv(tag: str) -> str:
+    """Return canonical LIVE CSV path for ``tag``."""
+    return f"data/live/{tag}_1h.csv"
+
+
+def split_tag(tag: str) -> tuple[str, str]:
+    """Return base symbol and Kraken quote asset code for ``tag``."""
+    tag = tag.upper()
+    mapping = {
+        "USDT": "USDT",
+        "USDC": "USDC",
+        "DAI": "DAI",
+        "USD": "ZUSD",
+        "EUR": "ZEUR",
+        "GBP": "ZGBP",
+    }
+    for suffix, asset_code in mapping.items():
+        if tag.endswith(suffix):
+            return tag[: -len(suffix)], asset_code
+    return tag, ""

--- a/systems/utils/time.py
+++ b/systems/utils/time.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+
+def parse_cutoff(value: str) -> timedelta:
+    """Return a timedelta parsed from strings like '1d' or '2w'."""
+    if not value:
+        raise ValueError("cutoff value required")
+    value = value.strip().lower()
+    if len(value) < 2:
+        raise ValueError("cutoff must be in format <num><d|w|m|y>")
+    try:
+        num = int(value[:-1])
+    except ValueError as exc:
+        raise ValueError("invalid numeric portion for cutoff") from exc
+    unit = value[-1]
+    if unit == "h":
+        return timedelta(hours=num)
+    if unit == "d":
+        return timedelta(days=num)
+    if unit == "w":
+        return timedelta(weeks=num)
+    if unit == "m":
+        return timedelta(days=30 * num)
+    if unit == "y":
+        return timedelta(days=365 * num)
+    raise ValueError("cutoff unit must be one of h,d,w,m,y")
+
+
+def parse_duration(value: str) -> timedelta:
+    """Return a ``timedelta`` parsed from shorthand like ``'1m'`` or ``'7d'``."""
+    return parse_cutoff(value)
+
+
+def parse_relative_time(value: str) -> tuple[float, float]:
+    """Return (start_ts, end_ts) parsed from a relative time string."""
+    delta = parse_cutoff(value)
+    end = datetime.now(tz=timezone.utc).timestamp()
+    start = end - delta.total_seconds()
+    return start, end
+
+def duration_from_candle_count(candle_count: int, candle_interval_minutes: int = 60) -> str:
+    """
+    Converts a number of candles into a human-readable time duration.
+    Outputs years, months, days, hours (rounded, no zeroes).
+    """
+    total_minutes = candle_count * candle_interval_minutes
+    total_hours = total_minutes // 60
+
+    days, rem_hours = divmod(total_hours, 24)
+    years, rem_days = divmod(days, 365)
+    months, days = divmod(rem_days, 30)
+
+    parts = []
+    if years:
+        parts.append(f"{years}y")
+    if months:
+        parts.append(f"{months}mo")
+    if days:
+        parts.append(f"{days}d")
+    if rem_hours:
+        parts.append(f"{rem_hours}h")
+
+    return " ".join(parts)
+

--- a/systems/utils/trade_logger.py
+++ b/systems/utils/trade_logger.py
@@ -1,0 +1,39 @@
+import json
+import os
+from typing import Any, Dict, List
+
+_log_path: str | None = None
+
+
+def init_logger(ledger_name: str) -> None:
+    """Initialize JSON log file for a given ledger."""
+    global _log_path
+    os.makedirs("data/logs", exist_ok=True)
+    _log_path = os.path.join("data", "logs", f"{ledger_name}.json")
+    if not os.path.exists(_log_path):
+        with open(_log_path, "w", encoding="utf-8") as f:
+            json.dump([], f)
+
+
+def _load_events() -> List[Dict[str, Any]]:
+    if not _log_path:
+        raise RuntimeError("Logger not initialized")
+    if os.path.exists(_log_path):
+        with open(_log_path, "r", encoding="utf-8") as f:
+            try:
+                data = json.load(f)
+            except json.JSONDecodeError:
+                data = []
+    else:
+        data = []
+    return data
+
+
+def record_event(event: Dict[str, Any]) -> None:
+    """Append ``event`` to the current ledger's JSON log."""
+    if not _log_path:
+        raise RuntimeError("Logger not initialized")
+    data = _load_events()
+    data.append(event)
+    with open(_log_path, "w", encoding="utf-8") as f:
+        json.dump(data, f, indent=2)

--- a/test.py
+++ b/test.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""Connectivity and configuration checks."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Optional
+
+import ccxt  # type: ignore
+
+
+def _normalize_market(market: str) -> str:
+    if "/" in market:
+        return market
+    market = market.upper()
+    for quote in ("USDT", "USDC", "USD", "EUR", "GBP"):
+        if market.endswith(quote):
+            base = market[: -len(quote)]
+            return f"{base}/{quote}"
+    return market
+
+
+def _load_json(path: Path) -> dict:
+    with path.open("r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def main(argv: Optional[list[str]] = None) -> None:
+    parser = argparse.ArgumentParser(description="Configuration tester")
+    parser.add_argument("--account", required=True, help="Account name")
+    parser.add_argument("--market", required=True, help="Market symbol e.g. DOGEUSD")
+    parser.add_argument("--smoketest", action="store_true", help="Run exchange ping")
+    args = parser.parse_args(argv)
+
+    ok = True
+
+    acct_cfg = _load_json(Path("settings/account_settings.json")).get("accounts", {})
+    coin_cfg = _load_json(Path("settings/coin_settings.json")).get("coin_settings", {})
+
+    account_ok = args.account in acct_cfg
+    market_ok = account_ok and args.market in acct_cfg.get(args.account, {}).get("market settings", {})
+    coin_ok = args.market in coin_cfg or "default" in coin_cfg
+
+    keys_path = Path("settings/keys.json")
+    secrets_ok = False
+    if keys_path.exists():
+        keys = _load_json(keys_path)
+        acct_keys = keys.get(args.account, {})
+        secrets_ok = bool(acct_keys.get("api_key")) and bool(acct_keys.get("api_secret"))
+    else:
+        acct = acct_cfg.get(args.account, {})
+        kraken_api = acct.get("kraken_api", {})
+        secrets_ok = bool(kraken_api.get("key")) and bool(kraken_api.get("secret"))
+
+    if not account_ok:
+        print(f"❌ Unknown account {args.account}")
+        ok = False
+    if not market_ok:
+        print(f"❌ Unknown market {args.market} for account {args.account}")
+        ok = False
+    if not coin_ok:
+        print(f"❌ Missing coin settings for {args.market}")
+        ok = False
+    if not secrets_ok:
+        print(f"❌ Missing API secrets for account {args.account}")
+        ok = False
+
+    if args.smoketest and ok:
+        exchange = ccxt.kraken({"enableRateLimit": True})
+        try:
+            exchange.public_get_time()
+            exchange.fetch_ticker(_normalize_market(args.market))
+            print("✅ Kraken connectivity ok")
+        except Exception as exc:
+            print(f"❌ Kraken connectivity failed: {exc}")
+            ok = False
+
+    sys.exit(0 if ok else 1)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()


### PR DESCRIPTION
## Summary
- Add dedicated `sim.py`, `live.py`, and `test.py` command line entrypoints
- Preserve legacy `bot.py` and migrate supporting scripts into `systems`
- Provide minimal graph utilities for optional plotting

## Testing
- `python -m py_compile sim.py live.py test.py graph.py systems/scripts/*.py systems/utils/*.py`
- `python sim.py --help`
- `python live.py --help`
- `python test.py --help`
- `python test.py --account Kris --market DOGEUSD --smoketest` *(fails: Kraken connectivity failed)*

------
https://chatgpt.com/codex/tasks/task_e_68ab8c10658c832698cb5ae34dabf635