### PR TITLE
Enable JSON-backed visualization for coin simulations

### DIFF
--- a/test_mode.py
+++ b/test_mode.py
@@ -59,7 +59,7 @@ def test_simulation_writes_ledger(monkeypatch):
     ledger_path = Path("data/temp/sim_data.json")
     assert ledger_path.exists()
     data = json.loads(ledger_path.read_text())
-    sides = {e["side"] for e in data.get("entries", [])}
+    sides = {e["side"] for e in data.get("trades", [])}
     assert {"BUY", "SELL", "PASS"}.issubset(sides)
 
 


### PR DESCRIPTION
## Summary
- Capture starting capital and final value and output a simplified JSON ledger for simulations
- CLI loads this ledger, prints results, and converts trades for plotting when `--viz` is used
- Update tests for new ledger structure

## Testing
- `pytest`
- `python sim.py --coin DOGEUSD --time 1m --viz` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68abbc917aa4832695293378d960a8bb