### PR TITLE
Fix time window filtering and overhaul sim visualization

### DIFF
--- a/systems/sim_engine.py
+++ b/systems/sim_engine.py
@@ -104,7 +104,8 @@ def _run_single_sim(
 
     if timeframe:
         delta = parse_timeframe(timeframe)
-        cutoff_ts = (datetime.now(tz=timezone.utc) - delta).timestamp()
+        end_ts = df[ts_col].max()
+        cutoff_ts = end_ts - delta.total_seconds()
         df = df[df[ts_col] >= cutoff_ts].reset_index(drop=True)
 
     # Log one line so we always know what we ran on


### PR DESCRIPTION
## Summary
- Trim simulation candles relative to dataset end when using `--time`
- Plot only strategy features in viz: price, slope with triggers and flat band

## Testing
- `pytest`
- `python sim.py --account Kris --market DOGEUSD --time 1m --viz` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68ab9c33568c8326b6977f619e0eea7d