### PR TITLE
Respect coin-specific window_step in simulation

### DIFF
--- a/test_mode.py
+++ b/test_mode.py
@@ -36,6 +36,8 @@ def test_simulation_writes_ledger(monkeypatch):
     from systems.scripts import runtime_state
     monkeypatch.setattr(runtime_state, "resolve_symbols", lambda client, market: {"kraken_name": market, "kraken_pair": market, "binance_name": market})
 
+    monkeypatch.setattr(sim_engine, "load_coin_settings", lambda *args, **kwargs: {"default": {"window_step": 1}})
+
     def fake_state(*args, **kwargs):
         return {
             "strategy": {


### PR DESCRIPTION
## Summary
- Resolve coin-specific settings at simulation start and apply `window_step` stride
- Pass resolved settings into buy/sell evaluators and record them in output metadata
- Log PASS trades and add test hook for configurable `window_step`

## Testing
- `python -m pytest`
- `python sim.py --coin DOGEUSD --time 1m --viz` *(fails: Network is unreachable when loading Kraken symbols; verified `_run_single_sim` separately)*

------
https://chatgpt.com/codex/tasks/task_e_68abd032101083268d2eec963cb9dc9f