### PR TITLE
Add coin-based simulation harness

### DIFF
--- a/data/logs/Kris_DOGEUSD.json
+++ b/data/logs/Kris_DOGEUSD.json
@@ -12221,5 +12221,70 @@
       "sell_trigger": 10.0
     },
     "trades": []
+  },
+  {
+    "timestamp": "1970-01-01T00:00:01Z",
+    "ledger": "Kris_DOGEUSD",
+    "pair": "DOGEUSD",
+    "window": "1h",
+    "decision": "BUY",
+    "features": {
+      "close": 1.0,
+      "slope": null,
+      "volatility": null,
+      "buy_pressure": 0.0,
+      "sell_pressure": 0.0,
+      "buy_trigger": 1,
+      "sell_trigger": 0.0
+    },
+    "trades": [
+      {
+        "action": "BUY",
+        "amount": 10.0,
+        "price": 1.0,
+        "note_id": "strategy-0"
+      }
+    ]
+  },
+  {
+    "timestamp": "1970-01-01T00:00:02Z",
+    "ledger": "Kris_DOGEUSD",
+    "pair": "DOGEUSD",
+    "window": "1h",
+    "decision": "SELL",
+    "features": {
+      "close": 2.0,
+      "slope": null,
+      "volatility": null,
+      "buy_pressure": 0.0,
+      "sell_pressure": 0.0,
+      "buy_trigger": 1,
+      "sell_trigger": 0.0
+    },
+    "trades": [
+      {
+        "action": "SELL",
+        "amount": 20.0,
+        "price": 2.0,
+        "note_id": "strategy-0"
+      }
+    ]
+  },
+  {
+    "timestamp": "1970-01-01T00:00:03Z",
+    "ledger": "Kris_DOGEUSD",
+    "pair": "DOGEUSD",
+    "window": "1h",
+    "decision": "HOLD",
+    "features": {
+      "close": 3.0,
+      "slope": null,
+      "volatility": null,
+      "buy_pressure": 0.0,
+      "sell_pressure": 0.0,
+      "buy_trigger": 1,
+      "sell_trigger": 0.0
+    },
+    "trades": []
   }
 ]

--- a/sim.py
+++ b/sim.py
@@ -8,36 +8,29 @@ from pathlib import Path
 from typing import Optional
 import sys
 
-from systems.utils.config import (
-    load_account_settings,
-    load_coin_settings,
-    resolve_account_market,
-    resolve_coin_config,
-)
 from systems.scripts.plot import plot_trades_from_ledger
 
 
-def _ensure_candles(account: str, market: str) -> Path:
-    """Ensure candle CSV exists for ``market``.
+def _ensure_candles(coin: str) -> Path:
+    """Ensure candle CSV exists for ``coin``.
 
-    If the canonical file is missing, attempt to fetch it using the
-    ``systems.scripts.fetch_candles`` helpers.
+    If the canonical file is missing, attempt to fetch it from Binance.
     """
-    market = market.replace("/", "").upper()
+    coin = coin.replace("/", "").upper()
     candles_dir = Path("data/candles/sim")
-    csv_path = candles_dir / f"{market}.csv"
+    csv_path = candles_dir / f"{coin}.csv"
 
     # Backwards compatibility with previous layout
     if not csv_path.exists():
         candles_dir = Path("data/sim")
-        csv_path = candles_dir / f"{market}.csv"
+        csv_path = candles_dir / f"{coin}.csv"
 
     if csv_path.exists():
         return csv_path
 
     from systems.scripts.fetch_candles import fetch_binance_full_history_1h
 
-    symbol = market
+    symbol = coin
     if symbol.endswith("USD"):
         symbol = symbol + "T"
     df = fetch_binance_full_history_1h(symbol)
@@ -48,39 +41,19 @@ def _ensure_candles(account: str, market: str) -> Path:
 
 def main(argv: Optional[list[str]] = None) -> None:
     parser = argparse.ArgumentParser(description="Run historical simulation")
-    parser.add_argument("--account", required=True, help="Account name")
-    parser.add_argument("--market", required=True, help="Market symbol e.g. DOGEUSD")
+    parser.add_argument("--coin", required=True, help="Coin symbol e.g. DOGEUSD")
     parser.add_argument("--time", dest="timeframe", default="1m", help="Lookback window")
     parser.add_argument("--viz", action="store_true", help="Enable plotting")
     args = parser.parse_args(argv)
 
-    market = args.market.replace("/", "").upper()
+    coin = args.coin.replace("/", "").upper()
 
-    # Load and validate settings
-    accounts_cfg = load_account_settings()
-    coin_cfg = load_coin_settings()
-
-    acct_cfg = accounts_cfg.get(args.account)
-    if not acct_cfg:
-        print(f"[ERROR] Unknown account {args.account}")
-        sys.exit(1)
-    if market not in acct_cfg.get("market settings", {}):
-        print(f"[ERROR] Unknown market {market} for account {args.account}")
-        sys.exit(1)
-
-    # Merge configs to ensure consistency (unused here but placeholder for future)
-    _ = {
-        **resolve_coin_config(market, coin_cfg),
-        **resolve_account_market(args.account, market, accounts_cfg),
-    }
-
-    csv_path = _ensure_candles(args.account, market)
+    _ensure_candles(coin)
 
     from systems.sim_engine import run_simulation
 
     run_simulation(
-        account=args.account,
-        market=market,
+        coin=coin,
         timeframe=args.timeframe,
         viz=False,
     )
@@ -92,9 +65,10 @@ def main(argv: Optional[list[str]] = None) -> None:
 
     if args.viz:
         try:
+            # Use a placeholder account label for plotting since the engine is coin-centric
             plot_trades_from_ledger(
-                args.account,
-                market,
+                "SIM",
+                coin,
                 mode="sim",
                 ledger_path=str(sim_path),
             )

--- a/test_mode.py
+++ b/test_mode.py
@@ -54,7 +54,7 @@ def test_simulation_writes_ledger(monkeypatch):
 
     monkeypatch.setattr(sim_engine, "build_runtime_state", fake_state)
 
-    sim_engine.run_simulation(account="Kris", market="DOGEUSD", timeframe="100y", viz=False)
+    sim_engine.run_simulation(coin="DOGEUSD", timeframe="100y", viz=False)
 
     ledger_path = Path("data/temp/sim_data.json")
     assert ledger_path.exists()


### PR DESCRIPTION
## Summary
- simplify `sim.py` CLI to focus on `--coin` lookbacks and ensure candles are fetched
- refactor `systems.sim_engine.run_simulation` to accept a coin symbol and write minimal trade fields
- update tests for new simulation interface

## Testing
- `pytest -q`
- `python sim.py --coin DOGEUSD --time 1m` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68abb96cc2508326ab493f6acab39df7