### PR TITLE
Add debug logging for simulation ledger path

### DIFF
--- a/sim.py
+++ b/sim.py
@@ -95,6 +95,7 @@ def main(argv: Optional[list[str]] = None) -> None:
         viz=False,
     )
     sim_path = Path("data/temp/sim_data.json")
+    print(f"[DEBUG][sim.py] Looking for sim ledger at {sim_path.resolve()}")
     if not sim_path.exists():
         print(f"[ERROR] Simulation did not produce {sim_path}")
         return

--- a/systems/sim_engine.py
+++ b/systems/sim_engine.py
@@ -380,10 +380,14 @@ def _run_single_sim(
         shutil.copyfile(default_path, sim_path)
     temp_dir = resolve_path("data/temp")
     temp_dir.mkdir(parents=True, exist_ok=True)
-
+    full_path = temp_dir / "sim_data.json"
+    print(f"[DEBUG][sim_engine] Attempting to write sim ledger → {full_path.resolve()}")
     ledger_save(
         trade_ledger,
-        str(temp_dir / "sim_data.json"),
+        str(full_path),
+    )
+    print(
+        f"[DEBUG][sim_engine] Finished writing ledger, entries={len(trade_ledger.get('entries', []))}"
     )
     logs_dir = root / "logs"
     logs_dir.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Summary
- log absolute path and entry count when writing sim ledger in sim_engine
- log absolute path checked for sim ledger in sim.py

## Testing
- `pytest`
- `python sim.py --account Kris --market DOGEUSD --time 1m`


------
https://chatgpt.com/codex/tasks/task_e_68ab97fd6a0c8326971ab7ca847031d5