### PR TITLE
Use slashless market identifiers across engines

### DIFF
--- a/live.py
+++ b/live.py
@@ -16,17 +16,6 @@ from systems.utils.config import (
 from systems.scripts.plot import plot_trades_from_ledger
 
 
-def _normalize_market(market: str) -> str:
-    if "/" in market:
-        return market
-    market = market.upper()
-    for quote in ("USDT", "USDC", "USD", "EUR", "GBP"):
-        if market.endswith(quote):
-            base = market[: -len(quote)]
-            return f"{base}/{quote}"
-    return market
-
-
 def main(argv: Optional[list[str]] = None) -> None:
     parser = argparse.ArgumentParser(description="Run live trading loop")
     parser.add_argument("--account", required=True, help="Account name")
@@ -35,14 +24,16 @@ def main(argv: Optional[list[str]] = None) -> None:
     args = parser.parse_args(argv)
     from systems.utils.load_config import load_config
 
+    market = args.market.replace("/", "").upper()
+
     cfg = load_config()
     accounts = cfg.get("accounts", {})
     if args.account not in accounts:
         print(f"[ERROR] Unknown account: {args.account}")
         raise SystemExit(1)
     markets = accounts[args.account].get("markets", {})
-    if args.market not in markets:
-        print(f"[ERROR] Unknown market: {args.market} for account {args.account}")
+    if market not in markets:
+        print(f"[ERROR] Unknown market: {market} for account {args.account}")
         raise SystemExit(1)
 
     accounts_cfg = load_account_settings()
@@ -51,26 +42,23 @@ def main(argv: Optional[list[str]] = None) -> None:
     if not acct_cfg:
         print(f"[ERROR] Unknown account {args.account}")
         sys.exit(1)
-    if args.market not in acct_cfg.get("market settings", {}):
-        print(f"[ERROR] Unknown market {args.market} for account {args.account}")
+    if market not in acct_cfg.get("market settings", {}):
+        print(f"[ERROR] Unknown market {market} for account {args.account}")
         sys.exit(1)
     _ = {
-        **resolve_coin_config(args.market, coin_cfg),
-        **resolve_account_market(args.account, args.market, accounts_cfg),
+        **resolve_coin_config(market, coin_cfg),
+        **resolve_account_market(args.account, market, accounts_cfg),
     }
 
     from systems.live_engine import run_live
 
-    run_live(account=args.account, market=_normalize_market(args.market))
+    run_live(account=args.account, market=market)
 
     if args.graph:
         try:
-    from systems.scripts.plot import plot_trades_from_ledger
-
-    try:
-        plot_trades_from_ledger(args.account, args.market, mode="live")
-    except Exception as exc:  # pragma: no cover - plotting best effort
-        print(f"[WARN] Plotting failed: {exc}")
+            plot_trades_from_ledger(args.account, market, mode="live")
+        except Exception as exc:  # pragma: no cover - plotting best effort
+            print(f"[WARN] Plotting failed: {exc}")
 
 
 


### PR DESCRIPTION
## Summary
- accept noslash symbols from CLI and configs in sim and live entrypoints
- update engines and candle loader to strip slashes, generate CCXT pairs internally, and name ledgers/candles with noslash markets
- write candle files under `data/candles/{sim,live}` and ledgers under `data/ledgers/{account}_{market}.json`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ab99ce0c948326b2a364c0fe5f9237