### PR TITLE
Stub CLI commands for sim, live, and test scripts

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Unified CLI entry point for WindowSurfer.
+
+This optional wrapper exposes subcommands for the individual scripts so
+they can be invoked from one location::
+
+    python bot.py sim --coin DOGEUSD --time 1m --viz
+    python bot.py live --account Kris --market DOGEUSD --graph
+    python bot.py test --account Kris --market DOGEUSD --smoketest
+
+Each subcommand forwards its arguments to the corresponding module.
+Use ``--help`` on the subcommands to see available options.
+"""
+
+from __future__ import annotations
+
+import argparse
+from typing import Optional
+
+import live
+import sim
+import test as test_mod
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Create the top-level argument parser with subcommands."""
+
+    parser = argparse.ArgumentParser(description="WindowSurfer CLI")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    sim_parser = sub.add_parser("sim", help="Run historical simulation")
+    sim_parser.add_argument("--coin", required=True, help="Coin symbol e.g. DOGEUSD")
+    sim_parser.add_argument("--time", default="1m", help="Lookback window")
+    sim_parser.add_argument("--viz", action="store_true", help="Enable plotting")
+
+    live_parser = sub.add_parser("live", help="Run live trading loop")
+    live_parser.add_argument("--account", required=True, help="Account name")
+    live_parser.add_argument("--market", required=True, help="Market symbol e.g. DOGEUSD")
+    live_parser.add_argument("--graph", action="store_true", help="Plot ledger after run")
+
+    test_parser = sub.add_parser("test", help="Run configuration tests")
+    test_parser.add_argument("--account", required=True, help="Account name")
+    test_parser.add_argument("--market", required=True, help="Market symbol e.g. DOGEUSD")
+    test_parser.add_argument("--smoketest", action="store_true", help="Run exchange ping")
+
+    return parser
+
+
+def main(argv: Optional[list[str]] = None) -> None:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    if args.command == "sim":
+        sim_args = ["--coin", args.coin, "--time", args.time]
+        if args.viz:
+            sim_args.append("--viz")
+        sim.main(sim_args)
+    elif args.command == "live":
+        live_args = ["--account", args.account, "--market", args.market]
+        if args.graph:
+            live_args.append("--graph")
+        live.main(live_args)
+    elif args.command == "test":
+        test_args = ["--account", args.account, "--market", args.market]
+        if args.smoketest:
+            test_args.append("--smoketest")
+        test_mod.main(test_args)
+    else:  # pragma: no cover - argparse ensures we don't reach here
+        parser.error(f"Unknown command {args.command}")
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()
+

--- a/live.py
+++ b/live.py
@@ -1,5 +1,11 @@
 #!/usr/bin/env python3
-"""CLI entry point for live trading loop."""
+"""CLI entry point for live trading loop.
+
+Example:
+    python live.py --account Kris --market DOGEUSD --graph
+
+Use ``--help`` to see available options.
+"""
 
 from __future__ import annotations
 

--- a/sim.py
+++ b/sim.py
@@ -1,5 +1,11 @@
 #!/usr/bin/env python3
-"""CLI entry point for running historical simulations."""
+"""CLI entry point for running historical simulations.
+
+Example:
+    python sim.py --coin DOGEUSD --time 1m --viz
+
+Use ``--help`` to see available options.
+"""
 
 from __future__ import annotations
 
@@ -53,7 +59,7 @@ def main(argv: Optional[list[str]] = None) -> None:
     from systems.sim_engine import run_simulation
 
     run_simulation(
-        coin=coin,
+        market=coin,
         timeframe=args.time,
         viz=False,
     )

--- a/systems/fetch.py
+++ b/systems/fetch.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+"""CLI helpers for candle fetching."""
+
+import os
+from pathlib import Path
+import sys
+
+import ccxt
+
+if __package__ is None or __package__ == "":
+    sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from systems.utils.addlog import addlog
+from systems.utils.load_config import load_config
+from systems.utils.resolve_symbol import resolve_symbols, candle_filename
+from systems.scripts.fetch_candles import (
+    fetch_binance_full_history_1h,
+    fetch_kraken_last_n_hours_1h,
+)
+
+
+def run_fetch(
+    account: str | None = None, market: str | None = None, all_accounts: bool = False
+) -> None:
+    """Fetch candles for configured accounts/markets."""
+
+    cfg = load_config()
+    accounts = cfg.get("accounts", {})
+    targets = accounts.keys() if (all_accounts or not account) else [account]
+
+    for acct_name in targets:
+        acct_cfg = accounts.get(acct_name)
+        if not acct_cfg:
+            addlog(
+                f"Error: Unknown account {acct_name}",
+                verbose_int=1,
+                verbose_state=True,
+            )
+            continue
+        os.environ["WS_ACCOUNT"] = acct_name
+        client = ccxt.kraken(
+            {
+                "enableRateLimit": True,
+                "apiKey": acct_cfg.get("api_key", ""),
+                "secret": acct_cfg.get("api_secret", ""),
+            }
+        )
+        markets_cfg = acct_cfg.get("markets", {})
+        m_targets = [market] if market else list(markets_cfg.keys())
+        for m in m_targets:
+            if m not in markets_cfg:
+                continue
+            addlog(
+                f"[RUN][{acct_name}][{m}]",
+                verbose_int=1,
+                verbose_state=True,
+            )
+            symbols = resolve_symbols(client, m)
+            kraken_name = symbols["kraken_name"]
+            kraken_pair = symbols["kraken_pair"]
+            binance_name = symbols["binance_name"]
+
+            addlog(
+                f"[RESOLVE][{acct_name}][{m}] KrakenName={kraken_name} KrakenPair={kraken_pair} BinanceName={binance_name}",
+                verbose_int=1,
+                verbose_state=True,
+            )
+
+            if "/" not in kraken_name:
+                addlog(
+                    f"[ERROR] Kraken symbol missing '/' : {kraken_name}",
+                    verbose_int=1,
+                    verbose_state=True,
+                )
+                raise SystemExit(1)
+            if "/" in binance_name:
+                addlog(
+                    f"[ERROR] Binance symbol must not contain '/' : {binance_name}",
+                    verbose_int=1,
+                    verbose_state=True,
+                )
+                raise SystemExit(1)
+
+            # Binance full history -> SIM
+            df_sim = fetch_binance_full_history_1h(binance_name)
+            sim_path = candle_filename(acct_name, m)
+            tmp_sim = sim_path + ".tmp"
+            os.makedirs(os.path.dirname(sim_path), exist_ok=True)
+            df_sim.to_csv(tmp_sim, index=False)
+            os.replace(tmp_sim, sim_path)
+
+            # Kraken last 720 -> LIVE
+            df_live = fetch_kraken_last_n_hours_1h(kraken_name, n=720)
+            live_path = candle_filename(acct_name, m, live=True)
+            tmp_live = live_path + ".tmp"
+            os.makedirs(os.path.dirname(live_path), exist_ok=True)
+            df_live.to_csv(tmp_live, index=False)
+            os.replace(tmp_live, live_path)
+            rows = len(df_live)
+            if rows < 720:
+                addlog(
+                    f"[FETCH][WARN] {acct_name} {kraken_name} returned {rows} rows (<720) from kraken",
+                    verbose_int=1,
+                    verbose_state=True,
+                )
+
+            addlog(
+                f"[FETCH][{acct_name}][{kraken_name}] saved sim/live candles",
+                verbose_int=1,
+                verbose_state=True,
+            )

--- a/systems/live_engine.py
+++ b/systems/live_engine.py
@@ -1,0 +1,310 @@
+from __future__ import annotations
+
+"""Live engine mirroring the simulation strategy."""
+
+import os
+import time
+import pandas as pd
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Dict, Any
+
+import ccxt
+from tqdm import tqdm
+
+from systems.utils.resolve_symbol import to_tag, resolve_symbols, candle_filename
+from systems.scripts.fetch_candles import fetch_kraken_last_n_hours_1h
+from systems.scripts.ledger import load_ledger, save_ledger
+from systems.scripts.evaluate_buy import evaluate_buy
+from systems.scripts.evaluate_sell import evaluate_sell
+from systems.scripts.runtime_state import build_runtime_state
+from systems.scripts.trade_apply import apply_sell
+from systems.scripts.execution_handler import execute_sell, process_buy_signal
+from systems.scripts.candle_loader import load_candles_df
+from systems.utils.trade_logger import init_logger as init_trade_logger, record_event
+from systems.utils.config import (
+    load_general,
+    load_coin_settings,
+    load_account_settings,
+    load_keys,
+    resolve_coin_config,
+    resolve_account_market,
+)
+
+
+def _run_iteration(
+    general,
+    coin_settings,
+    accounts_cfg,
+    keys,
+    runtime_states: Dict[str, Dict],
+    hist_cache: Dict[str, tuple[float, float]],
+    *,
+    account_filter: str | None,
+    market_filter: str | None,
+    verbose: int,
+) -> None:
+    for acct_name, acct_cfg in accounts_cfg.items():
+        if account_filter and acct_name != account_filter:
+            continue
+
+        if not acct_cfg.get("is_live", False):
+            print(f"[SKIP] {acct_name} (is_live = false)")
+            continue
+
+        keypair = keys.get(acct_name, {})
+        client = ccxt.kraken(
+            {
+                "enableRateLimit": True,
+                "apiKey": keypair.get("api_key", ""),
+                "secret": keypair.get("api_secret", ""),
+            }
+        )
+
+        for market in acct_cfg.get("market settings", {}).keys():
+            if market_filter and market != market_filter:
+                continue
+
+            strategy_cfg = {
+                **resolve_coin_config(market, coin_settings),
+                **resolve_account_market(acct_name, market, accounts_cfg),
+            }
+
+            symbols = resolve_symbols(client, market)
+            kraken_name = symbols["kraken_name"]
+            kraken_pair = symbols["kraken_pair"]
+            binance_name = symbols["binance_name"]
+            tag = to_tag(kraken_name)
+            file_tag = market.replace("/", "_")
+            ledger_name = f"{acct_name}_{file_tag}"
+
+            # init log file for this ledger
+            init_trade_logger(ledger_name)
+
+            # refresh last 720h from kraken
+            live_file = candle_filename(acct_name, market, live=True)
+            df_live = fetch_kraken_last_n_hours_1h(kraken_name, n=720)
+            tmp_live = live_file + ".tmp"
+            os.makedirs(os.path.dirname(live_file), exist_ok=True)
+            df_live.to_csv(tmp_live, index=False)
+            os.replace(tmp_live, live_file)
+
+            df, _ = load_candles_df(acct_name, market, live=True, verbose=verbose)
+            if df.empty:
+                continue
+
+            last_ts = int(df["timestamp"].iloc[-1])
+            last_iso = datetime.fromtimestamp(last_ts, tz=timezone.utc).strftime(
+                "%Y-%m-%dT%H:%M:%SZ"
+            )
+            print(f"[DATA][LIVE] file={live_file} rows={len(df)} last={last_iso}")
+
+            if ledger_name not in hist_cache:
+                df_sim, _ = load_candles_df(acct_name, market, verbose=verbose)
+                hist_low = float(df_sim["low"].min())
+                hist_high = float(df_sim["high"].max())
+                hist_cache[ledger_name] = (hist_low, hist_high)
+                print(
+                    f"[STATS][LIVE] hist_low={hist_low:.2f} hist_high={hist_high:.2f}"
+                )
+            hist_low, hist_high = hist_cache[ledger_name]
+
+            t = len(df) - 1
+            ledger_obj = load_ledger(ledger_name, tag=file_tag)
+            prev = runtime_states.get(ledger_name, {"verbose": verbose})
+            state = build_runtime_state(
+                general,
+                coin_settings,
+                accounts_cfg,
+                acct_name,
+                market,
+                mode="live",
+                client=client,
+                prev=prev,
+            )
+            state["mode"] = "live"
+            state["symbol"] = tag
+            state["hist_low"] = hist_low
+            state["hist_high"] = hist_high
+            state["capital"] = ledger_obj.get_metadata().get(
+                "capital", state.get("capital", 0.0)
+            )
+            runtime_states[ledger_name] = state
+            strategy_cfg = state.get("strategy", {})
+
+            price = float(df.iloc[t]["close"])
+            ctx = {"ledger": ledger_obj}
+            decision = "HOLD"
+            trades_log: list[dict[str, Any]] = []
+
+            # BUY
+            buy_res = evaluate_buy(
+                ctx,
+                t,
+                df,
+                cfg=strategy_cfg,
+                runtime_state=state,
+            )
+            if buy_res:
+                buy_result = process_buy_signal(
+                    buy_signal=buy_res,
+                    ledger=ledger_obj,
+                    t=t,
+                    runtime_state=state,
+                    pair_code=kraken_pair,
+                    price=price,
+                    ledger_name=tag,
+                    wallet_code=kraken_name.split("/")[0],
+                    verbose=state.get("verbose", 0),
+                )
+                decision = "BUY"
+                trades_log.append(
+                    {
+                        "action": "BUY",
+                        "amount": buy_res.get("size_usd", 0.0),
+                        "price": (buy_result or {}).get("avg_price", 0.0),
+                        "note_id": f"{buy_res.get('window_name','strategy')}-{t}",
+                    }
+                )
+
+            # SELL
+            sell_notes = evaluate_sell(
+                {"ledger": ledger_obj},
+                t,
+                df,
+                cfg=strategy_cfg,
+                open_notes=ledger_obj.get_open_notes(),
+                runtime_state=state,
+            )
+            if sell_notes:
+                decision = "FLAT" if any(
+                    n.get("sell_mode") == "flat" for n in sell_notes
+                ) else "SELL"
+
+            for note in sell_notes:
+                result = execute_sell(
+                    None,
+                    pair_code=kraken_pair,
+                    coin_amount=note.get("entry_amount", 0.0),
+                    price=price,
+                    ledger_name=tag,
+                    verbose=state.get("verbose", 0),
+                )
+                if result and not result.get("error"):
+                    closed = apply_sell(
+                        ledger=ledger_obj,
+                        note=note,
+                        t=t,
+                        result=result,
+                        state=state,
+                    )
+                    trades_log.append(
+                        {
+                            "action": "SELL",
+                            "amount": result.get("filled_amount", 0.0)
+                            * result.get("avg_price", 0.0),
+                            "price": result.get("avg_price", 0.0),
+                            "note_id": closed.get("id"),
+                        }
+                    )
+
+            ledger_obj.set_metadata({"capital": state.get("capital", 0.0)})
+            save_ledger(ledger_name, ledger_obj, tag=file_tag)
+
+            # record structured event
+            features = state.get("last_features", {}).get("strategy", {})
+            pressures = state.get("pressures", {})
+            event = {
+                "timestamp": last_iso,
+                "ledger": ledger_name,
+                "pair": tag,
+                "window": f"{strategy_cfg.get('window_size', 0)}h",
+                "decision": decision,
+                "features": {
+                    "close": float(df.iloc[t]["close"]),
+                    "slope": features.get("slope"),
+                    "volatility": features.get("volatility"),
+                    "buy_pressure": pressures.get("buy", {}).get("strategy", 0.0),
+                    "sell_pressure": pressures.get("sell", {}).get("strategy", 0.0),
+                    "buy_trigger": strategy_cfg.get("buy_trigger", 0.0),
+                    "sell_trigger": strategy_cfg.get("sell_trigger", 0.0),
+                },
+                "trades": trades_log,
+            }
+            record_event(event)
+
+
+def run_live(
+    *,
+    account: str | None = None,
+    market: str | None = None,
+    all_accounts: bool = False,
+    dry: bool = False,
+    verbose: int = 0,
+) -> None:
+    general = load_general()
+    coin_settings = load_coin_settings()
+    accounts_cfg = load_account_settings()
+    keys = load_keys()
+    runtime_states: Dict[str, Dict] = {}
+    hist_cache: Dict[str, tuple[float, float]] = {}
+
+    targets = (
+        accounts_cfg.keys() if (all_accounts or not account) else [account]
+    )
+
+    for acct_name in targets:
+        acct_cfg = accounts_cfg.get(acct_name)
+        if not acct_cfg:
+            continue
+        if not acct_cfg.get("is_live", False):
+            print(f"[SKIP] {acct_name} (is_live = false)")
+            continue
+        for mkt in acct_cfg.get("market settings", {}).keys():
+            if market and mkt != market:
+                continue
+            ledger_name = f"{acct_name}_{mkt.replace('/','_')}"
+            init_trade_logger(ledger_name)
+
+    account_filter = None if (all_accounts or not account) else account
+    if dry:
+        _run_iteration(
+            general,
+            coin_settings,
+            accounts_cfg,
+            keys,
+            runtime_states,
+            hist_cache,
+            account_filter=account_filter,
+            market_filter=market,
+            verbose=verbose,
+        )
+        return
+
+    while True:
+        now = datetime.utcnow().replace(tzinfo=timezone.utc)
+        elapsed = now.minute * 60 + now.second
+        remaining = 3600 - elapsed
+        with tqdm(
+            total=3600,
+            initial=elapsed,
+            desc="⏳ Time to next hour",
+            bar_format="{l_bar}{bar}| {percentage:3.0f}% {remaining}s",
+            leave=True,
+            dynamic_ncols=True,
+        ) as pbar:
+            for _ in range(remaining):
+                time.sleep(1)
+                pbar.update(1)
+        print("[LIVE] Running top of hour")
+        _run_iteration(
+            general,
+            coin_settings,
+            accounts_cfg,
+            keys,
+            runtime_states,
+            hist_cache,
+            account_filter=account_filter,
+            market_filter=market,
+            verbose=verbose,
+        )

--- a/systems/manual.py
+++ b/systems/manual.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+"""Command-line tool to place manual Kraken buy/sell test orders."""
+
+from typing import Optional
+
+from systems.utils.config import load_settings, resolve_path
+from systems.utils.addlog import addlog
+from systems.scripts.kraken_utils import get_live_price
+from systems.utils.cli import build_parser
+from systems.scripts.execution_handler import execute_buy, execute_sell
+from systems.scripts.ledger import load_ledger, save_ledger
+from systems.utils.resolve_symbol import resolve_symbols, to_tag
+import ccxt
+def _coin_label(tag: str) -> str:
+    for suffix in ["USD", "USDT", "USDC", "EUR", "GBP", "DAI"]:
+        if tag.endswith(suffix):
+            return tag[: -len(suffix)]
+    return tag
+
+
+def _parse_args(argv: Optional[list[str]] = None):
+    parser = build_parser()
+    action = parser.add_mutually_exclusive_group(required=True)
+    action.add_argument("--buy", action="store_true", help="Execute a buy")
+    action.add_argument("--sell", action="store_true", help="Execute a sell")
+    parser.add_argument("--usd", required=True, type=float, help="USD amount")
+    args = parser.parse_args(argv)
+    if not args.account:
+        parser.error("--account is required")
+    return args
+
+
+def main(argv: Optional[list[str]] = None) -> None:
+    args = _parse_args(argv)
+
+    settings = load_settings()
+    ledger_cfg = settings.get("ledger_settings", {}).get(args.account)
+    if ledger_cfg is None:
+        raise SystemExit(f"[ERROR] Account '{args.account}' not found in settings")
+
+    if args.usd <= 0:
+        raise SystemExit("[ERROR] --usd must be positive")
+
+    client = ccxt.kraken({"enableRateLimit": True})
+    symbols = resolve_symbols(client, ledger_cfg["kraken_name"])
+    tag = to_tag(symbols["kraken_name"])
+    file_tag = symbols["kraken_name"].replace("/", "_")
+    kraken_pair = symbols["kraken_pair"]
+    base = symbols["kraken_name"].split("/")[0]
+
+    price = get_live_price(kraken_pair)
+    if price <= 0:
+        raise SystemExit("[ERROR] Live price unavailable (0) — aborting")
+
+    coin_amt = args.usd / price
+    coin_str = _coin_label(tag)
+    path_new = resolve_path(f"data/ledgers/{args.account}.json")
+    legacy_path = resolve_path(f"data/ledgers/{file_tag}.json") if file_tag else None
+    if legacy_path and legacy_path.exists() and not path_new.exists():
+        legacy_path.rename(path_new)
+
+    ledger = load_ledger(args.account, tag=file_tag)
+    metadata = ledger.get_metadata()
+
+    if args.buy:
+        if not args.dry:
+            result = execute_buy(
+                None,
+                pair_code=kraken_pair,
+                wallet_code=base,
+                price=price,
+                amount_usd=args.usd,
+                ledger_name=args.account,
+                verbose=args.verbose,
+            )
+            if not result or result.get("error"):
+                raise SystemExit("[ERROR] Buy order failed")
+            coin_amt = result.get("filled_amount", coin_amt)
+            price = result.get("avg_price", price)
+            metadata.setdefault("trades", []).append(
+                {
+                    "action": "buy",
+                    "symbol": tag,
+                    "usd": args.usd,
+                    "coin": coin_amt,
+                    "price": price,
+                    "timestamp": result.get("timestamp"),
+                }
+            )
+            ledger.set_metadata(metadata)
+            save_ledger(args.account, ledger, tag=file_tag)
+        addlog(
+            f"[MANUAL BUY] {args.account} | {tag} | ${args.usd:.2f} → {coin_amt:.4f} {coin_str} @ ${price:.4f}",
+            verbose_int=1,
+            verbose_state=args.verbose,
+        )
+    else:  # sell
+        if not args.dry:
+            result = execute_sell(
+                None,
+                pair_code=kraken_pair,
+                coin_amount=coin_amt,
+                price=price,
+                ledger_name=args.account,
+                verbose=args.verbose,
+            )
+            if not result or result.get("error"):
+                raise SystemExit("[ERROR] Sell order failed")
+            coin_amt = result.get("filled_amount", coin_amt)
+            price = result.get("avg_price", price)
+            usd_total = coin_amt * price
+            metadata.setdefault("trades", []).append(
+                {
+                    "action": "sell",
+                    "symbol": tag,
+                    "usd": usd_total,
+                    "coin": coin_amt,
+                    "price": price,
+                    "timestamp": result.get("timestamp"),
+                }
+            )
+            ledger.set_metadata(metadata)
+            save_ledger(args.account, ledger, tag=file_tag)
+        else:
+            usd_total = args.usd
+        addlog(
+            f"[MANUAL SELL] {args.account} | {tag} | {coin_amt:.4f} {coin_str} → ${usd_total:.2f} @ ${price:.4f}",
+            verbose_int=1,
+            verbose_state=args.verbose,
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/systems/scripts/account_book.py
+++ b/systems/scripts/account_book.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+"""Lightweight in-memory book for open notes during testing."""
+
+from typing import Dict, List
+
+
+class AccountBook:
+    """Track open and closed notes for account validation."""
+
+    def __init__(self) -> None:
+        self.open_notes: List[Dict] = []
+        self.closed_notes: List[Dict] = []
+
+    def open_note(self, note: Dict) -> None:
+        """Register a new open note."""
+        self.open_notes.append(note)
+
+    def close_note(self, note: Dict) -> None:
+        """Move ``note`` from open to closed."""
+        if note in self.open_notes:
+            self.open_notes.remove(note)
+            self.closed_notes.append(note)
+
+    def get_open_notes(self) -> List[Dict]:
+        """Return a copy of open notes."""
+        return list(self.open_notes)

--- a/systems/scripts/candle_cache.py
+++ b/systems/scripts/candle_cache.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+import json
+import os
+import time
+from datetime import datetime, timezone
+from typing import Tuple
+
+import pandas as pd
+
+from systems.scripts.fetch_candles import fetch_kraken_range
+from systems.utils.resolve_symbol import (
+    to_tag as _to_tag,
+    live_path_csv,
+    sim_path_csv,
+)
+
+_HIST_CACHE: dict[str, Tuple[float, float]] = {}
+
+
+def to_tag(symbol: str) -> str:
+    """Return uppercase tag without separators for exchange symbol."""
+    return _to_tag(symbol)
+
+
+def load_sim_for_high_low(tag: str) -> Tuple[float, float]:
+    """Load historical low/high from SIM cache, cached in-memory."""
+    if tag in _HIST_CACHE:
+        return _HIST_CACHE[tag]
+    path = sim_path_csv(tag)
+    df = pd.read_csv(path)
+    low = float(df["low"].min())
+    high = float(df["high"].max())
+    _HIST_CACHE[tag] = (low, high)
+    return low, high
+
+
+def last_closed_hour_ts(now_utc: int) -> int:
+    """Return Unix timestamp of the last closed UTC hour."""
+    return int((now_utc // 3600 - 1) * 3600)
+
+
+def fetch_kraken_range_1h(symbol: str, end_ts: int, n: int = 720) -> pd.DataFrame:
+    """Fetch N Kraken hourly candles ending at ``end_ts`` inclusive."""
+    start_ts = end_ts - (n - 1) * 3600
+    return fetch_kraken_range(symbol, start_ts, end_ts)
+
+
+def refresh_live_kraken_720(symbol: str) -> None:
+    """Refresh last 720h from Kraken into live cache with locking."""
+    tag = to_tag(symbol)
+    end_ts = last_closed_hour_ts(int(time.time()))
+    path = live_path_csv(tag)
+    dir_path = os.path.dirname(path)
+    os.makedirs(dir_path, exist_ok=True)
+    lock_path = os.path.join(dir_path, f"{tag}.refresh.lock")
+    meta_path = os.path.join(dir_path, f"{tag}.meta.json")
+
+    # Check meta for up-to-date
+    if os.path.exists(meta_path):
+        try:
+            with open(meta_path, "r") as f:
+                meta = json.load(f)
+            if meta.get("last_refresh_ts") == end_ts:
+                print("[LIVE][REFRESH][SKIP] reason=up_to_date")
+                return
+        except Exception:
+            pass
+
+    now = int(time.time())
+    # Lock handling
+    if os.path.exists(lock_path):
+        mtime = os.path.getmtime(lock_path)
+        if now - mtime < 180:
+            print("[LIVE][REFRESH][SKIP] reason=locked")
+            return
+        try:
+            os.remove(lock_path)
+        except FileNotFoundError:
+            pass
+
+    try:
+        fd = os.open(lock_path, os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+        os.close(fd)
+    except FileExistsError:
+        print("[LIVE][REFRESH][SKIP] reason=locked")
+        return
+
+    try:
+        df = fetch_kraken_range_1h(symbol, end_ts, n=720)
+        rows = len(df)
+        iso_end = datetime.fromtimestamp(end_ts, tz=timezone.utc).strftime(
+            "%Y-%m-%dT%H:00Z"
+        )
+        print(
+            f"[LIVE][REFRESH] kraken symbol={symbol} tag={tag} end={iso_end} n={rows}"
+        )
+        tmp = path + ".tmp"
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        df.to_csv(tmp, index=False)
+        os.replace(tmp, path)
+        print(f"[LIVE][REFRESH] wrote={rows} path={path}")
+        if rows < 720:
+            print(f"[LIVE][REFRESH][WARN] exchange returned {rows} bars (<720)")
+        with open(meta_path, "w") as f:
+            json.dump({"last_refresh_ts": end_ts, "last_closed_ts": end_ts}, f)
+    finally:
+        try:
+            os.remove(lock_path)
+        except FileNotFoundError:
+            pass
+
+
+__all__ = [
+    "to_tag",
+    "live_path_csv",
+    "sim_path_csv",
+    "load_sim_for_high_low",
+    "last_closed_hour_ts",
+    "fetch_kraken_range_1h",
+    "refresh_live_kraken_720",
+]

--- a/systems/scripts/candle_loader.py
+++ b/systems/scripts/candle_loader.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+"""Shared candle loading utilities for sim and live engines."""
+
+from pathlib import Path
+from typing import Tuple
+
+import pandas as pd
+
+from systems.utils.addlog import addlog
+from systems.utils.resolve_symbol import (
+    candle_filename,
+    sim_path_csv,
+    live_path_csv,
+    to_tag,
+)
+
+
+def load_candles_df(
+    account: str,
+    market: str,
+    *,
+    live: bool = False,
+    verbose: int = 0,
+) -> Tuple[pd.DataFrame, int]:
+    """Return normalised candles for ``account``/``market``.
+
+    Parameters
+    ----------
+    account: str
+        Account name used for the candle filename.
+    market: str
+        Market pair in CCXT format, e.g. ``"SOL/USD"``.
+    live: bool, optional
+        If ``True``, load from ``data/live`` else ``data/sim``.
+    verbose: int, optional
+        Verbosity level forwarded to ``addlog``.
+
+    Returns
+    -------
+    Tuple[pd.DataFrame, int]
+        Normalised dataframe and number of duplicate rows removed.
+    """
+
+    csv_path = candle_filename(account, market, live=live)
+    if not Path(csv_path).exists():
+        tag = to_tag(market)
+        legacy = live_path_csv(tag) if live else sim_path_csv(tag)
+        if Path(legacy).exists():
+            addlog(
+                f"[DEPRECATED] Found legacy file {legacy}, use {csv_path}",
+                verbose_int=1,
+                verbose_state=verbose,
+            )
+        raise FileNotFoundError(
+            f"Missing data file: {csv_path}. Run: python bot.py --mode fetch --account {account} --market {market}"
+        )
+
+    df = pd.read_csv(csv_path)
+
+    ts_col = next(
+        (c for c in df.columns if str(c).lower() in ("timestamp", "time", "date")),
+        None,
+    )
+    if ts_col is None:
+        raise ValueError(f"No timestamp column in {csv_path}")
+
+    df[ts_col] = pd.to_numeric(df[ts_col], errors="coerce")
+    df = df.dropna(subset=[ts_col])
+    before = len(df)
+    df = df.sort_values(ts_col).drop_duplicates(subset=[ts_col], keep="last").reset_index(drop=True)
+    removed = before - len(df)
+
+    if ts_col != "timestamp":
+        df = df.rename(columns={ts_col: "timestamp"})
+
+    return df, removed
+

--- a/systems/scripts/candle_refresh.py
+++ b/systems/scripts/candle_refresh.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+"""Legacy utilities for refreshing candles (live mode deprecated)."""
+
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import List
+
+import pandas as pd
+
+from systems.scripts.fetch_candles import fetch_candles, COLUMNS
+from systems.utils.config import resolve_path
+
+try:  # pragma: no cover - optional dependency
+    from systems.utils.resolve_symbol import resolve_ccxt_symbols
+except Exception:  # pragma: no cover - fallback
+    def resolve_ccxt_symbols(settings, tag):  # type: ignore
+        return tag, None
+
+from systems.utils.addlog import addlog
+
+
+def get_raw_path(tag: str, ext: str = "csv") -> Path:
+    """Return the full path to the raw-data file for ``tag``."""
+
+    root = resolve_path("")
+    return root / "data" / "raw" / f"{tag}.{ext}"
+
+
+def _load_existing(path: Path) -> pd.DataFrame:
+    if path.exists():
+        df = pd.read_csv(path)
+        df["timestamp"] = pd.to_numeric(df["timestamp"], errors="coerce")
+        df = df.dropna(subset=["timestamp"]).sort_values("timestamp")
+        return df
+    return pd.DataFrame(columns=COLUMNS)
+
+
+def _merge_and_save(path: Path, existing: pd.DataFrame, new_frames: List[pd.DataFrame]) -> int:
+    combined = pd.concat([existing] + new_frames, ignore_index=True)
+    combined = combined.drop_duplicates(subset="timestamp").sort_values("timestamp")
+
+    ts = combined["timestamp"].to_numpy()
+    if len(ts) > 1:
+        gaps = (ts[1:] - ts[:-1]) != 3600
+        if gaps.any():
+            missing_spans = int(gaps.sum())
+            addlog(
+                f"[WARN] Post-merge gaps detected: {missing_spans} hour(s) missing",
+                verbose_state=True,
+            )
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    combined.to_csv(path, index=False)
+    return len(combined)
+
+
+def compute_missing_ranges(
+    candles_df: pd.DataFrame, start_ts: int, end_ts: int, interval_ms: int
+) -> List[tuple[int, int]]:
+    """Return a list of (start, end) tuples for missing candle ranges."""
+
+    interval_s = interval_ms // 1000
+    if candles_df.empty:
+        return [(start_ts, end_ts)]
+
+    windowed = candles_df[
+        (candles_df["timestamp"] >= start_ts)
+        & (candles_df["timestamp"] <= end_ts)
+    ]["timestamp"].sort_values()
+
+    ranges: List[tuple[int, int]] = []
+    current = start_ts
+    for ts in windowed:
+        if ts > current:
+            ranges.append((current, min(ts - interval_s, end_ts)))
+        current = ts + interval_s
+        if current > end_ts:
+            break
+
+    if current <= end_ts:
+        ranges.append((current, end_ts))
+
+    return ranges
+
+
+def refresh_to_last_closed_hour(
+    settings,
+    tag: str,
+    *,
+    exchange: str = "kraken",
+    lookback_hours: int = 72,
+    verbose: int = 1,
+) -> None:
+    """Deprecated helper retained for legacy scripts."""
+
+    raise RuntimeError(
+        "refresh_to_last_closed_hour is deprecated; use refresh_live_kraken_720 from candle_cache"
+    )
+

--- a/systems/scripts/data_loader.py
+++ b/systems/scripts/data_loader.py
@@ -1,0 +1,215 @@
+from __future__ import annotations
+
+import csv
+from collections import deque
+from pathlib import Path
+from typing import Dict, Any
+
+from systems.utils.config import resolve_path
+from systems.utils.addlog import addlog
+
+
+def _extract_candle_row(df, row_offset: int = 0) -> dict | None:
+    """Return a candle row from a dataframe if available."""
+    if df is None or df.empty or row_offset >= len(df):
+        return None
+
+    row = df.iloc[-(1 + row_offset)]
+    return {
+        "timestamp": int(row["timestamp"]),
+        "open": float(row["open"]),
+        "high": float(row["high"]),
+        "low": float(row["low"]),
+        "close": float(row["close"]),
+        "volume": float(row["volume"]),
+    }
+
+
+def get_candle_data_df(df, row_offset: int = 0) -> dict | None:
+    """Return candle data from a preloaded dataframe."""
+    try:
+        import pandas as pd  # noqa: F401
+    except Exception:  # pragma: no cover - pandas may not be installed
+        return None
+
+    return _extract_candle_row(df, row_offset)
+
+
+def get_candle_data_json(tag: str, row_offset: int = 0) -> dict | None:
+    """Load candle data from CSV for ``tag`` and return a row."""
+    try:
+        import pandas as pd
+    except Exception:  # pragma: no cover - pandas may not be installed
+        pd = None  # type: ignore
+
+    root = resolve_path("")
+    path: Path = root / "data" / "raw" / f"{tag.upper()}.csv"
+
+    if pd is None:
+        if not path.exists():
+            return None
+        with path.open(newline="") as f:
+            reader = csv.DictReader(f)
+            last_rows = deque(reader, maxlen=row_offset + 1)
+            if len(last_rows) <= row_offset:
+                return None
+            row = last_rows[-(1 + row_offset)]
+            return {
+                "timestamp": int(row["timestamp"]),
+                "open": float(row["open"]),
+                "high": float(row["high"]),
+                "low": float(row["low"]),
+                "close": float(row["close"]),
+                "volume": float(row["volume"]),
+            }
+
+    try:
+        df = pd.read_csv(path)
+    except FileNotFoundError:
+        return None
+
+    return _extract_candle_row(df, row_offset)
+
+
+def get_candle_data(tag: str, row_offset: int = 0, verbose: int = 0) -> Dict[str, Any]:
+    """Return the most recent candle for ``tag`` from the raw CSV data.
+
+    Parameters
+    ----------
+    tag : str
+        Market or ticker tag (e.g. ``"DOGEUSD"``). Case-insensitive.
+    row_offset : int, optional
+        Offset from the latest row. ``0`` selects the most recent candle,
+        ``1`` selects the candle before that, and so on.
+
+    Returns
+    -------
+    Dict[str, Any]
+        Dictionary containing ``timestamp``, ``open``, ``high``, ``low``,
+        ``close`` and ``volume`` as numeric types.
+
+    Raises
+    ------
+    FileNotFoundError
+        If the CSV file for ``tag`` does not exist.
+    IndexError
+        If the requested row does not exist in the file.
+    """
+
+    addlog(
+        f"[get_candle_data] tag={tag} row_offset={row_offset}",
+        verbose_int=3,
+        verbose_state=verbose,
+    )
+
+    root = resolve_path("")
+    path: Path = root / "data" / "raw" / f"{tag.upper()}.csv"
+
+    if not path.exists():
+        raise FileNotFoundError(f"Raw candle file not found: {path}")
+
+    # Try to use pandas for convenience if available
+    row = None
+    try:
+        import pandas as pd
+    except Exception:  # pragma: no cover - pandas may not be installed
+        pd = None  # type: ignore
+
+    if pd is not None:
+        df = pd.read_csv(path)
+        if row_offset >= len(df):
+            raise IndexError(
+                f"File {path} contains only {len(df)} rows, cannot access offset {row_offset}"
+            )
+        row = df.iloc[-(1 + row_offset)].to_dict()
+    else:
+        with path.open(newline="") as f:
+            reader = csv.DictReader(f)
+            last_rows = deque(reader, maxlen=row_offset + 1)
+            if len(last_rows) <= row_offset:
+                raise IndexError(
+                    f"File {path} does not contain row with offset {row_offset}"
+                )
+            row = last_rows[-(1 + row_offset)]
+
+    result = {
+        "timestamp": int(row["timestamp"]),
+        "open": float(row["open"]),
+        "high": float(row["high"]),
+        "low": float(row["low"]),
+        "close": float(row["close"]),
+        "volume": float(row["volume"]),
+    }
+
+    addlog(
+        f"[get_candle_data] result={result}",
+        verbose_int=3,
+        verbose_state=verbose,
+    )
+
+    return result
+
+
+def get_window_data(df, window: str, candle_offset: int = 0) -> dict | None:
+    """
+    Return window-relative wave structure data for current price.
+
+    Returns:
+        dict with:
+            - window: str (e.g. "3d")
+            - floor: float
+            - ceiling: float
+            - range: float
+            - price: float
+            - position_in_window: float (0 = floor, 1 = ceiling)
+    """
+    from systems.utils.time import parse_cutoff
+
+    if df is None or df.empty:
+        return None
+    try:
+        from systems.utils.time import parse_cutoff
+        window_duration = parse_cutoff(window)
+        num_candles = int(window_duration.total_seconds() // 3600)
+
+        curr_close = float(df.iloc[len(df) - candle_offset - 1]["close"])
+        past_close = float(
+            df.iloc[len(df) - candle_offset - num_candles]["close"]
+        )
+        # Normalize to % change: (current - past) / past
+        trend_direction_delta_window = (
+            ((curr_close - past_close) / past_close) * 100 if past_close else 0.0
+        )
+    except (IndexError, KeyError, ZeroDivisionError):
+        trend_direction_delta_window = 0.0
+
+    duration = parse_cutoff(window)
+    num_candles = int(duration.total_seconds() // 3600)
+
+    start_idx = max(0, len(df) - candle_offset - num_candles)
+    end_idx = len(df) - candle_offset if candle_offset != 0 else None
+    window_df = df.iloc[start_idx:end_idx]
+
+    if window_df.empty:
+        return None
+
+    try:
+        last_candle = df.iloc[-1 - candle_offset]
+        price = float(last_candle["close"])
+    except IndexError:
+        return None
+
+    floor = float(window_df["low"].min())
+    ceiling = float(window_df["high"].max())
+    range_val = ceiling - floor
+    position = (price - floor) / range_val if range_val != 0 else 0.5
+
+    return {
+        "window": window,
+        "floor": round(floor, 6),
+        "ceiling": round(ceiling, 6),
+        "range": round(range_val, 6),
+        "price": round(price, 6),
+        "position_in_window": round(position, 4),
+        "trend_direction_delta_window": trend_direction_delta_window,
+    }

--- a/systems/scripts/email_report.py
+++ b/systems/scripts/email_report.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+"""Send scheduled trading reports via email."""
+
+import json
+import io
+import smtplib
+import ssl
+from datetime import datetime, timedelta
+from email.message import EmailMessage
+from pathlib import Path
+
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import pandas as pd
+import yaml
+
+from systems.utils.config import load_settings
+from systems.scripts.view_log import view_log  # reuse plotting logic reference
+
+
+def send_email(to_email: str, subject: str, body: str, image_bytes: bytes) -> None:
+    """Send ``image_bytes`` as PNG attachment using Gmail SMTP credentials."""
+    with open("gmail_key.yaml", "r", encoding="utf-8") as fh:
+        creds = yaml.safe_load(fh)
+    msg = EmailMessage()
+    msg["Subject"] = subject
+    msg["From"] = creds["email"]
+    msg["To"] = to_email
+    msg.set_content(body)
+    msg.add_attachment(
+        image_bytes,
+        maintype="image",
+        subtype="png",
+        filename="report.png",
+    )
+    context = ssl.create_default_context()
+    with smtplib.SMTP_SSL(
+        creds["smtp_server"], creds["smtp_port"], context=context
+    ) as server:
+        server.login(creds["email"], creds["app_password"])
+        server.send_message(msg)
+
+
+def generate_report(ledger: str, timeframe: str) -> bytes | None:
+    """Generate a trading chart for ``ledger`` and return PNG bytes."""
+    log_path = Path(f"data/logs/{ledger}.json")
+    if not log_path.exists():
+        return None
+    events = json.loads(log_path.read_text())
+    if not events:
+        return None
+    now = datetime.utcnow()
+    cutoff = {
+        "day": now - timedelta(days=1),
+        "week": now - timedelta(weeks=1),
+        "month": now - timedelta(days=30),
+        "year": now - timedelta(days=365),
+    }[timeframe]
+    df = pd.DataFrame(events)
+    df["timestamp"] = pd.to_datetime(df["timestamp"])
+    df = df[df["timestamp"] >= cutoff]
+
+    fig, ax = plt.subplots()
+    buys = df[df["decision"] == "BUY"]
+    sells = df[df["decision"] == "SELL"]
+    flats = df[df["decision"] == "FLAT"]
+    ax.scatter(
+        buys["timestamp"],
+        [t[0]["price"] for t in buys["trades"]],
+        c="green",
+        marker="^",
+        label="Buy",
+    )
+    ax.scatter(
+        sells["timestamp"],
+        [t[0]["price"] for t in sells["trades"]],
+        c="red",
+        marker="v",
+        label="Sell",
+    )
+    ax.scatter(
+        flats["timestamp"],
+        [t[0]["price"] for t in flats["trades"]],
+        c="orange",
+        marker="v",
+        label="Flat",
+    )
+    ax.legend()
+    ax.set_title(f"{ledger} Report ({timeframe})")
+    ax.set_xlabel("Time")
+    ax.set_ylabel("Price")
+    plt.xticks(rotation=45)
+    plt.tight_layout()
+
+    buf = io.BytesIO()
+    plt.savefig(buf, format="png")
+    plt.close(fig)
+    buf.seek(0)
+    return buf.getvalue()
+
+
+def run_email_reports() -> None:
+    """Generate and send email reports for configured accounts."""
+    cfg = load_settings()
+    for acct, acct_cfg in cfg.get("accounts", {}).items():
+        reporting = acct_cfg.get("reporting", {})
+        email = reporting.get("email")
+        if not email:
+            continue
+        flags = [
+            ("day", reporting.get("daily")),
+            ("week", reporting.get("weekly")),
+            ("month", reporting.get("monthly")),
+            ("year", reporting.get("yearly")),
+        ]
+        for tf, enabled in flags:
+            if enabled:
+                img = generate_report(acct, tf)
+                if img:
+                    send_email(
+                        email,
+                        f"{acct} {tf} report",
+                        "See attached chart.",
+                        img,
+                    )
+
+
+if __name__ == "__main__":
+    run_email_reports()

--- a/systems/scripts/evaluate_buy.py
+++ b/systems/scripts/evaluate_buy.py
@@ -1,0 +1,210 @@
+from __future__ import annotations
+
+"""Buy evaluation driven by predictive pressures."""
+
+from math import atan, degrees
+from typing import Any, Dict
+
+import numpy as np
+
+from systems.utils.addlog import addlog
+
+
+# ---------------------------------------------------------------------------
+# Feature extraction and prediction rules
+# ---------------------------------------------------------------------------
+
+def classify_slope(slope: float, flat_band_deg: float = 10.0) -> int:
+    """Return -1 for down, 0 for flat, +1 for up."""
+    angle = degrees(atan(slope))
+    if -flat_band_deg <= angle <= flat_band_deg:
+        return 0
+    return 1 if angle > flat_band_deg else -1
+
+
+def compute_window_features(series, start: int, window_size: int) -> Dict[str, float]:
+    """Compute window statistics matching reference logic."""
+    end = start + window_size
+    sub = series.iloc[start:end]
+
+    closes = sub["close"].values
+    x = np.arange(len(closes))
+    slope = float(np.polyfit(x, closes, 1)[0]) if len(closes) > 1 else 0.0
+    volatility = float(np.std(closes)) if len(closes) else 0.0
+
+    low = float(sub["low"].min()) if "low" in sub else float(sub["close"].min())
+    high = float(sub["high"].max()) if "high" in sub else float(sub["close"].max())
+    rng = high - low
+
+    vol_mean = float(sub["volume"].mean()) if "volume" in sub else 0.0
+    mid = len(sub) // 2
+    if mid and "volume" in sub:
+        early = float(sub["volume"].iloc[:mid].mean())
+        late = float(sub["volume"].iloc[mid:].mean())
+        volume_skew = ((late - early) / early) if early else 0.0
+    else:
+        volume_skew = 0.0
+
+    level = float(sub.iloc[0]["close"]) if len(sub) else 0.0
+    exit_price = float(sub.iloc[-1]["close"]) if len(sub) else 0.0
+    pct_change = (exit_price - level) / level if level else 0.0
+
+    return {
+        "slope": slope,
+        "volatility": volatility,
+        "range": rng,
+        "volume_mean": vol_mean,
+        "volume_skew": volume_skew,
+        "pct_change": pct_change,
+    }
+
+
+def rule_predict(features: Dict[str, float], cfg: Dict[str, float]) -> int:
+    """Classify next window move with multi-feature rules."""
+    slope = features.get("slope", 0.0)
+    rng = features.get("range", 0.0)
+
+    slope_cls = classify_slope(slope, cfg.get("flat_band_deg", 10.0))
+    if slope_cls == 0:
+        return 0
+    if rng < cfg.get("range_min", 0.0):
+        return 0
+
+    skew = features.get("volume_skew", 0.0)
+    skew_bias = cfg.get("volume_skew_bias", 0.0)
+    if skew > skew_bias and slope_cls > 0:
+        return 1
+    if skew < -skew_bias and slope_cls < 0:
+        return -1
+
+    pct = features.get("pct_change", 0.0)
+    strong = cfg.get("strong_move_threshold", 0.0)
+    if pct >= strong:
+        return 2
+    if pct > 0:
+        return 1
+    if pct <= -strong:
+        return -2
+    if pct < 0:
+        return -1
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# Main evaluator
+# ---------------------------------------------------------------------------
+
+def evaluate_buy(
+    ctx: Dict[str, Any],
+    t: int,
+    series,
+    *,
+    cfg: Dict[str, Any],
+    runtime_state: Dict[str, Any],
+):
+    """Return sizing and metadata for a buy signal."""
+
+    window_name = "strategy"
+    strategy = cfg or runtime_state.get("strategy", {})
+    window_size = int(strategy.get("window_size", 0))
+
+    verbose = runtime_state.get("verbose", 0)
+
+    pressures = runtime_state.setdefault("pressures", {"buy": {}, "sell": {}})
+
+    # Compute features for this window and store for other components
+    features = compute_window_features(series, t, window_size)
+    runtime_state.setdefault("last_features", {})[window_name] = features
+
+    buy_p = pressures["buy"].get(window_name, 0.0)
+    sell_p = pressures["sell"].get(window_name, 0.0)
+    max_p = strategy.get("max_pressure", 1.0)
+
+    pred = rule_predict(features, strategy)
+    slope_cls = classify_slope(
+        features.get("slope", 0.0), strategy.get("flat_band_deg", 10.0)
+    )
+
+    if pred > 0:
+        buy_p = min(max_p, buy_p + 1)
+        sell_p = max(0.0, sell_p - 2)
+    elif pred < 0:
+        sell_p = min(max_p, sell_p + 1)
+        buy_p = max(0.0, buy_p - 2)
+    else:
+        if slope_cls == 0:
+            sell_p = min(max_p, sell_p + 0.5)
+            buy_p = max(0.0, buy_p - 0.5)
+        else:
+            buy_p = max(0.0, buy_p - 0.5)
+            sell_p = max(0.0, sell_p - 0.5)
+
+    pressures["buy"][window_name] = buy_p
+    pressures["sell"][window_name] = sell_p
+    if verbose >= 2:
+        addlog(
+            f"[PRESSURE][{window_name}] buy={buy_p:.1f} sell={sell_p:.1f} pred={pred} slope_cls={slope_cls}",
+            verbose_int=2,
+            verbose_state=verbose,
+        )
+
+    buy_trigger = strategy.get("buy_trigger", 0.0)
+
+    if buy_p < buy_trigger:
+        if verbose >= 1:
+            addlog(
+                f"[HOLD][BUY {window_size}h] need={buy_trigger:.2f}, have={buy_p:.2f}, sell_p={sell_p:.2f}",
+                verbose_int=1,
+                verbose_state=verbose,
+            )
+        return False
+
+    fraction = buy_p / max_p if max_p else 0.0
+    aggressiveness = strategy.get("buy_percent_aggressiveness", 1.0)
+    fraction *= aggressiveness
+    fraction = min(fraction, 1.0)
+
+    capital = runtime_state.get("capital", 0.0)
+    limits = runtime_state.get("limits", {})
+    max_sz = float(limits.get("max_note_usdt", capital))
+    min_sz = float(limits.get("min_note_size", 0.0))
+
+    inv_frac = strategy.get("investment_fraction", 1.0)
+    raw = capital * fraction * inv_frac
+    size_usd = min(raw, capital, max_sz)
+    if size_usd != raw:
+        addlog(
+            f"[CLAMP] size=${raw:.2f} → ${size_usd:.2f} (cap=${capital:.2f}, max=${max_sz:.2f})",
+            verbose_int=2,
+            verbose_state=verbose,
+        )
+    if size_usd < min_sz:
+        addlog(
+            f"[SKIP][{window_name} {window_size}] size=${size_usd:.2f} < min=${min_sz:.2f}",
+            verbose_int=2,
+            verbose_state=verbose,
+        )
+        return False
+
+    addlog(
+        f"[BUY][{window_name} {window_size}] pressure={buy_p:.1f}/{max_p:.1f} "
+        f"buy_frac={fraction:.2f} agg={aggressiveness:.2f} spend=${size_usd:.2f}",
+        verbose_int=1,
+        verbose_state=verbose,
+    )
+
+    pressures["buy"][window_name] = 0.0
+
+    result = {
+        "size_usd": size_usd,
+        "window_name": window_name,
+        "window_size": window_size,
+        "p_buy": fraction,
+        "unlock_p": None,
+    }
+    candle = series.iloc[t]
+    if "timestamp" in series.columns:
+        result["created_ts"] = int(candle.get("timestamp"))
+    result["created_idx"] = t
+
+    return result

--- a/systems/scripts/evaluate_sell.py
+++ b/systems/scripts/evaluate_sell.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+"""Sell evaluation based on predictive pressures."""
+
+from typing import Any, Dict, List
+
+from systems.scripts.evaluate_buy import (
+    classify_slope,
+    compute_window_features,
+)
+from systems.utils.addlog import addlog
+
+
+def evaluate_sell(
+    ctx: Dict[str, Any],
+    t: int,
+    series,
+    *,
+    cfg: Dict[str, Any],
+    open_notes: List[Dict[str, Any]],
+    runtime_state: Dict[str, Any] | None = None,
+) -> List[Dict[str, Any]]:
+    """Return a list of notes to sell on this candle."""
+
+    runtime_state = runtime_state or {}
+    window_name = "strategy"
+    strategy = cfg or runtime_state.get("strategy", {})
+    window_size = int(strategy.get("window_size", 0))
+
+    verbose = runtime_state.get("verbose", 0)
+
+    pressures = runtime_state.setdefault("pressures", {"buy": {}, "sell": {}})
+    sell_p = pressures["sell"].get(window_name, 0.0)
+    buy_p = pressures["buy"].get(window_name, 0.0)
+    max_p = strategy.get("max_pressure", 1.0)
+    results: List[Dict[str, Any]] = []
+    window_notes = open_notes
+    n_notes = len(window_notes)
+    candle = series.iloc[t]
+    price = float(candle["close"])
+
+    features = runtime_state.get("last_features", {}).get(window_name)
+    if features is None:
+        features = compute_window_features(series, t, window_size)
+    slope = features.get("slope", 0.0)
+    def roi_now(note: Dict[str, Any]) -> float:
+        buy = note.get("entry_price", 0.0)
+        return (price - buy) / buy if buy else 0.0
+
+    window_notes.sort(key=roi_now, reverse=True)
+
+    sell_trigger = strategy.get("sell_trigger", 0.0)
+
+    if sell_p >= max_p and window_notes:
+        all_count = strategy.get("all_sell_count", n_notes)
+        k = min(all_count, n_notes)
+        if k <= 0:
+            return []
+        results = window_notes[:k]
+        for n in results:
+            n["sell_mode"] = "all"
+        pressures["sell"][window_name] = 0.0
+        addlog(
+            f"[SELL][{window_name} {window_size}] mode=all count={k}/{n_notes}",
+            verbose_int=1,
+            verbose_state=verbose,
+        )
+        return results
+
+    slope_cls = classify_slope(
+        slope, strategy.get("flat_band_deg", 10.0)
+    )
+    if slope_cls == 0 and sell_p >= sell_trigger:
+        if window_notes:
+            flat_percent = strategy.get("flat_sell_percent", 0.0)
+            k = int(round(n_notes * flat_percent))
+            if k <= 0:
+                return []
+            results = window_notes[:k]
+            for n in results:
+                n["sell_mode"] = "flat"
+            pressures["sell"][window_name] = 0.0
+            addlog(
+                f"[SELL][{window_name} {window_size}] mode=flat count={k}/{n_notes} "
+                f"flat_percent={flat_percent:.2%}",
+                verbose_int=1,
+                verbose_state=verbose,
+            )
+            return results
+        addlog(
+            f"[HOLD][{window_name} {window_size}] flat sell condition met but no notes",
+            verbose_int=2,
+            verbose_state=verbose,
+        )
+        return []
+
+    addlog(
+        f"[HOLD][{window_name} {window_size}] need={sell_trigger:.2f}, have={sell_p:.2f}, buy_p={buy_p:.2f}",
+        verbose_int=2,
+        verbose_state=verbose,
+    )
+
+    return []
+

--- a/systems/scripts/execution_handler.py
+++ b/systems/scripts/execution_handler.py
@@ -1,0 +1,344 @@
+import time
+import requests
+import hashlib
+import hmac
+import base64
+from urllib.parse import urlencode
+
+from systems.scripts.kraken_utils import load_kraken_keys
+from systems.scripts.kraken_utils import get_live_price
+from systems.utils.addlog import addlog
+from systems.utils.resolve_symbol import split_tag
+from systems.utils.quote_norm import norm_quote
+from systems.scripts.trade_apply import apply_buy
+
+
+def fetch_price_data(symbol: str) -> dict:
+    resp = requests.get(
+        f"https://api.kraken.com/0/public/Ticker?pair={symbol}", timeout=10
+    )
+    result = resp.json().get("result", {})
+    return next(iter(result.values()), {})
+
+
+def now_utc_timestamp() -> int:
+    return int(time.time())
+
+
+
+def _kraken_request(endpoint: str, data: dict, api_key: str, api_secret: str) -> dict:
+    url_path = f"/0/private/{endpoint}"
+    url = f"https://api.kraken.com{url_path}"
+
+    nonce = str(int(time.time() * 1000))
+    data["nonce"] = nonce
+
+    post_data = urlencode(data)
+    encoded = (nonce + post_data).encode()
+    message = url_path.encode() + hashlib.sha256(encoded).digest()
+
+    signature = hmac.new(base64.b64decode(api_secret), message, hashlib.sha512)
+    sig_digest = base64.b64encode(signature.digest())
+
+    headers = {
+        "API-Key": api_key,
+        "API-Sign": sig_digest.decode()
+    }
+
+    resp = requests.post(url, headers=headers, data=data, timeout=10)
+    result = resp.json()
+    if "error" in result and result["error"]:
+        raise Exception(f"Kraken API error: {result['error']}")
+    return result
+
+def place_order(
+    order_type: str,
+    pair_code: str,
+    fiat_symbol: str,
+    amount: float,
+    ledger_name: str,
+    wallet_code: str,
+    verbose: int = 0,
+) -> dict:
+    api_key, api_secret = load_kraken_keys()
+    balance_resp = _kraken_request("Balance", {}, api_key, api_secret).get("result", {})
+    balance = {k: float(v) for k, v in balance_resp.items()}
+
+    price_data = fetch_price_data(pair_code)
+    price = float(price_data.get("c", [0])[0])
+    coin_amount = round(amount / price, 8)
+    usd_amount = coin_amount * price
+
+    if order_type.lower() == "buy":
+        available_usd = float(balance.get(fiat_symbol, 0.0))
+        addlog(f"[DEBUG] Balance: {balance}", verbose_int=1, verbose_state=verbose)
+        addlog(f"[DEBUG] Using fiat_symbol = {fiat_symbol}", verbose_int=1, verbose_state=verbose)
+        addlog(
+            f"[DEBUG] available_usd = {available_usd} | trying to spend = {amount}",
+            verbose_int=1,
+            verbose_state=verbose,
+        )
+        if available_usd < amount:
+            addlog(
+                f"[SKIP] Insufficient {fiat_symbol}",
+                verbose_int=1,
+                verbose_state=verbose,
+            )
+            return {}
+        addlog(
+            f"[BUY ATTEMPT] {fiat_symbol} available: ${available_usd:.2f}, attempting to buy ${amount:.2f}",
+            verbose_int=3,
+            verbose_state=verbose,
+        )
+    else:
+        addlog(
+            f"[SELL ATTEMPT] Attempting to sell ${usd_amount:.2f} worth of {pair_code}",
+            verbose_int=3,
+            verbose_state=verbose,
+        )
+
+    try:
+        order_resp = _kraken_request(
+            "AddOrder",
+            {
+                "pair": pair_code,
+                "type": order_type,
+                "ordertype": "market",
+                "volume": coin_amount,
+                "trades": True,
+            },
+            api_key,
+            api_secret,
+        )
+    except Exception as e:
+        err_msg = str(e)
+        if "EOrder:Insufficient funds" in err_msg:
+            addlog(
+                "[SKIP] Kraken rejected order — insufficient funds",
+                verbose_int=1,
+                verbose_state=verbose,
+            )
+            return {}
+        raise
+
+    txid_list = order_resp.get("result", {}).get("txid")
+    txid = txid_list[0] if txid_list else None
+    if not txid:
+        raise Exception(f"{order_type.capitalize()} order failed — no txid returned")
+
+    if order_type.lower() == "buy":
+        post_balance = _kraken_request("Balance", {}, api_key, api_secret).get("result", {})
+        new_fiat_balance = float(post_balance.get(fiat_symbol, 0.0))
+        spent = float(balance.get(fiat_symbol, 0.0)) - new_fiat_balance
+        if spent < amount * 0.8:
+            for code, prev_amt in balance.items():
+                if code == fiat_symbol:
+                    continue
+                drop = float(prev_amt) - float(post_balance.get(code, 0.0))
+                if drop > amount * 0.8:
+                    addlog(
+                        f"[ERROR] Fiat mismatch: {code} decreased instead of {fiat_symbol}",
+                        verbose_int=1,
+                        verbose_state=verbose,
+                    )
+                    break
+            else:
+                addlog(
+                    f"[ERROR] Fiat mismatch: {fiat_symbol} balance unchanged after buy",
+                    verbose_int=1,
+                    verbose_state=verbose,
+                )
+
+    return {
+        "txid": txid,
+        "volume": coin_amount,
+        "price": price,
+        "filled_amount": coin_amount,
+        "avg_price": price,
+        "timestamp": now_utc_timestamp(),
+    }
+
+def execute_buy(
+    client,
+    *,
+    pair_code: str,
+    price: float,
+    amount_usd: float,
+    ledger_name: str,
+    wallet_code: str,
+    verbose: int = 0,
+) -> dict:
+    """Place a real buy order and normalise the result structure.
+
+    Parameters are kept for API compatibility; ``client`` and ``price`` are
+    currently unused as ``place_order`` pulls pricing from Kraken directly.
+    """
+
+    expected_raw = "USDC" if ledger_name.upper().endswith("USDC") else "USD"
+    _, fiat_symbol = split_tag(pair_code)
+    got_raw = fiat_symbol
+    exp = norm_quote(expected_raw)
+    got = norm_quote(got_raw)
+    if exp != got:
+        addlog(
+            f"[DEBUG][QUOTE_RAW] expected_raw={expected_raw} got_raw={got_raw}",
+            verbose_int=1,
+            verbose_state=verbose,
+        )
+        addlog(
+            f"[ABORT][QUOTE_MISMATCH] ledger={ledger_name} expected={exp} got={got} pair={pair_code}",
+            verbose_int=1,
+            verbose_state=verbose,
+        )
+        return {
+            "error": "QUOTE_MISMATCH",
+            "expected": exp,
+            "got": got,
+            "pair": pair_code,
+        }
+
+    result = place_order(
+        "buy",
+        pair_code,
+        fiat_symbol,
+        amount_usd,
+        ledger_name,
+        wallet_code,
+        verbose,
+    )
+    if (
+        not result
+        or result.get("filled_amount", 0) <= 0
+        or result.get("price", 0) <= 0
+        or not result.get("txid")
+        or not result.get("timestamp")
+    ):
+        addlog(
+            f"[SKIP] Trade result invalid — not logging to ledger for {ledger_name}",
+            verbose_int=1,
+            verbose_state=verbose,
+        )
+        return
+    return {
+        "filled_amount": result.get("filled_amount", 0.0),
+        "avg_price": result.get("price", 0.0),
+        "timestamp": result.get("timestamp"),
+    }
+
+
+def process_buy_signal(
+    *,
+    buy_signal: dict,
+    ledger,
+    t: int,
+    runtime_state: dict,
+    pair_code: str,
+    price: float,
+    ledger_name: str,
+    wallet_code: str,
+    verbose: int = 0,
+):
+    """Execute a buy and record it, setting the rebound gate on success."""
+
+    result = execute_buy(
+        None,
+        pair_code=pair_code,
+        price=price,
+        amount_usd=buy_signal.get("size_usd", 0.0),
+        ledger_name=ledger_name,
+        wallet_code=wallet_code,
+        verbose=verbose,
+    )
+    if not result or result.get("error"):
+        return result
+
+    note = apply_buy(
+        ledger=ledger,
+        window_name=buy_signal.get("window_name", ""),
+        t=t,
+        meta=buy_signal,
+        result=result,
+        state=runtime_state,
+    )
+
+    window_name = note.get("window_name")
+    unlock_p = buy_signal.get("unlock_p")
+    if window_name and unlock_p is not None:
+        runtime_state.setdefault("buy_unlock_p", {})[window_name] = unlock_p
+
+    msg = (
+        f"[BUY][EXECUTED][{window_name} {note.get('window_size')}] "
+        f"qty={note.get('entry_amount'):.6f} at ${note.get('entry_price'):.4f} "
+        f"spend=${note.get('entry_usdt'):.2f} target=${note.get('target_price'):.4f} "
+        f"p={note.get('p_buy'):.3f} note_id={note.get('id')}"
+    )
+    addlog(msg, verbose_int=1, verbose_state=verbose)
+
+    return result
+
+
+def execute_sell(
+    client,
+    *,
+    pair_code: str,
+    coin_amount: float,
+    price: float | None = None,
+    ledger_name: str,
+    verbose: int = 0,
+) -> dict:
+    """Place a real sell order and normalise the result structure.
+
+    ``price`` is optional and, if absent, the current live price is fetched to
+    estimate USD notional.
+    """
+    sell_price = price if price is not None else get_live_price(pair_code)
+    usd_amount = coin_amount * sell_price
+    _, fiat_symbol = split_tag(pair_code)
+    expected_raw = "USDC" if ledger_name.upper().endswith("USDC") else "USD"
+    got_raw = fiat_symbol
+    exp = norm_quote(expected_raw)
+    got = norm_quote(got_raw)
+    if exp != got:
+        addlog(
+            f"[DEBUG][QUOTE_RAW] expected_raw={expected_raw} got_raw={got_raw}",
+            verbose_int=1,
+            verbose_state=verbose,
+        )
+        addlog(
+            f"[ABORT][QUOTE_MISMATCH] ledger={ledger_name} expected={exp} got={got} pair={pair_code}",
+            verbose_int=1,
+            verbose_state=verbose,
+        )
+        return {
+            "error": "QUOTE_MISMATCH",
+            "expected": exp,
+            "got": got,
+            "pair": pair_code,
+        }
+    result = place_order(
+        "sell",
+        pair_code,
+        fiat_symbol,
+        usd_amount,
+        ledger_name,
+        "",
+        verbose,
+    )
+    if (
+        not result
+        or result.get("filled_amount", 0) <= 0
+        or result.get("price", 0) <= 0
+        or not result.get("txid")
+        or not result.get("timestamp")
+    ):
+        addlog(
+            f"[SKIP] Trade result invalid — not logging to ledger for {ledger_name}",
+            verbose_int=1,
+            verbose_state=verbose,
+        )
+        return
+    return {
+        "filled_amount": result.get("filled_amount", 0.0),
+        "avg_price": result.get("price", 0.0),
+        "timestamp": result.get("timestamp"),
+    }

--- a/systems/scripts/fetch_candles.py
+++ b/systems/scripts/fetch_candles.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+"""Unified candle fetching utilities."""
+
+import os
+import time
+from typing import List
+
+import ccxt
+import pandas as pd
+
+from systems.utils.config import resolve_path
+
+COLUMNS = ["timestamp", "open", "high", "low", "close", "volume"]
+
+
+def _fetch_kraken(symbol: str, start_ms: int, end_ms: int) -> List[List]:
+    exchange = ccxt.kraken({"enableRateLimit": True})
+    limit = min(720, int((end_ms - start_ms) // 3600000) + 1)
+    ohlcv = exchange.fetch_ohlcv(symbol, timeframe="1h", since=start_ms, limit=limit)
+    return [row for row in ohlcv if row and start_ms <= row[0] <= end_ms]
+
+
+def _fetch_binance(symbol: str, start_ms: int, end_ms: int) -> List[List]:
+    """Forward pagination with simple retries."""
+
+    exchange = ccxt.binance({"enableRateLimit": True})
+    rows: List[List] = []
+    limit = 1000
+    page_idx = 0
+    verbose = os.environ.get("FETCH_DEBUG", "0") == "1"
+    MAX_EMPTY_RETRY = 3
+    PARTIAL_RETRY_ON_LEN_LT = limit
+    SLEEP_ON_RETRY_SEC = 0.5
+
+    since = start_ms
+    last_progress_ts: int | None = None
+
+    def _vprint(msg: str) -> None:
+        if verbose:
+            print(msg)
+
+    while since <= end_ms:
+        page = exchange.fetch_ohlcv(symbol, timeframe="1h", since=since, limit=limit) or []
+        page_len = len(page)
+
+        empty_retries = 0
+        while page_len == 0 and empty_retries < MAX_EMPTY_RETRY:
+            _vprint(
+                f"[FETCH][BINANCE] page={page_idx} since={since} EMPTY (retry {empty_retries+1}/{MAX_EMPTY_RETRY})"
+            )
+            time.sleep(SLEEP_ON_RETRY_SEC)
+            page = exchange.fetch_ohlcv(symbol, timeframe="1h", since=since, limit=limit) or []
+            page_len = len(page)
+            empty_retries += 1
+
+        if page_len == 0:
+            _vprint(f"[FETCH][BINANCE] floor or no data at since={since} → stop")
+            break
+
+        did_partial_retry = False
+        if page_len < PARTIAL_RETRY_ON_LEN_LT:
+            _vprint(
+                f"[FETCH][BINANCE] page={page_idx} got {page_len}/{limit} rows → partial, retrying once"
+            )
+            time.sleep(SLEEP_ON_RETRY_SEC)
+            page2 = exchange.fetch_ohlcv(symbol, timeframe="1h", since=since, limit=limit) or []
+            if len(page2) > page_len:
+                page = page2
+                page_len = len(page)
+                did_partial_retry = True
+
+        first_ts = page[0][0]
+        last_ts = page[-1][0]
+        filtered = [r for r in page if start_ms <= r[0] <= end_ms]
+        rows.extend(filtered)
+        page_idx += 1
+
+        _vprint(
+            f"[FETCH][BINANCE] page={page_idx:05d} since={since} first={first_ts} last={last_ts} rows={page_len} total={len(rows)}"
+            f"{' (partial→retry improved)' if did_partial_retry else ''}"
+        )
+
+        next_since = last_ts + 1
+        if last_progress_ts is not None and next_since <= last_progress_ts:
+            _vprint(
+                f"[FETCH][BINANCE] no progress (next_since={next_since} <= last_progress={last_progress_ts}) → stop"
+            )
+            break
+        last_progress_ts = next_since
+        since = next_since
+
+    return rows
+
+
+def _rows_to_df(rows: List[List], start_ts: int, end_ts: int) -> pd.DataFrame:
+    df = pd.DataFrame(rows, columns=COLUMNS)
+    if not df.empty:
+        df["timestamp"] = (
+            pd.to_datetime(df["timestamp"], unit="ms", utc=True).astype("int64") // 1_000_000_000
+        )
+        df["timestamp"] = (df["timestamp"] // 3600) * 3600
+        df = df[(df["timestamp"] >= start_ts) & (df["timestamp"] <= end_ts)]
+        df[COLUMNS] = df[COLUMNS].apply(pd.to_numeric, errors="coerce")
+        df = df.dropna(subset=["timestamp"])
+    return df
+
+
+def fetch_kraken_range(symbol: str, start_ts: int, end_ts: int) -> pd.DataFrame:
+    """Fetch Kraken candles between ``start_ts`` and ``end_ts`` (seconds)."""
+    rows = _fetch_kraken(symbol, int(start_ts * 1000), int(end_ts * 1000))
+    return _rows_to_df(rows, start_ts, end_ts)
+
+
+def fetch_candles(symbol: str, start: int, end: int, source: str) -> pd.DataFrame:
+    """Fetch candles for ``symbol`` between ``start`` and ``end`` from ``source``.
+
+    Parameters
+    ----------
+    symbol: str
+        Market symbol understood by the exchange (e.g., ``"SOL/USD"``).
+    start: int
+        Start timestamp in seconds since epoch.
+    end: int
+        End timestamp in seconds since epoch.
+    source: str
+        ``"kraken"`` or ``"binance"``.
+    """
+
+    src = source.lower()
+    if src == "kraken":
+        rows = _fetch_kraken(symbol, int(start * 1000), int(end * 1000))
+    elif src == "binance":
+        rows = _fetch_binance(symbol, int(start * 1000), int(end * 1000))
+    else:
+        raise ValueError(f"Unknown source '{source}'")
+    return _rows_to_df(rows, start, end)
+
+
+def fetch_binance_full_history_1h(symbol: str) -> pd.DataFrame:
+    """Return all available Binance 1h candles for ``symbol``."""
+    now = int(time.time())
+    end_ts = (now // 3600 - 1) * 3600
+    rows = _fetch_binance(symbol, 0, end_ts * 1000)
+    return _rows_to_df(rows, 0, end_ts)
+
+
+def fetch_kraken_last_n_hours_1h(symbol: str, n: int = 720) -> pd.DataFrame:
+    """Return up to ``n`` latest Kraken 1h candles for ``symbol``."""
+    now = int(time.time())
+    end_ts = (now // 3600 - 1) * 3600
+    start_ts = end_ts - (n - 1) * 3600
+    rows = _fetch_kraken(symbol, start_ts * 1000, end_ts * 1000)
+    return _rows_to_df(rows, start_ts, end_ts)
+
+
+def load_coin_csv(coin: str) -> pd.DataFrame:
+    """Load historical candles for ``coin`` from ``data/raw``."""
+
+    root = resolve_path("")
+    path = root / "data" / "raw" / f"{coin.upper()}.csv"
+    if not path.exists():  # pragma: no cover - file presence check
+        raise FileNotFoundError(f"Candle file not found: {path}")
+    return pd.read_csv(path)
+

--- a/systems/scripts/handle_top_of_hour.py
+++ b/systems/scripts/handle_top_of_hour.py
@@ -1,0 +1,489 @@
+from __future__ import annotations
+
+"""Execute trading logic at the top of each hour."""
+
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict
+
+import json
+import pandas as pd
+
+from systems.scripts.evaluate_buy import evaluate_buy
+from systems.scripts.evaluate_sell import evaluate_sell
+from systems.scripts.data_loader import get_window_data
+from systems.scripts.kraken_utils import get_live_price
+from systems.scripts.execution_handler import (
+    execute_buy,
+    execute_sell,
+    load_or_fetch_snapshot,
+)
+from systems.scripts.ledger import load_ledger, save_ledger
+from systems.scripts.trade_apply import apply_buy, apply_sell
+from systems.utils.addlog import addlog, send_telegram_message
+from systems.scripts.send_top_hour_report import send_top_hour_report
+from systems.utils.config import resolve_path
+from systems.utils.top_hour_report import format_top_of_hour_report
+from systems.utils.resolve_symbol import split_tag
+from systems.scripts.window_utils import get_trade_params
+from systems.scripts.candle_refresh import refresh_to_last_closed_hour
+
+
+def handle_top_of_hour(
+    *,
+    tick: int | datetime,
+    sim: bool,
+    settings: dict | None = None,
+    candle: dict | None = None,
+    ledger: Ledger | None = None,
+    ledger_config: dict | None = None,
+    **kwargs: Any,
+) -> None:
+    """Run buy/sell evaluations for all windows on an hourly boundary.
+
+    Parameters
+    ----------
+    tick:
+        Current tick index.
+    candle:
+        Candle data for this tick.
+    ledger:
+        Ledger tracking open and closed notes.
+    ledger_config:
+        Ledger-specific configuration.
+    sim:
+        ``True`` when running in simulation mode. Live logic is not yet
+        implemented.
+    **kwargs:
+        Additional context. The simulation engine passes a DataFrame ``df`` and
+        ``offset`` for window calculations along with a mutable ``state``
+        dictionary containing capital and cooldown counters.
+    """
+
+    if not sim:
+        if settings is None:
+            return
+
+        root: Path = resolve_path("")
+        cooldown_path = root / "data" / "tmp" / "cooldowns.json"
+        if cooldown_path.exists():
+            with open(cooldown_path, "r") as f:
+                cooldowns = json.load(f)
+        else:
+            cooldowns = {}
+
+        dry_run = kwargs.get("dry", False)
+        client = kwargs.get("client")
+
+        general_cfg = settings.get("general_settings", {})
+        verbose = general_cfg.get("verbose", 0)
+
+        for ledger_name, ledger_cfg in settings.get("ledger_settings", {}).items():
+            tag = ledger_cfg["tag"]
+            pair_code = ledger_cfg.get("kraken_pair", tag)
+            refresh_to_last_closed_hour(
+                settings,
+                tag,
+                exchange="kraken",
+                lookback_hours=72,
+                verbose=verbose,
+            )
+            _, quote = split_tag(tag)
+            wallet_code = ledger_cfg["wallet_code"]
+            window_settings = ledger_cfg.get("window_settings", {})
+            triggered_strategies = {wn.title(): False for wn in window_settings}
+            strategy_summary: dict[str, dict] = {}
+            ledger = load_ledger(ledger_name, tag=ledger_cfg["tag"])
+
+            snapshot = load_or_fetch_snapshot(ledger_name)
+            if not snapshot:
+                addlog(
+                    "[ERROR] Kraken snapshot missing — cannot proceed in live mode.",
+                    verbose_int=1,
+                    verbose_state=True,
+                )
+                continue
+            balance = snapshot.get("balance", {})
+
+            price = get_live_price(kraken_pair=pair_code)
+
+            current_ts = (
+                int(tick.timestamp()) if isinstance(tick, datetime) else int(tick)
+            )
+
+            metadata = ledger.get_metadata()
+            ledger_cooldowns = cooldowns.get(ledger_name, {})
+            last_buy_tick = ledger_cooldowns.get("last_buy_tick", {})
+            last_sell_tick = ledger_cooldowns.get("last_sell_tick", {})
+
+            for window_name, window_cfg in window_settings.items():
+                addlog(
+                    f"[EVAL] {ledger_name} | {tag} | {window_name} window → evaluating",
+                    verbose_int=3,
+                    verbose_state=True,
+                )
+
+                buy_count = 0
+                sell_count = 0
+
+                try:
+                    df = pd.read_csv(root / "data" / "raw" / f"{tag}.csv")
+                except Exception:
+                    df = None
+
+                wave = get_window_data(
+                    df,
+                    window=window_cfg["window_size"],
+                    candle_offset=0,
+                )
+
+                if wave:
+                    trade = get_trade_params(
+                        current_price=price,
+                        window_high=wave["ceiling"],
+                        window_low=wave["floor"],
+                        config=window_cfg,
+                    )
+                    if verbose >= 3:
+                        addlog(
+                            f"[DEBUG][LIVE BUY] Window={window_name} price={price:.6f} pos_pct={trade['pos_pct']:.2f} "
+                            f"ceiling={wave['ceiling']:.6f} floor={wave['floor']:.6f} "
+                            f"buy_mult={trade['buy_multiplier']:.2f} "
+                            f"buy_cd_mult={trade['buy_cooldown_multiplier']:.2f}",
+                            verbose_int=3,
+                            verbose_state=verbose,
+                        )
+                    if trade["in_dead_zone"]:
+                        addlog(
+                            f"[SKIP] {ledger_name} | {tag} | {window_name} → In dead zone",
+                            verbose_int=3,
+                            verbose_state=True,
+                        )
+                        continue
+
+                    buy_cd_base = window_cfg.get("buy_cooldown", 0) * 3600
+                    buy_cd = int(
+                        buy_cd_base
+                        / trade["buy_cooldown_multiplier"]
+                    )
+                    last_buy = last_buy_tick.get(window_name, float("-inf"))
+                    if dry_run or current_ts - last_buy >= buy_cd:
+                        available = float(balance.get(quote, 0.0))
+                        base_invest = available * window_cfg.get(
+                            "investment_fraction", 0
+                        )
+                        adjusted_invest = base_invest * trade["buy_multiplier"]
+                        max_usd = general_cfg.get("max_note_usdt", adjusted_invest)
+                        min_usd = general_cfg.get("minimum_note_size", 0.0)
+                        invest = min(adjusted_invest, max_usd)
+                        if invest >= min_usd and invest <= available and invest > 0:
+                            result = execute_buy(
+                                client=client,
+                                pair_code=pair_code,
+                                price=price,
+                                amount_usd=invest,
+                                ledger_name=ledger_name,
+                                wallet_code=wallet_code,
+                            )
+                            if result and not result.get("error"):
+                                apply_buy(
+                                    ledger=ledger,
+                                    window_name=window_name,
+                                    t=current_ts,
+                                    meta={"window_name": window_name, "window_size": window_cfg.get("window_size")},
+                                    result=result,
+                                    state={},
+                                )
+                                if not dry_run:
+                                    last_buy_tick[window_name] = current_ts
+                                buy_count += 1
+                                msg = (
+                                    f"[LIVE][BUY] {ledger_name} | {tag} | "
+                                    f"{result['filled_amount']:.4f} {wallet_code} @ "
+                                    f"${result['avg_price']:.3f}"
+                                )
+                                addlog(msg)
+                                send_telegram_message(msg)
+                    else:
+                        reasons = []
+                        if not dry_run and current_ts - last_buy < buy_cd:
+                            remaining = buy_cd - (current_ts - last_buy)
+                            reasons.append(
+                                f"cooldown active ({remaining // 60}m left)"
+                            )
+                        if not reasons:
+                            reasons.append("unknown gating condition")
+
+                        addlog(
+                            f"[SKIP] {ledger_name} | {tag} | {window_name} → Buy blocked: {', '.join(reasons)}",
+                            verbose_int=3,
+                            verbose_state=True,
+                        )
+
+
+                    notes = [
+                        n for n in ledger.get_active_notes() if n.get("window") == window_name
+                    ]
+                    notes.sort(
+                        key=lambda n: (price - n["entry_price"]) / n["entry_price"],
+                        reverse=True,
+                    )
+                    sell_cd_base = window_cfg.get("sell_cooldown", 0) * 3600
+                    for note in notes:
+                        gain_pct = (price - note["entry_price"]) / note["entry_price"]
+                        trade_note = get_trade_params(
+                            current_price=price,
+                            window_high=wave["ceiling"],
+                            window_low=wave["floor"],
+                            config=window_cfg,
+                            entry_price=note["entry_price"],
+                        )
+                        maturity_roi = trade_note["maturity_roi"]
+                        if maturity_roi is not None:
+                            addlog(
+                                f"[DEBUG][LIVE SELL] gain_pct={gain_pct:.2%} maturity_roi={maturity_roi:.2%}",
+                                verbose_int=3,
+                                verbose_state=True,
+                            )
+                        else:
+                            addlog(
+                                f"[DEBUG][LIVE SELL] gain_pct={gain_pct:.2%} maturity_roi=None",
+                                verbose_int=3,
+                                verbose_state=True,
+                            )
+                        if (
+                            maturity_roi is None
+                            or maturity_roi <= 0
+                            or gain_pct < 0
+                            or gain_pct < maturity_roi
+                        ):
+                            continue
+                        sell_cd = int(
+                            sell_cd_base
+                            / trade_note["sell_cooldown_multiplier"]
+                        )
+                        if not dry_run and (
+                            current_ts - last_sell_tick.get(window_name, float("-inf"))
+                            < sell_cd
+                        ):
+                            continue
+                        result = execute_sell(
+                            client=client,
+                            pair_code=pair_code,
+                            coin_amount=note["entry_amount"],
+                            ledger_name=ledger_name,
+                        )
+                        if not result or result.get("error"):
+                            continue
+                        apply_sell(
+                            ledger=ledger,
+                            note=note,
+                            t=current_ts,
+                            result=result,
+                            state={},
+                        )
+                        if not dry_run:
+                            last_sell_tick[window_name] = current_ts
+                        sell_count += 1
+                        addlog(
+                            f"[LIVE][SELL] {ledger_name} | {tag} | Gain: ${gain:.2f} ({note['gain_pct']:.2%})",
+                        )
+                if buy_count > 0 or sell_count > 0:
+                    triggered_strategies[window_name.title()] = True
+
+                summary = ledger.get_account_summary(price)
+                idle_capital = float(balance.get(quote, 0.0))
+                summary["idle_capital"] = idle_capital
+                summary["total_value"] += idle_capital
+                hour_str = datetime.now().strftime("%I:%M%p")
+                addlog(
+                    f"[SUMMARY] {hour_str} | {ledger_name} | \U0001F4B0 ${summary['total_value']:.2f} | "
+                    f"\U0001F4B5 ${summary['idle_capital']:.2f} | \U0001FA99 ${summary['open_value']:.2f}",
+                    verbose_int=2,
+                    verbose_state=True,
+                )
+                message = (
+                    f"[LIVE] {ledger_name} | {tag} | {window_name} window\n"
+                    f"✅ Buy attempts: {buy_count} | Sells: {sell_count} | "
+                    f"Open Notes: {summary['open_notes']} | Realized Gain: ${summary['realized_gain']:.2f}"
+                )
+                addlog(
+                    message,
+                    verbose_int=1,
+                    verbose_state=True,
+                )
+
+                open_notes_w = [
+                    n for n in ledger.get_open_notes() if n.get("window") == window_name
+                ]
+                closed_notes_w = [
+                    n for n in ledger.get_closed_notes() if n.get("window") == window_name
+                ]
+                unrealized = sum(
+                    (price - n.get("entry_price", 0.0)) * n.get("entry_amount", 0.0)
+                    for n in open_notes_w
+                )
+                realized = sum(n.get("gain", 0.0) for n in closed_notes_w)
+                total_gain = unrealized + realized
+                invested = sum(
+                    n.get("entry_price", 0.0) * n.get("entry_amount", 0.0)
+                    for n in open_notes_w + closed_notes_w
+                )
+                roi = (total_gain / invested * 100.0) if invested else 0.0
+                strategy_summary[window_name.title()] = {
+                    "buys": buy_count,
+                    "sells": sell_count,
+                    "open": len(open_notes_w),
+                    "roi": roi,
+                    "total": total_gain,
+                }
+
+            if not dry_run:
+                metadata["last_buy_tick"] = last_buy_tick
+                metadata["last_sell_tick"] = last_sell_tick
+            ledger.set_metadata(metadata)
+            save_ledger(ledger_name, ledger, tag=ledger_cfg["tag"])
+
+            jackpot_path = root / "data" / "tmp" / "jackpot.json"
+            if jackpot_path.exists():
+                with jackpot_path.open("r") as jfile:
+                    jackpot_state = json.load(jfile)
+            else:
+                jackpot_state = {}
+            pool_usd = float(jackpot_state.get("pool_usd", 0.0))
+            drips = float(jackpot_state.get("drips", 0.0))
+            buys = int(jackpot_state.get("buys", 0))
+            sells = int(jackpot_state.get("sells", 0))
+            coin_value = sum(
+                n.get("entry_amount", 0.0) * price
+                for n in ledger.get_open_notes()
+                if n.get("kind") == "jackpot"
+            )
+            strategy_summary["jackpot"] = {
+                "pool": pool_usd,
+                "coin_value": coin_value,
+                "drips": drips,
+                "buys": buys,
+                "sells": sells,
+            }
+
+            usd_balance = float(balance.get(quote, 0.0))
+            coin_balance = float(balance.get(wallet_code, 0.0))
+            coin_balance_usd = coin_balance * price
+            total_liquid_value = usd_balance + coin_balance_usd
+            note_counts = {}
+            for win in window_settings.keys():
+                open_n = sum(
+                    1 for n in ledger.get_open_notes() if n.get("window") == win
+                )
+                closed_n = sum(
+                    1 for n in ledger.get_closed_notes() if n.get("window") == win
+                )
+                note_counts[win.title()] = (open_n, closed_n)
+            report = format_top_of_hour_report(
+                tag,
+                datetime.utcnow(),
+                usd_balance,
+                coin_balance_usd,
+                wallet_code,
+                total_liquid_value,
+                triggered_strategies,
+                note_counts,
+            )
+            addlog(report, verbose_int=1, verbose_state=True)
+
+            send_top_hour_report(
+                ledger_name=ledger_name,
+                tag=tag,
+                strategy_summary=strategy_summary,
+                verbose=general_cfg.get("verbose", 0),
+            )
+
+            if not dry_run:
+                cooldowns[ledger_name] = {
+                    "last_buy_tick": last_buy_tick,
+                    "last_sell_tick": last_sell_tick,
+                }
+
+        if not dry_run:
+            cooldown_path.parent.mkdir(parents=True, exist_ok=True)
+            with open(cooldown_path, "w") as f:
+                json.dump(cooldowns, f, indent=2)
+
+        return
+
+    if candle is None or ledger is None or ledger_config is None:
+        return
+
+    # Extract common context
+    df = kwargs.get("df")
+    offset = kwargs.get("offset")
+    state: Dict[str, Any] = kwargs.get("state", {})
+    verbose = kwargs.get("verbose", 0)
+
+    windows = ledger_config.get("window_settings", {})
+    if not windows or df is None or offset is None:
+        return
+
+    price = float(candle.get("close", 0.0))
+
+    for name, cfg in windows.items():
+        wave = get_window_data(
+            df,
+            window=cfg["window_size"],
+            candle_offset=offset,
+        )
+        if not wave:
+            continue
+
+        sim_capital = state.get("capital", 0.0)
+        max_note_usdt = kwargs.get("max_note_usdt", sim_capital)
+        min_note_usdt = kwargs.get("min_note_usdt", 0.0)
+
+        sim_capital, buy_skipped = evaluate_buy(
+            ledger=ledger,
+            name=name,
+            cfg=cfg,
+            wave=wave,
+            tick=tick,
+            price=price,
+            sim_capital=sim_capital,
+            last_buy_tick=state.get("last_buy_tick", {}),
+            max_note_usdt=max_note_usdt,
+            min_note_usdt=min_note_usdt,
+            verbose=verbose,
+        )
+        state["capital"] = sim_capital
+        if buy_skipped:
+            state.get("buy_cooldown_skips", {}).setdefault(name, 0)
+            state["buy_cooldown_skips"][name] += 1
+
+        last_sell_tick = state.setdefault("last_sell_tick", {})
+        sim_capital, closed, roi_skipped = evaluate_sell(
+            ledger=ledger,
+            name=name,
+            tick=tick,
+            price=price,
+            wave=wave,
+            cfg=cfg,
+            sim_capital=sim_capital,
+            verbose=verbose,
+            base_sell_cooldown=cfg.get("sell_cooldown", 0),
+            last_sell_tick=last_sell_tick,
+        )
+        state["capital"] = sim_capital
+        state["min_roi_gate_hits"] = state.get("min_roi_gate_hits", 0) + roi_skipped
+
+        if closed:
+            for note in closed:
+                msg = (
+                    f"[SELL] Tick {tick} | Window: {note['window']} | "
+                    f"Gain: +${note['gain']:.2f} ({note['gain_pct']:.2%})"
+                )
+                addlog(msg, verbose_int=2, verbose_state=verbose)
+                send_telegram_message(msg)
+
+    if sim:
+        # Simulation-specific behaviour already covered through state mutation.
+        # Placeholder for future live logic.
+        pass

--- a/systems/scripts/kraken_utils.py
+++ b/systems/scripts/kraken_utils.py
@@ -1,0 +1,88 @@
+import os
+import requests
+from pathlib import Path
+import yaml
+
+from systems.utils.addlog import addlog
+from systems.utils.price_fetcher import get_price
+
+KRAKEN_API_URL = "https://api.kraken.com"
+
+
+# --- Authentication -------------------------------------------------------
+
+def load_kraken_keys(path: str = "kraken.yaml") -> tuple[str, str]:
+    """Load Kraken API key/secret using WS_ACCOUNT or fallback YAML."""
+    account = os.environ.get("WS_ACCOUNT")
+    if account:
+        try:
+            from systems.utils.load_config import load_config
+
+            cfg = load_config()
+            acct = cfg.get("accounts", {}).get(account, {})
+            key = acct.get("api_key")
+            secret = acct.get("api_secret")
+            if key and secret:
+                return key, secret
+        except Exception:
+            pass
+
+    file = Path(path)
+    if not file.exists():
+        raise FileNotFoundError("Missing kraken.yaml in project root")
+
+    with file.open("r", encoding="utf-8") as f:
+        data = yaml.safe_load(f)
+
+    kraken = data.get("kraken")
+    if not kraken or "api_key" not in kraken or "api_secret" not in kraken:
+        raise ValueError("Malformed kraken.yaml: missing 'kraken.api_key' or 'api_secret'")
+
+    return kraken["api_key"], kraken["api_secret"]
+
+
+def get_live_price(kraken_pair: str) -> float:
+    """Return the current best ask price for ``kraken_pair``."""
+    pair = kraken_pair.replace("/", "")
+    try:
+        resp = requests.get(
+            f"{KRAKEN_API_URL}/0/public/Ticker", params={"pair": pair}, timeout=10
+        )
+        data = resp.json()
+        result = next(iter(data.get("result", {}).values()), {})
+        ask = result.get("a", [None])[0]
+        return float(ask) if ask is not None else 0.0
+    except Exception:
+        return 0.0
+
+
+def get_kraken_balance(fiat_code: str, verbose: int = 0) -> dict:
+    """Return Kraken balances converted to ``fiat_code`` for logging."""
+    from systems.scripts.execution_handler import _kraken_request
+
+    api_key, api_secret = load_kraken_keys()
+    result = _kraken_request("Balance", {}, api_key, api_secret).get("result", {})
+
+    fiat_code = fiat_code.upper()
+    fiat_code_symbol = fiat_code[1:] if fiat_code.startswith("Z") else fiat_code
+
+    fiat_balances = {}
+    for asset, amount in result.items():
+        amount = float(amount)
+        if asset.upper() == fiat_code:
+            fiat_balances[asset] = amount
+        else:
+            price = get_price(f"{asset}{fiat_code_symbol}")
+            if price:
+                fiat_balances[asset] = amount * price
+
+    addlog(
+        f"[INFO] Kraken balance fetched ({fiat_code_symbol}): {fiat_balances}",
+        verbose_int=3,
+        verbose_state=verbose,
+    )
+
+    return {k: float(v) for k, v in result.items()}
+
+
+

--- a/systems/scripts/ledger.py
+++ b/systems/scripts/ledger.py
@@ -1,0 +1,213 @@
+from __future__ import annotations
+
+"""Simple in-memory ledger for simulations and live trading."""
+
+import json
+from typing import Dict, List
+
+from systems.utils.config import resolve_path, load_settings, load_ledger_config
+
+
+class Ledger:
+    """Track raw trade state and compute summary metrics on demand."""
+
+    def __init__(self) -> None:
+        self.open_notes: List[Dict] = []
+        self.closed_notes: List[Dict] = []
+        self.metadata: Dict = {}
+
+    # Basic note management -------------------------------------------------
+    def open_note(self, note: Dict) -> None:
+        """Register a newly opened note.
+
+        Notes may contain additional metadata such as:
+
+        ``p_buy``            – window position at entry
+        ``unlock_p``         – bounce threshold to re-enable buys
+        ``target_price``     – price at which the note should be sold
+        ``target_roi``       – expected ROI at target price
+        ``window_name``      – name of the window configuration
+        ``window_size``      – size of the evaluation window
+        ``created_idx/ts``   – creation index or timestamp
+
+        These fields are stored verbatim and are not interpreted by the
+        ledger itself but are useful for downstream analysis and evaluation.
+        """
+        self.open_notes.append(note)
+
+    def close_note(self, note: Dict) -> None:
+        """Move ``note`` from open to closed."""
+        if note not in self.open_notes:
+            return
+        self.open_notes.remove(note)
+        self.closed_notes.append(note)
+
+    def set_metadata(self, metadata: Dict) -> None:
+        """Merge ``metadata`` into the ledger metadata."""
+        if not isinstance(metadata, dict):
+            return
+        self.metadata.update(metadata)
+
+    def get_metadata(self) -> Dict:
+        return dict(self.metadata)
+
+    # Accessors -------------------------------------------------------------
+    def get_open_notes(self) -> List[Dict]:
+        return list(self.open_notes)
+
+    def get_active_notes(self) -> List[Dict]:
+        return self.get_open_notes()
+
+    def get_closed_notes(self) -> List[Dict]:
+        return list(self.closed_notes)
+
+    def get_total_liquid_value(self, final_price: float) -> float:
+        """Return all value assuming open notes liquidate at ``final_price``."""
+        open_value = sum(
+            n.get("entry_amount", 0) for n in self.get_open_notes()
+        ) * final_price
+        realised = sum(
+            n.get("entry_amount", 0)
+            * (n.get("exit_price", 0) - n.get("entry_price", 0))
+            for n in self.get_closed_notes()
+        )
+        return open_value + realised
+
+    # Summary ---------------------------------------------------------------
+    def get_account_summary(self, final_price: float) -> dict:
+        open_amount = sum(n.get("entry_amount", 0) for n in self.get_open_notes())
+        open_value = open_amount * final_price
+        realised = sum(
+            n.get("entry_amount", 0)
+            * (n.get("exit_price", 0) - n.get("entry_price", 0))
+            for n in self.get_closed_notes()
+        )
+        total_value = open_value + realised
+
+        return {
+            "final_price": round(final_price, 8),
+            "open_coin_amount": round(open_amount, 8),
+            "open_value": round(open_value, 2),
+            "realized_gain": round(realised, 2),
+            "total_value": round(total_value, 2),
+            "closed_notes": len(self.get_closed_notes()),
+            "open_notes": len(self.get_open_notes()),
+        }
+
+    # Persistence -----------------------------------------------------------
+    @staticmethod
+    def load_ledger(
+        ledger_name: str, *, tag: str | None = None, sim: bool = False
+    ) -> "Ledger":
+        """Load a ledger for ``ledger_name``.
+
+        If a legacy ledger file named after ``tag`` exists, it will be
+        migrated to the ``ledger_name`` convention on first load.
+        """
+
+        root = resolve_path("")
+        ledger = Ledger()
+
+        if sim:
+            out_dir = root / "data" / "tmp" / "simulation"
+        else:
+            out_dir = root / "data" / "ledgers"
+
+        out_path = out_dir / f"{ledger_name}.json"
+
+        if tag and not out_path.exists():
+            legacy_path = out_dir / f"{tag}.json"
+            if legacy_path.exists():
+                legacy_path.rename(out_path)
+
+        if out_path.exists():
+            with out_path.open("r", encoding="utf-8") as f:
+                data = json.load(f)
+            ledger.open_notes = data.get("open_notes", [])
+            ledger.closed_notes = data.get("closed_notes", [])
+            ledger.metadata = data.get("metadata", {})
+        return ledger
+
+
+def load_ledger(
+    ledger_name: str, *, tag: str | None = None, sim: bool = False
+) -> "Ledger":
+    """Public wrapper to load a ledger from disk."""
+
+    return Ledger.load_ledger(ledger_name, tag=tag, sim=sim)
+
+
+def save_ledger(
+    ledger_name: str,
+    ledger: "Ledger" | dict,
+    *,
+    sim: bool = False,
+    final_tick: int | None = None,
+    summary: dict | None = None,
+    tag: str | None = None,
+) -> None:
+    """Persist ``ledger`` data to the canonical ledger directory."""
+
+    root = resolve_path("")
+
+    if sim:
+        out_dir = root / "data" / "tmp" / "simulation"
+    else:
+        out_dir = root / "data" / "ledgers"
+
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_path = out_dir / f"{ledger_name}.json"
+
+    if tag and not out_path.exists():
+        legacy_path = out_dir / f"{tag}.json"
+        if legacy_path.exists():
+            legacy_path.rename(out_path)
+
+    if isinstance(ledger, Ledger):
+        ledger_data = {
+            "open_notes": ledger.get_open_notes(),
+            "closed_notes": ledger.get_closed_notes(),
+        }
+
+        if final_tick is not None:
+            ledger_data["final_tick"] = final_tick
+
+        if summary:
+            ledger_data["closed_notes_count"] = summary.get("closed_notes")
+            ledger_data["open_notes_count"] = summary.get("open_notes")
+            ledger_data["realized_gain"] = summary.get("realized_gain")
+            ledger_data["final_value"] = summary.get("total_value")
+
+        metadata = ledger.get_metadata()
+        if metadata:
+            ledger_data["metadata"] = metadata
+    else:
+        ledger_data = ledger
+
+    with out_path.open("w", encoding="utf-8") as f:
+        json.dump(ledger_data, f, indent=2)
+
+def init_ledger(
+    ledger_name: str,
+    *,
+    tag: str | None = None,
+    sim: bool = False,
+) -> Ledger:
+    """Load ``ledger_name`` and ensure its file exists on disk."""
+
+    ledger = load_ledger(ledger_name, tag=tag, sim=sim)
+    save_ledger(ledger_name, ledger, tag=tag, sim=sim)
+    return ledger
+
+
+def resolve_ledger_config(ledger_name: str | None) -> Dict:
+    """Return configuration dictionary for ``ledger_name``.
+
+    If ``ledger_name`` is ``None``, the first ledger defined in settings is
+    returned. Mirrors previous inline logic previously in ``bot.py``.
+    """
+
+    settings = load_settings()
+    if ledger_name:
+        return load_ledger_config(ledger_name)
+    return next(iter(settings.get("ledger_settings", {}).values()))

--- a/systems/scripts/migrate_settings.py
+++ b/systems/scripts/migrate_settings.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+"""One-time helper to migrate legacy settings.json into split files."""
+
+import json
+from pathlib import Path
+
+from systems.utils.config import resolve_path
+
+
+def migrate_settings() -> None:
+    settings_path = resolve_path("settings/settings.json")
+    if not settings_path.exists():
+        print("[MIGRATE][ERROR] settings/settings.json not found")
+        return
+    with settings_path.open("r", encoding="utf-8") as fh:
+        data = json.load(fh)
+
+    accounts = data.get("accounts")
+    if accounts:
+        out_path = resolve_path("settings/account_settings.json")
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        with out_path.open("w", encoding="utf-8") as fh:
+            json.dump({"accounts": accounts}, fh, indent=2)
+        print(f"[MIGRATE] wrote {out_path}")
+
+    coin_settings = data.get("coin_settings")
+    if coin_settings:
+        out_path = resolve_path("settings/coin_settings.json")
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        with out_path.open("w", encoding="utf-8") as fh:
+            json.dump({"coin_settings": coin_settings}, fh, indent=2)
+        print(f"[MIGRATE] wrote {out_path}")
+
+
+if __name__ == "__main__":
+    migrate_settings()

--- a/systems/scripts/plot.py
+++ b/systems/scripts/plot.py
@@ -1,0 +1,42 @@
+"""Lightweight wrappers around :mod:`graph` plotting helpers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from graph import plot
+
+
+def plot_from_json(sim_path: str) -> None:
+    """Plot simulation results from a JSON ledger file.
+
+    The JSON file is expected to contain ``candles_path`` pointing at the
+    CSV of candle data. This is a very small stub to preserve the public
+    API used by :mod:`sim`.
+    """
+
+    ledger_file = Path(sim_path)
+    if not ledger_file.exists():  # pragma: no cover - best effort
+        return
+    import json
+
+    with ledger_file.open("r", encoding="utf-8") as fh:
+        data = json.load(fh)
+    candles = data.get("meta", {}).get("candles_path")
+    if candles:
+        plot(str(sim_path), str(candles))
+
+
+def plot_trades_from_ledger(account: str, market: str, mode: str = "live") -> None:
+    """Plot trades from a ledger file for ``account`` and ``market``.
+
+    This stub attempts to locate a ledger under ``data/{mode}`` and plot it
+    alongside the corresponding candle data if available. It is intended as
+    a minimal replacement for the richer legacy plotting utilities.
+    """
+
+    ledger = Path("data") / mode / account / f"{market}_ledger.json"
+    candles = Path("data") / "candles" / mode / f"{market}.csv"
+    if ledger.exists() and candles.exists():  # pragma: no cover - best effort
+        plot(str(ledger), str(candles))
+

--- a/systems/scripts/prime_kraken_snapshot.py
+++ b/systems/scripts/prime_kraken_snapshot.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+"""Prime a Kraken API data snapshot for reuse within the current hour."""
+
+from systems.utils.addlog import addlog
+from systems.utils.snapshot import prime_snapshot
+
+
+def prime_kraken_snapshot(
+    api_key: str, api_secret: str, ledger_name: str, verbose: int = 0
+) -> None:
+    """Fetch balance and trades once and cache them for the hour."""
+    prime_snapshot(ledger_name, api_key, api_secret)
+    addlog(
+        f"[SNAPSHOT] Cached Kraken balance and trades for {ledger_name}",
+        verbose_int=3,
+        verbose_state=verbose,
+    )

--- a/systems/scripts/report.py
+++ b/systems/scripts/report.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+"""Generate and email trading reports."""
+
+import argparse
+import json
+import smtplib
+import ssl
+from datetime import datetime
+from email.message import EmailMessage
+from pathlib import Path
+
+import yaml
+
+from systems.scripts.view_log import export_png
+from systems.scripts.ledger import load_ledger
+from systems.utils.addlog import addlog
+from systems.utils.config import load_settings
+
+
+def run_report(account: str, period: str) -> None:
+    """Create and email a report for ``account`` over ``period``."""
+
+    cfg = load_settings()
+    acct_cfg = cfg.get("accounts", {}).get(account)
+    if not acct_cfg or not acct_cfg.get("is_live", False):
+        addlog(f"[EMAIL][SKIP] {account} not live or unknown")
+        return
+
+    general_email = cfg.get("general_settings", {}).get("email", {})
+    acct_reporting = acct_cfg.get("reporting", {})
+
+    if period != "test":
+        if not (general_email.get("enabled") and general_email.get(period, False)):
+            addlog(f"[EMAIL][SKIP] {period} disabled")
+            return
+        if not acct_reporting.get(period, False):
+            addlog(f"[EMAIL][SKIP] {account} {period} disabled")
+            return
+        now = datetime.utcnow()
+        if period == "weekly" and now.weekday() != 0:
+            addlog("[EMAIL][SKIP] not start of week")
+            return
+        if period == "monthly" and now.day != 1:
+            addlog("[EMAIL][SKIP] not start of month")
+            return
+        if period == "yearly" and not (now.month == 1 and now.day == 1):
+            addlog("[EMAIL][SKIP] not start of year")
+            return
+
+    log_path = Path(f"data/logs/{account}.json")
+    if not log_path.exists():
+        addlog("[EMAIL][SKIP] no log")
+        return
+    events = json.loads(log_path.read_text())
+    if not events:
+        addlog("[EMAIL][SKIP] empty log")
+        return
+
+    out_dir = log_path.parent
+    out_dir.mkdir(parents=True, exist_ok=True)
+    png_path = out_dir / f"{account}_{period}.png"
+    export_png(log_path, png_path)
+
+    ledger = load_ledger(account)
+    last_price = events[-1].get("features", {}).get("close", 0.0)
+    summary = ledger.get_account_summary(last_price)
+    buys = sum(1 for e in events if e.get("decision") == "BUY")
+    sells = sum(1 for e in events if e.get("decision") == "SELL")
+    flats = sum(1 for e in events if e.get("decision") == "FLAT")
+    pnl = summary.get("realized_gain", 0.0)
+    capital = ledger.get_metadata().get("capital", 0.0)
+    roi = (pnl / capital) if capital else 0.0
+    open_notes = summary.get("open_notes", 0)
+
+    body = (
+        f"PnL: ${pnl:.2f}\n"
+        f"ROI: {roi*100:.2f}%\n"
+        f"Buys: {buys} Sells: {sells} Flats: {flats}\n"
+        f"Open notes: {open_notes}"
+    )
+
+    to_email = acct_reporting.get("email")
+    if not to_email:
+        addlog("[EMAIL][SKIP] no recipient")
+        return
+
+    key_path = Path("gmail_key.yaml")
+    if not key_path.exists():
+        addlog("[EMAIL][SKIP] no creds")
+        return
+    try:
+        creds = yaml.safe_load(key_path.read_text())
+    except Exception:
+        addlog("[EMAIL][SKIP] no creds")
+        return
+
+    msg = EmailMessage()
+    msg["Subject"] = f"{account} {period} report"
+    msg["From"] = creds.get("email")
+    msg["To"] = to_email
+    msg.set_content(body)
+    with png_path.open("rb") as fh:
+        msg.add_attachment(fh.read(), maintype="image", subtype="png", filename="report.png")
+
+    context = ssl.create_default_context()
+    try:
+        with smtplib.SMTP_SSL(creds["smtp_server"], creds["smtp_port"], context=context) as server:
+            server.login(creds["email"], creds["app_password"])
+            server.send_message(msg)
+        addlog(f"[EMAIL][SENT] {account} {period} report to {to_email}")
+    except Exception as exc:
+        addlog(f"[EMAIL][FAIL] {exc}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--account", required=True)
+    parser.add_argument(
+        "--period",
+        required=True,
+        choices=["daily", "weekly", "monthly", "yearly", "test"],
+    )
+    args = parser.parse_args()
+    run_report(args.account, args.period)
+
+
+if __name__ == "__main__":
+    main()

--- a/systems/scripts/runtime_state.py
+++ b/systems/scripts/runtime_state.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+from systems.utils.resolve_symbol import resolve_symbols
+from systems.utils.config import (
+    resolve_coin_config,
+    resolve_account_market,
+)
+
+
+def build_runtime_state(
+    general: Dict[str, Any],
+    coin_settings: Dict[str, Any],
+    accounts_cfg: Dict[str, Any],
+    account: str,
+    symbol: str,
+    mode: str,
+    *,
+    client,
+    prev: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    """Build and refresh runtime state for engines."""
+
+    prev = prev or {}
+    coin_cfg = resolve_coin_config(symbol, coin_settings)
+    acct_mkt_cfg = resolve_account_market(account, symbol, accounts_cfg)
+    knobs = {**coin_cfg, **acct_mkt_cfg}
+
+    limits = prev.get(
+        "limits",
+        {
+            "min_note_size": float(general.get("minimum_note_size", 0.0)),
+            "max_note_usdt": float(general.get("max_note_usdt", float("inf"))),
+        },
+    )
+
+    defaults = {
+        "window_size": 24,
+        "window_step": 2,
+        "buy_trigger": 3.0,
+        "sell_trigger": 10.0,
+        "flat_sell_percent": 0.25,
+        "all_sell_count": 99,
+        "max_pressure": 10.0,
+        "strong_move_threshold": 0.15,
+        "range_min": 0.08,
+        "volume_skew_bias": 0.4,
+        "flat_band_deg": 10.0,
+    }
+    strategy = {**defaults, **knobs}
+
+    buy_unlock_p = prev.get("buy_unlock_p", {})
+    verbose = prev.get("verbose", 0)
+
+    symbols = resolve_symbols(client, symbol)
+    if mode == "sim":
+        capital = float(general.get("simulation_capital", 0.0))
+    elif mode == "live":
+        quote = symbols["kraken_name"].split("/")[1]
+        balance = client.fetch_balance().get("free", {})
+        capital = float(balance.get(quote, 0.0))
+    else:
+        capital = prev.get("capital", 0.0)
+
+    state = {
+        "capital": capital,
+        "buy_unlock_p": buy_unlock_p,
+        "verbose": verbose,
+        "limits": limits,
+        "strategy": strategy,
+    }
+
+    state.update(symbols)
+
+    state.setdefault("pressures", prev.get("pressures", {"buy": {}, "sell": {}}))
+    state.setdefault("last_features", prev.get("last_features", {}))
+
+    return state

--- a/systems/scripts/send_top_hour_report.py
+++ b/systems/scripts/send_top_hour_report.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+"""Generate and send a top-of-hour report from cached Kraken snapshots."""
+
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+from systems.utils.addlog import addlog, send_telegram_message
+from systems.utils.config import load_settings
+from systems.utils.resolve_symbol import split_tag
+from systems.utils.snapshot import load_snapshot
+
+
+def _get_latest_price(trades: dict, pair: str) -> float:
+    """Return the most recent trade price for ``pair`` from ``trades``."""
+    if not isinstance(trades, dict):
+        return 0.0
+    latest = 0.0
+    latest_time = -1.0
+    for trade in trades.values():
+        if trade.get("pair") != pair:
+            continue
+        ts = float(trade.get("time", 0.0))
+        if ts > latest_time:
+            latest_time = ts
+            latest = float(trade.get("price", 0.0))
+    return latest
+
+
+def send_top_hour_report(
+    ledger_name: str,
+    tag: str,
+    strategy_summary: dict,
+    verbose: int = 0,
+) -> None:
+    """Load Kraken snapshot and send a formatted Telegram report."""
+    snapshot = load_snapshot(ledger_name)
+    if not snapshot:
+        addlog(
+            f"[WARN] Snapshot for {ledger_name} not found; skipping report",
+            verbose_int=1,
+            verbose_state=verbose,
+        )
+        return
+
+    settings = load_settings()
+    ledger_cfg = settings.get("ledger_settings", {}).get(ledger_name, {})
+    wallet_code = ledger_cfg.get("wallet_code", "")
+    _, fiat_code = split_tag(tag)
+
+    balance = snapshot.get("balance", {})
+    trades = snapshot.get("trades", {})
+
+    usd_balance = float(balance.get(fiat_code, 0.0))
+    coin_balance = float(balance.get(wallet_code, 0.0))
+    pair_code = tag
+    price = _get_latest_price(trades, pair_code)
+    coin_value = coin_balance * price
+    total_value = usd_balance + coin_value
+
+    # Determine display names
+    fiat_symbol = fiat_code.replace("Z", "").replace("X", "")
+    coin_symbol = (
+        tag[: -len(fiat_symbol)] if fiat_symbol and tag.endswith(fiat_symbol) else tag
+    )
+
+    ct_now = datetime.now(ZoneInfo("America/Chicago")).strftime("%I:%M%p")
+    lines = [f"🕒 {ct_now} CT | Ledger: {ledger_name}", ""]
+
+    for name, data in strategy_summary.items():
+        if name == "jackpot":
+            continue
+        strat_name = name.title()
+        if not strat_name.lower().endswith("catch"):
+            strat_name += " Catch"
+        buys = data.get("buys", 0)
+        sells = data.get("sells", 0)
+        open_n = data.get("open", 0)
+        roi = data.get("roi", 0.0)
+        total = data.get("total", 0.0)
+        lines.append(
+            " ".join(
+                [
+                    f"📈 {strat_name}",
+                    f"| Buys: {buys}",
+                    f"| Sells: {sells}",
+                    f"| Open: {open_n}",
+                    f"| ROI: {roi:+.1f}%",
+                    f"| 💵 Total: ${total:+.2f}",
+                ]
+            )
+        )
+
+    jackpot = strategy_summary.get("jackpot")
+    if jackpot:
+        pool = float(jackpot.get("pool", 0.0))
+        coin_value = float(jackpot.get("coin_value", 0.0))
+        total_jackpot = pool + coin_value
+        lines.append(
+            " ".join(
+                [
+                    "🎰 Jackpot",
+                    f"| Pool: ${pool:.2f}",
+                    f"| Coin: ${coin_value:.2f}",
+                    f"| Total: ${total_jackpot:.2f}",
+                    f"| Drips: +${jackpot.get('drips', 0.0):.2f}",
+                    f"| Buys: {jackpot.get('buys', 0)}",
+                    f"| Sells: {jackpot.get('sells', 0)}",
+                ]
+            )
+        )
+
+    lines.append("------------------------------------------------------------------------")
+    lines.append(
+        f"🧱 {fiat_symbol}: ${usd_balance:,.2f} | 🪙 {coin_symbol}: ${coin_value:,.2f} | "
+        f"💰Total Wallet Value: ${total_value:,.2f}"
+    )
+    lines.append("------------------------------------------------------------------------")
+    message = "\n".join(lines)
+    addlog(message, verbose_int=1, verbose_state=verbose)
+    send_telegram_message(message)

--- a/systems/scripts/sim_tuner.py
+++ b/systems/scripts/sim_tuner.py
@@ -1,0 +1,185 @@
+from __future__ import annotations
+
+"""Sequential per-window simulation tuner using Optuna."""
+
+import copy
+import csv
+import json
+import os
+from collections import OrderedDict
+from typing import Any, Dict
+
+import optuna
+
+from systems.sim_engine import run_simulation
+from systems.scripts.fetch_candles import load_coin_csv
+from systems.scripts.ledger import load_ledger
+from systems.utils.addlog import addlog
+from systems.utils.config import (
+    load_ledger_config,
+    load_settings,
+    resolve_path,
+)
+from systems.utils.resolve_symbol import split_tag
+
+
+def run_sim_tuner(*, ledger: str, verbose: int = 0) -> None:
+    """Run sequential Optuna tuning on each window for ``ledger``."""
+
+    ledger_cfg = load_ledger_config(ledger)
+    tag = ledger_cfg.get("tag", "").upper()
+    window_settings = ledger_cfg.get("window_settings", {})
+    if not window_settings:
+        raise ValueError("No windows defined for ledger")
+
+    root = resolve_path("")
+    settings = load_settings(reload=True)
+    knobs_path = root / "settings" / "knobs.json"
+    with knobs_path.open("r", encoding="utf-8") as f:
+        knobs_cfg = json.load(f).get(tag)
+    if knobs_cfg is None:
+        raise ValueError(f"No knob configuration found for tag: {tag}")
+
+    init_capital = float(settings.get("simulation_capital", 0))
+    results_path = root / "data" / "tmp" / "simtune_results.csv"
+    results_path.parent.mkdir(parents=True, exist_ok=True)
+    best_knobs: Dict[str, Any] = {}
+
+    import systems.utils.config as config_mod
+    import systems.sim_engine as sim_engine
+
+    for window_name in window_settings:
+        window_knobs = knobs_cfg.get(window_name)
+        if not window_knobs:
+            if verbose:
+                addlog(
+                    f"[TUNE] No knob ranges for window '{window_name}', skipping",
+                    verbose_int=1,
+                    verbose_state=verbose,
+                )
+            continue
+
+        def objective(trial: optuna.trial.Trial) -> float:
+            trial_settings = copy.deepcopy(settings)
+            trial_ledger_cfg = copy.deepcopy(ledger_cfg)
+
+            # Freeze previously tuned windows
+            w_settings = trial_ledger_cfg.get("window_settings", {})
+            for w, params in best_knobs.items():
+                if w in w_settings:
+                    w_settings[w].update(params)
+
+            current_cfg = w_settings[window_name]
+
+            for knob, bounds in window_knobs.items():
+                if isinstance(bounds, dict):
+                    low = bounds.get("low") or bounds.get("min")
+                    high = bounds.get("high") or bounds.get("max")
+                else:
+                    low, high = bounds
+                base_val = current_cfg.get(knob)
+                if (
+                    isinstance(base_val, int)
+                    and isinstance(low, int)
+                    and isinstance(high, int)
+                ):
+                    value = trial.suggest_int(knob, int(low), int(high))
+                else:
+                    value = trial.suggest_float(knob, float(low), float(high))
+                current_cfg[knob] = value
+
+            trial_settings["ledger_settings"][ledger] = trial_ledger_cfg
+
+            original_load_settings = config_mod.load_settings
+            original_load_ledger = config_mod.load_ledger_config
+            config_mod.load_settings = lambda reload=False: trial_settings
+            config_mod.load_ledger_config = (
+                lambda name: trial_settings["ledger_settings"][name]
+            )
+
+            original_sim_loader = (
+                sim_engine.load_settings if hasattr(sim_engine, "load_settings") else None
+            )
+            if original_sim_loader:
+                sim_engine.load_settings = lambda reload=False: trial_settings
+
+            try:
+                run_simulation(ledger=ledger, verbose=verbose, window_names=[window_name])
+            finally:
+                config_mod.load_settings = original_load_settings
+                config_mod.load_ledger_config = original_load_ledger
+                if original_sim_loader:
+                    sim_engine.load_settings = original_sim_loader
+
+            ledger_obj = load_ledger(ledger, tag=tag, sim=True)
+            base, _ = split_tag(tag)
+            final_price = float(load_coin_csv(base).iloc[-1]["close"])
+            summary = ledger_obj.get_account_summary(final_price)
+            open_value = summary.get("open_value", 0.0)
+            realized_gain = summary.get("realized_gain", 0.0)
+            open_cost = sum(
+                n.get("entry_price", 0.0) * n.get("entry_amount", 0.0)
+                for n in ledger_obj.get_open_notes()
+            )
+            idle_capital = init_capital + realized_gain - open_cost
+            penalty = 0.01
+            score = realized_gain - penalty * (idle_capital + open_value)
+            if verbose:
+                addlog(
+                    f"[TUNE][{window_name}] Trial {trial.number} score={score:.4f}",
+                    verbose_int=1,
+                    verbose_state=verbose,
+                )
+            return score
+
+        if verbose <= 0:
+            optuna.logging.set_verbosity(optuna.logging.WARNING)
+        else:
+            optuna.logging.set_verbosity(optuna.logging.INFO)
+
+        study = optuna.create_study(direction="maximize")
+        interrupted = False
+
+        try:
+            while True:
+                study.optimize(objective, n_trials=1)
+                trial = study.trials[-1]
+                row = OrderedDict(
+                    [
+                        ("ledger", ledger),
+                        ("window", window_name),
+                        ("trial", trial.number),
+                        ("score", trial.value),
+                    ]
+                )
+                for k, v in trial.params.items():
+                    row[k] = v
+                file_exists = results_path.exists()
+                with results_path.open("a", newline="", encoding="utf-8") as csvfile:
+                    writer = csv.DictWriter(csvfile, fieldnames=row.keys())
+                    if not file_exists:
+                        writer.writeheader()
+                    writer.writerow(row)
+                    csvfile.flush()
+                    os.fsync(csvfile.fileno())
+        except KeyboardInterrupt:
+            addlog(
+                "[TUNE] Interrupted by user, shutting down.",
+                verbose_int=1,
+                verbose_state=verbose,
+            )
+            interrupted = True
+
+        best_score = study.best_value
+        best_params = study.best_params
+        best_knobs[window_name] = best_params
+
+        addlog(
+            f"[TUNE][{window_name}] Best parameters: {best_params}",
+            verbose_int=1,
+            verbose_state=verbose,
+        )
+
+        if interrupted:
+            return
+

--- a/systems/scripts/strategy_jackpot.py
+++ b/systems/scripts/strategy_jackpot.py
@@ -1,0 +1,275 @@
+from __future__ import annotations
+
+"""Jackpot drip and cashout strategy helper."""
+
+from typing import Any, Dict
+
+from systems.utils.addlog import addlog, send_telegram_message
+from systems.scripts.trade_apply import (
+    paper_execute_buy,
+    paper_execute_sell,
+    apply_buy,
+    apply_sell,
+)
+from systems.scripts.execution_handler import execute_buy, execute_sell
+
+
+def _parse_period(period: str) -> int:
+    """Return number of seconds for ``period`` like "1w"."""
+    if not period:
+        return 0
+    try:
+        value = int(period[:-1])
+    except ValueError:
+        return 0
+    unit = period[-1].lower()
+    if unit == "h":
+        factor = 3600
+    elif unit == "d":
+        factor = 3600 * 24
+    elif unit == "w":
+        factor = 3600 * 24 * 7
+    else:
+        factor = 0
+    return value * factor
+
+
+def _compute_global_p(jstate: Dict[str, Any], price: float) -> float:
+    low = float(jstate.get("global_low", 0.0))
+    high = float(jstate.get("global_high", 0.0))
+    if price > high:
+        addlog(
+            f"[JACKPOT][STALE_BOUNDS] current_high={price:.2f} global_high={high:.2f}"
+        )
+        jstate["global_high"] = price
+        high = price
+    elif price < low:
+        addlog(
+            f"[JACKPOT][STALE_BOUNDS] current_low={price:.2f} global_low={low:.2f}"
+        )
+        jstate["global_low"] = price
+        low = price
+    if high == low:
+        return 0.0
+    p = (price - low) / (high - low)
+    return max(0.0, min(1.0, p))
+
+
+def init_jackpot(state: Dict[str, Any], ledger_cfg: Dict[str, Any], df) -> None:
+    cfg = ledger_cfg.get("jackpot", {})
+    enabled = bool(cfg.get("enabled"))
+    period_s = _parse_period(cfg.get("period", "1w"))
+    jstate = state.get("jackpot", {})
+    jstate.setdefault("pool_usd", 0.0)
+    jstate.setdefault("notes_open", [])
+    jstate.setdefault("drips", 0.0)
+    jstate.setdefault("buys", 0)
+    jstate.setdefault("sells", 0)
+    jstate.setdefault("realized_pnl", 0.0)
+    jstate["enabled"] = enabled
+    jstate["cfg"] = cfg
+    jstate["period_s"] = period_s
+    if df is not None and len(df):
+        if "low" in df:
+            jstate["global_low"] = float(df["low"].min())
+        else:
+            jstate["global_low"] = float(df["close"].min())
+        if "high" in df:
+            jstate["global_high"] = float(df["high"].max())
+        else:
+            jstate["global_high"] = float(df["close"].max())
+        if "timestamp" in df.columns:
+            now_ts = int(df.iloc[-1]["timestamp"])
+        else:
+            now_ts = 0
+        jstate.setdefault("next_period_ts", ((now_ts // period_s) + 1) * period_s if period_s else 0)
+    state["jackpot"] = jstate
+
+
+def on_buy_drip(state: Dict[str, Any], buy_usd: float) -> float:
+    j = state.get("jackpot", {})
+    if not j.get("enabled"):
+        return buy_usd
+    frac = float(j.get("cfg", {}).get("drip_fraction", 0.0))
+    drip = buy_usd * frac
+    if drip <= 0:
+        return buy_usd
+    j["pool_usd"] = j.get("pool_usd", 0.0) + drip
+    j["drips"] = j.get("drips", 0.0) + drip
+    if state.get("ctx", {}).get("verbosity", 0) >= 2:
+        addlog(f"[JACKPOT][DRIP] +${drip:.2f} → pool=${j['pool_usd']:.2f}")
+    return buy_usd - drip
+
+
+def maybe_periodic_jackpot_buy(ctx: Dict[str, Any], state: Dict[str, Any], t: int, df, price: float, limits: Dict[str, float], ledger_tag: str) -> None:
+    j = state.get("jackpot", {})
+    if not j.get("enabled"):
+        return
+    if "timestamp" in df.columns:
+        now_ts = int(df.iloc[t]["timestamp"])
+    else:
+        now_ts = 0
+    if now_ts < j.get("next_period_ts", 0):
+        return
+    p_global = _compute_global_p(j, price)
+    cfg = j.get("cfg", {})
+    trigger_p = float(cfg.get("trigger_p", 0.5))
+    min_usd = float(cfg.get("min_usd", 0.0))
+    if p_global <= trigger_p and j.get("pool_usd", 0.0) >= min_usd:
+        depth_scale = float(cfg.get("depth_scale", 1.0))
+        mult = 1.0 + (trigger_p - p_global) * depth_scale
+        amount_usd_calc = j["pool_usd"] * mult
+        max_note = float(limits.get("max_note_usdt", amount_usd_calc))
+        pool = float(j.get("pool_usd", 0.0))
+        amount_usd = max(0.0, min(pool, amount_usd_calc, max_note))
+        min_note = float(limits.get("min_note_size", 0.0))
+        if amount_usd <= 0 or amount_usd < min_note:
+            if ctx.get("verbosity", 0) >= 3:
+                addlog(
+                    f"[JACKPOT][POOL_DEBIT][SKIP] pool=${pool:.2f} "
+                    f"calc=${amount_usd_calc:.2f} cap=${max_note:.2f}"
+                )
+            j["next_period_ts"] = j.get("next_period_ts", 0) + j.get("period_s", 0)
+            return
+        j["pool_usd"] = pool - amount_usd
+        if ctx.get("verbosity", 0) >= 1:
+            addlog(f"[JACKPOT][POOL_DEBIT] -${amount_usd:.2f} → pool=${j['pool_usd']:.2f}")
+        mode = state.get("mode", "sim")
+        ts = now_ts if now_ts else None
+        note = None
+        if mode == "live":
+            result = execute_buy(
+                None,
+                pair_code=ctx.get("pair_code", ledger_tag),
+                price=price,
+                amount_usd=amount_usd,
+                ledger_name=ledger_tag,
+                wallet_code=ctx.get("wallet_code", ""),
+                verbose=state.get("verbose", 0),
+            )
+            if result and not result.get("error"):
+                note = apply_buy(
+                    ledger=ctx["ledger"],
+                    window_name="jackpot",
+                    t=t,
+                    meta={"kind": "jackpot", "window_name": "jackpot", "window_size": cfg.get("period", "")},
+                    result=result,
+                    state=state,
+                )
+        else:
+            result = paper_execute_buy(price, amount_usd, timestamp=ts)
+            note = apply_buy(
+                ledger=ctx["ledger"],
+                window_name="jackpot",
+                t=t,
+                meta={"kind": "jackpot", "window_name": "jackpot", "window_size": cfg.get("period", "")},
+                result=result,
+                state=state,
+            )
+        if note:
+            j.setdefault("notes_open", []).append(note)
+            j["buys"] = j.get("buys", 0) + 1
+            msg = f"[JACKPOT][BUY] p={p_global:.3f} pool→${j['pool_usd']:.2f} spent ${amount_usd:.2f}"
+            addlog(msg)
+            send_telegram_message(f"🎰 {msg}")
+    j["next_period_ts"] = j.get("next_period_ts", 0) + j.get("period_s", 0)
+
+
+def maybe_cashout_jackpot(ctx: Dict[str, Any], state: Dict[str, Any], t: int, df, price: float, limits: Dict[str, float], ledger_tag: str) -> None:
+    j = state.get("jackpot", {})
+    if not j.get("enabled"):
+        return
+    cfg = j.get("cfg", {})
+    cashout_p = float(cfg.get("cashout_p", 1.0))
+    p_global = _compute_global_p(j, price)
+    if ctx.get("verbosity", 0) >= 2:
+        addlog(
+            f"[JACKPOT][P_DEBUG] now=${price:.2f}, low=${j.get('global_low', 0.0):.2f}, "
+            f"high=${j.get('global_high', 0.0):.2f}, p={p_global:.3f}, cashout_p={cashout_p:.3f}"
+        )
+    notes = list(j.get("notes_open", []))
+    if not notes:
+        if ctx.get("verbosity", 0) >= 3:
+            addlog("[JACKPOT][NONE_TO_SELL]")
+        return
+    
+    if p_global < cashout_p:
+        if ctx.get("verbosity", 0) >= 2:
+            addlog(f"[JACKPOT][NO_TRIGGER] p={p_global:.3f} < cashout_p={cashout_p:.3f}")
+        return
+    ts = int(df.iloc[t]["timestamp"]) if "timestamp" in df.columns else None
+    sold = 0
+    total_gain = 0.0
+    for note in notes:
+        # Ensure we only process jackpot notes
+        if note.get("kind") != "jackpot":
+            addlog(
+                f"[JACKPOT][DEBUG] skip note id={note.get('id')} kind={note.get('kind')}"
+            )
+            continue
+
+        # Skip notes that are too small to sell
+        value = note.get("entry_amount", 0.0) * price
+        min_size = float(limits.get("min_note_size", 0.0))
+        if value < min_size:
+            addlog(
+                f"[JACKPOT][SKIP_MIN] id={note.get('id')} value=${value:.2f} min=${min_size:.2f}"
+            )
+            continue
+
+        mode = state.get("mode", "sim")
+        if mode == "live":
+            result = execute_sell(
+                None,
+                pair_code=ctx.get("pair_code", ledger_tag),
+                coin_amount=note.get("entry_amount", 0.0),
+                price=price,
+                ledger_name=ledger_tag,
+                verbose=state.get("verbose", 0),
+            )
+            if not result or result.get("error"):
+                continue
+        else:
+            result = paper_execute_sell(price, note.get("entry_amount", 0.0), timestamp=ts)
+        apply_sell(
+            ledger=ctx["ledger"],
+            note=note,
+            t=t,
+            result=result,
+            state=state,
+        )
+        exit_usd = note.get(
+            "exit_usdt", result.get("filled_amount", 0.0) * result.get("avg_price", 0.0)
+        )
+        proceeds = float(result.get("proceeds_usd", exit_usd))
+        j["pool_usd"] = float(j.get("pool_usd", 0.0)) + proceeds
+        if ctx.get("verbosity", 0) >= 3:
+            addlog(
+                f"[JACKPOT][POOL_CREDIT] +${proceeds:.2f} → pool=${j['pool_usd']:.2f}"
+            )
+        qty = result.get("filled_amount", note.get("entry_amount", 0.0))
+        exit_price = note.get("exit_price", result.get("avg_price", 0.0))
+        addlog(
+            f"[JACKPOT][SELL] id={note.get('id')} qty={qty:.8f} "
+            f"price={exit_price:.2f} pnl=${note.get('gain', 0.0):.2f}]"
+        )
+        total_gain += note.get("gain", 0.0)
+        sold += 1
+        j["notes_open"].remove(note)
+    if sold:
+        j["sells"] = j.get("sells", 0) + sold
+        j["realized_pnl"] = j.get("realized_pnl", 0.0) + total_gain
+        msg = f"[JACKPOT][CASHOUT] sold {sold} notes @ p={p_global:.3f} gain=${total_gain:.2f}"
+        addlog(msg)
+        send_telegram_message(f"🎰 {msg}")
+    if ctx.get("verbosity", 0) >= 3:
+        jackpot_notes = [n for n in j.get("notes_open", []) if n.get("kind") == "jackpot"]
+        coin_value = sum(
+            (float(n.get("entry_amount", 0.0)) or 0.0) * float(price)
+            for n in jackpot_notes
+        )
+        pool_now = float(j.get("pool_usd", 0.0))
+        addlog(
+            f"[JACKPOT][AUDIT] pool_usd=${pool_now:.2f} coin_value=${coin_value:.2f} "
+            f"total=${(pool_now + coin_value):.2f} open_notes={len(jackpot_notes)}"
+        )

--- a/systems/scripts/test_mode.py
+++ b/systems/scripts/test_mode.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+"""Safe account validation without placing trades."""
+
+import os
+import time
+from typing import Any
+
+import ccxt
+
+from systems.scripts.fetch_candles import fetch_candles
+from systems.scripts.kraken_utils import get_kraken_balance
+from systems.scripts.account_book import AccountBook
+from systems.scripts.evaluate_buy import evaluate_buy
+from systems.scripts.evaluate_sell import evaluate_sell
+from systems.scripts.runtime_state import build_runtime_state
+from systems.utils.config import (
+    load_general,
+    load_coin_settings,
+    load_account_settings,
+    load_keys,
+)
+from systems.utils.time import parse_duration
+
+
+def run_test(account: str, market: str, lookback: str | None = None) -> int:
+    """Run a short in-memory backtest requiring at least one BUY and SELL."""
+
+    general = load_general()
+    coin_settings = load_coin_settings()
+    accounts_cfg = load_account_settings()
+    keys = load_keys()
+
+    acct_cfg = accounts_cfg.get(account)
+    if not acct_cfg:
+        print(f"[TEST][FAIL] Account={account}\nReason: Unknown account")
+        return 1
+    if market not in acct_cfg.get("market settings", {}):
+        print(
+            f"[TEST][FAIL] Account={account} Market={market}\nReason: Unknown market"
+        )
+        return 1
+
+    lookback = lookback or "72h"
+    try:
+        delta = parse_duration(lookback)
+    except Exception:
+        print(
+            f"[TEST][FAIL] Account={account} Market={market}\nReason: Invalid lookback '{lookback}'"
+        )
+        return 1
+
+    end_ts = int(time.time())
+    start_ts = end_ts - int(delta.total_seconds())
+
+    df = fetch_candles(market, start_ts, end_ts, source="kraken")
+    if df.empty:
+        print(
+            f"[TEST][FAIL] Account={account} Market={market}\nReason: No recent candles in lookback"
+        )
+        return 1
+
+    keypair = keys.get(account, {})
+    client = ccxt.kraken(
+        {
+            "enableRateLimit": True,
+            "apiKey": keypair.get("api_key", ""),
+            "secret": keypair.get("api_secret", ""),
+        }
+    )
+
+    runtime_state = build_runtime_state(
+        general,
+        coin_settings,
+        accounts_cfg,
+        account,
+        market,
+        mode="sim",
+        client=client,
+        prev={"verbose": 0},
+    )
+    runtime_state["mode"] = "test"
+    strategy_cfg = runtime_state.get("strategy", {})
+
+    window = int(strategy_cfg.get("window_size", 0))
+    ctx: dict[str, Any] = {"account": AccountBook()}
+    saw_buy = 0
+    saw_sell = 0
+
+    for t in range(window, len(df)):
+        buy_res = evaluate_buy(ctx, t, df, cfg=strategy_cfg, runtime_state=runtime_state)
+        if buy_res:
+            saw_buy += 1
+            candle = df.iloc[t]
+            note = {
+                "entry_price": float(candle["close"]),
+                "size": float(buy_res.get("size_usd", 0.0)),
+                "created_ts": int(candle.get("timestamp", end_ts)),
+            }
+            ctx["account"].open_note(note)
+
+        sell_res = evaluate_sell(
+            ctx,
+            t,
+            df,
+            cfg=strategy_cfg,
+            open_notes=ctx["account"].get_open_notes(),
+            runtime_state=runtime_state,
+        )
+        if sell_res:
+            saw_sell += len(sell_res)
+            for note in sell_res:
+                ctx["account"].close_note(note)
+
+    features = runtime_state.get("last_features", {}).get("strategy", {})
+    slope = features.get("slope", 0.0)
+    vol = features.get("volatility", 0.0)
+
+    os.environ["WS_ACCOUNT"] = account
+    base, quote = market.split("/")
+    try:
+        balances = get_kraken_balance(quote)
+    except Exception:
+        balances = {}
+    quote_bal = float(balances.get(quote.upper(), 0.0))
+    base_bal = float(balances.get(base.upper(), 0.0))
+
+    passed = saw_buy > 0 and saw_sell > 0
+    prefix = "[TEST][PASS]" if passed else "[TEST][FAIL]"
+    print(f"{prefix} Account={account} Market={market}")
+    print(f"Balances: {quote.upper()}={quote_bal:.2f} {base.upper()}={base_bal:.2f}")
+    print(f"Summary: buys={saw_buy} sells={saw_sell} lookback={lookback}")
+    if not passed:
+        reason = []
+        if saw_buy == 0:
+            reason.append("no BUY in lookback")
+        if saw_sell == 0:
+            reason.append("no SELL in lookback")
+        print("Reason: " + ", ".join(reason))
+    print(f"Last candle: slope={slope:.2f} vol={vol:.2f}")
+
+    return 0 if passed else 1
+

--- a/systems/scripts/trade_apply.py
+++ b/systems/scripts/trade_apply.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+
+def paper_execute_buy(price: float, amount_usd: float, *, timestamp: Optional[int] = None) -> Dict[str, float | int | None]:
+    filled = amount_usd / price if price else 0.0
+    return {"filled_amount": filled, "avg_price": price, "timestamp": timestamp}
+
+
+def paper_execute_sell(price: float, coin_amount: float, *, timestamp: Optional[int] = None) -> Dict[str, float | int | None]:
+    return {"filled_amount": coin_amount, "avg_price": price, "timestamp": timestamp}
+
+
+def apply_buy(
+    *,
+    ledger,
+    window_name: str,
+    t: int,
+    meta: Dict[str, Any],
+    result: Dict[str, Any],
+    state: Dict[str, Any],
+) -> Dict[str, Any]:
+    note = {
+        "id": f"{window_name}-{t}",
+        "entry_idx": t,
+        "entry_price": result.get("avg_price", 0.0),
+        "entry_amount": result.get("filled_amount", 0.0),
+        "entry_usdt": result.get("filled_amount", 0.0) * result.get("avg_price", 0.0),
+        "window_name": meta.get("window_name"),
+        "window_size": meta.get("window_size"),
+        "p_buy": meta.get("p_buy"),
+        "target_price": meta.get("target_price"),
+        "target_roi": meta.get("target_roi"),
+        "unlock_p": meta.get("unlock_p"),
+    }
+    if "created_idx" in meta:
+        note["created_idx"] = meta["created_idx"]
+    if result.get("timestamp") is not None:
+        note["created_ts"] = result.get("timestamp")
+    elif "created_ts" in meta:
+        note["created_ts"] = meta["created_ts"]
+
+    # Merge any additional metadata (e.g. note kind)
+    for k, v in meta.items():
+        if k not in note:
+            note[k] = v
+
+    ledger.open_note(note)
+    cost = result.get("filled_amount", 0.0) * result.get("avg_price", 0.0)
+    state["capital"] = state.get("capital", 0.0) - cost
+    # Persist remaining capital on the ledger for live-mode parity
+    try:
+        ledger.set_metadata({"capital": state.get("capital", 0.0)})
+    except AttributeError:
+        pass
+    return note
+
+
+def apply_sell(
+    *,
+    ledger,
+    note: Dict[str, Any],
+    t: int | None,
+    result: Dict[str, Any],
+    state: Dict[str, Any],
+) -> Dict[str, Any]:
+    exit_price = result.get("avg_price", 0.0)
+    exit_usdt = result.get("filled_amount", 0.0) * exit_price
+    note["exit_price"] = exit_price
+    note["exit_usdt"] = exit_usdt
+    if t is not None:
+        note["exit_idx"] = t
+    if result.get("timestamp") is not None:
+        note["exit_ts"] = result.get("timestamp")
+    entry_usdt = note.get("entry_usdt", 0.0)
+    note["gain"] = exit_usdt - entry_usdt
+    note["gain_pct"] = (note["gain"] / entry_usdt) if entry_usdt else 0.0
+    ledger.close_note(note)
+    state["capital"] = state.get("capital", 0.0) + exit_usdt
+    # Persist capital back to ledger after the sale
+    try:
+        ledger.set_metadata({"capital": state.get("capital", 0.0)})
+    except AttributeError:
+        pass
+    return note

--- a/systems/scripts/trend_predict.py
+++ b/systems/scripts/trend_predict.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+"""Window feature extraction, rule-based predictor, and pressure updates."""
+
+from typing import Dict
+
+import numpy as np
+
+from systems.utils.addlog import addlog
+
+try:  # pragma: no cover - optional dependency
+    from systems.scripts.math.slope_score import classify_slope  # type: ignore
+except Exception:  # pragma: no cover - fallback
+    import math
+
+    def classify_slope(slope: float, flat_band_deg: float = 10.0) -> int:
+        """Return -1 for down, 0 for flat, +1 for up."""
+        angle = math.degrees(math.atan(slope))
+        if -flat_band_deg <= angle <= flat_band_deg:
+            return 0
+        return 1 if angle > flat_band_deg else -1
+
+
+def compute_window_features(series, start: int, window_size: int) -> Dict[str, float]:
+    """Compute window statistics matching reference logic."""
+    end = start + window_size
+    sub = series.iloc[start:end]
+
+    closes = sub["close"].values
+    x = np.arange(len(closes))
+    slope = float(np.polyfit(x, closes, 1)[0]) if len(closes) > 1 else 0.0
+    volatility = float(np.std(closes)) if len(closes) else 0.0
+
+    low = float(sub["low"].min()) if "low" in sub else float(sub["close"].min())
+    high = float(sub["high"].max()) if "high" in sub else float(sub["close"].max())
+    rng = high - low
+
+    vol_mean = float(sub["volume"].mean()) if "volume" in sub else 0.0
+    mid = len(sub) // 2
+    if mid and "volume" in sub:
+        early = float(sub["volume"].iloc[:mid].mean())
+        late = float(sub["volume"].iloc[mid:].mean())
+        volume_skew = ((late - early) / early) if early else 0.0
+    else:
+        volume_skew = 0.0
+
+    level = float(sub.iloc[0]["close"]) if len(sub) else 0.0
+    exit_price = float(sub.iloc[-1]["close"]) if len(sub) else 0.0
+    pct_change = (exit_price - level) / level if level else 0.0
+
+    return {
+        "slope": slope,
+        "volatility": volatility,
+        "range": rng,
+        "volume_mean": vol_mean,
+        "volume_skew": volume_skew,
+        "pct_change": pct_change,
+    }
+
+
+def rule_predict(features: Dict[str, float], cfg: Dict[str, float]) -> int:
+    """Classify next window move with multi-feature rules."""
+    slope = features.get("slope", 0.0)
+    rng = features.get("range", 0.0)
+
+    slope_cls = classify_slope(slope, cfg.get("flat_band_deg", 10.0))
+    if slope_cls == 0:
+        return 0
+    if rng < cfg.get("range_min", 0.0):
+        return 0
+
+    skew = features.get("volume_skew", 0.0)
+    skew_bias = cfg.get("volume_skew_bias", 0.0)
+    if skew > skew_bias and slope_cls > 0:
+        return 1
+    if skew < -skew_bias and slope_cls < 0:
+        return -1
+
+    pct = features.get("pct_change", 0.0)
+    strong = cfg.get("strong_move_threshold", 0.0)
+    if pct >= strong:
+        return 2
+    if pct > 0:
+        return 1
+    if pct <= -strong:
+        return -2
+    if pct < 0:
+        return -1
+    return 0
+
+
+def update_pressures(
+    state: Dict,
+    window_name: str,
+    pred: int,
+    slope_cls: int,
+    cfg: Dict[str, float],
+) -> None:
+    """Mutate buy/sell pressures based on prediction and slope."""
+    pressures = state.setdefault("pressures", {"buy": {}, "sell": {}})
+    buy_p = pressures.setdefault("buy", {}).get(window_name, 0.0)
+    sell_p = pressures.setdefault("sell", {}).get(window_name, 0.0)
+    max_p = cfg.get("max_pressure", 0.0)
+
+    if pred > 0:
+        buy_p = min(max_p, buy_p + 1)
+        sell_p = max(0.0, sell_p - 2)
+    elif pred < 0:
+        sell_p = min(max_p, sell_p + 1)
+        buy_p = max(0.0, buy_p - 2)
+    else:
+        if slope_cls == 0:
+            sell_p = min(max_p, sell_p + 0.5)
+            buy_p = max(0.0, buy_p - 0.5)
+        else:
+            buy_p = max(0.0, buy_p - 0.5)
+            sell_p = max(0.0, sell_p - 0.5)
+
+    pressures["buy"][window_name] = buy_p
+    pressures["sell"][window_name] = sell_p
+
+    verbose = state.get("verbose", 0)
+    if verbose >= 2:
+        addlog(
+            f"[PRESSURE][{window_name}] buy={buy_p:.1f} sell={sell_p:.1f} pred={pred} slope_cls={slope_cls}",
+            verbose_int=2,
+            verbose_state=verbose,
+        )
+

--- a/systems/scripts/view_log.py
+++ b/systems/scripts/view_log.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+"""Plot structured trading logs with hover annotations."""
+
+import argparse
+import json
+from pathlib import Path
+from datetime import datetime
+
+import matplotlib.pyplot as plt
+import mplcursors
+import pandas as pd
+
+from systems.utils.time import parse_duration
+
+
+def export_png(log_path: Path, out_path: Path) -> None:
+    """Render ``log_path`` events to a PNG chart at ``out_path``."""
+
+    if not log_path.exists():
+        print(f"[ERROR] No log found at {log_path}")
+        return
+
+    with log_path.open() as f:
+        events = json.load(f)
+
+    if not events:
+        print(f"[EMPTY] {log_path.stem} log has no entries")
+        return
+
+    times = pd.to_datetime([e["timestamp"] for e in events])
+    prices: list[float] = []
+    colors: list[str] = []
+
+    for e in events:
+        decision = e.get("decision")
+        trades = e.get("trades") or []
+        if trades:
+            price = trades[0].get("price")
+        else:
+            price = e.get("features", {}).get("close")
+        if price is None:
+            price = 0.0
+
+        prices.append(price)
+
+        if decision == "BUY":
+            colors.append("green")
+        elif decision == "SELL":
+            colors.append("red")
+        elif decision == "FLAT":
+            colors.append("orange")
+        elif decision == "HOLD":
+            colors.append("gray")
+        else:
+            colors.append("yellow")
+
+    plt.switch_backend("Agg")
+    fig, ax = plt.subplots()
+    ax.scatter(times, prices, c=colors, marker="o")
+    ax.set_title(f"Trading Decisions for {log_path.stem}")
+    ax.set_xlabel("Time")
+    ax.set_ylabel("Price (USDT)")
+    plt.xticks(rotation=45)
+    plt.tight_layout()
+    fig.savefig(out_path, format="png")
+    plt.close(fig)
+
+
+def view_log(account_name: str, timeframe: str | None = None) -> None:
+    """Render a scatter plot of decisions from log files."""
+
+    log_path = Path(f"data/logs/{account_name}.json")
+    if not log_path.exists():
+        print(f"[ERROR] No log found at {log_path}")
+        return
+
+    with log_path.open() as f:
+        events = json.load(f)
+
+    if timeframe:
+        delta = parse_duration(timeframe)
+        cutoff = datetime.utcnow() - delta
+        events = [e for e in events if pd.to_datetime(e["timestamp"]) >= cutoff]
+
+    if not events:
+        print(f"[EMPTY] {account_name} log has no entries")
+        return
+
+    times = pd.to_datetime([e["timestamp"] for e in events])
+    prices: list[float] = []
+    colors: list[str] = []
+    annotations: list[str] = []
+
+    for e in events:
+        decision = e["decision"]
+        trades = e.get("trades") or []
+        if trades:
+            price = trades[0].get("price")
+        else:
+            # fallback to candle close if no trade
+            price = e.get("features", {}).get("close")
+        if price is None:
+            price = 0.0
+
+        prices.append(price)
+
+        if decision == "BUY":
+            colors.append("green")
+        elif decision == "SELL":
+            colors.append("red")
+        elif decision == "FLAT":
+            colors.append("orange")
+        elif decision == "HOLD":
+            colors.append("gray")
+        else:
+            colors.append("yellow")  # catch unexpected cases
+
+        features = e.get("features", {})
+        annotations.append(
+            f"{e['timestamp']}\n"
+            f"Decision: {decision}\n"
+            f"Slope: {features.get('slope')}\n"
+            f"Volatility: {features.get('volatility')}\n"
+            f"BuyP: {features.get('buy_pressure')} | "
+            f"SellP: {features.get('sell_pressure')}"
+        )
+
+    fig, ax = plt.subplots()
+    sc = ax.scatter(times, prices, c=colors, marker="o")
+
+    cursor = mplcursors.cursor(sc, hover=True)
+
+    @cursor.connect("add")
+    def on_hover(sel):
+        sel.annotation.set(text=annotations[sel.index])
+
+    ax.set_title(f"Trading Decisions for {account_name}")
+    ax.set_xlabel("Time")
+    ax.set_ylabel("Price (USDT)")
+    plt.xticks(rotation=45)
+    plt.tight_layout()
+    plt.show()
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--account", required=True)
+    parser.add_argument("--time", type=str, default=None)
+    args = parser.parse_args()
+    view_log(args.account, timeframe=args.time)
+

--- a/systems/scripts/visualize.py
+++ b/systems/scripts/visualize.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+def plot_trades(candles_df, events, out_path="data/tmp/sim_plot.png", show=True) -> None:
+    # Lazy import to keep non-viz runs fast
+    import matplotlib.pyplot as plt
+
+    # Basic line of close vs candle index
+    # Original time-based x-axis retained for quick reversion if desired:
+    # x = candles_df["time"]
+    # ax.plot(x, y, linewidth=1)
+
+    x = range(len(candles_df))
+    y = candles_df["close"].values
+    fig, ax = plt.subplots()
+    ax.plot(x, y, linewidth=1)
+
+    # Map candle times to index for scatter buys/sells
+    idx_map = {t: i for i, t in enumerate(candles_df["time"])}
+    buys  = [(idx_map[e["time"]], e["price"]) for e in events if e["type"] == "buy" and e["time"] in idx_map]
+    sells = [(idx_map[e["time"]], e["price"]) for e in events if e["type"] == "sell" and e["time"] in idx_map]
+    if buys:
+        bx, by = zip(*buys)
+        ax.scatter(bx, by, marker="^", s=36, alpha=0.7, label=f"Buys ({len(buys)})")
+    if sells:
+        sx, sy = zip(*sells)
+        ax.scatter(sx, sy, marker="v", s=36, alpha=0.7, label=f"Sells ({len(sells)})")
+
+    if not events:
+        ax.text(0.02, 0.95, "No trades", transform=ax.transAxes)
+
+    ax.set_title("Simulation — Price with Buy/Sell Markers")
+    ax.set_xlabel("Candle #")
+    ax.set_ylabel("Price")
+    ax.legend(loc="best")
+
+    # Always save; best-effort show
+    import os
+    os.makedirs(os.path.dirname(out_path), exist_ok=True)
+    fig.savefig(out_path, dpi=150, bbox_inches="tight")
+    try:
+        if show:
+            plt.show()
+    except Exception:
+        pass
+    finally:
+        plt.close(fig)

--- a/systems/scripts/wallet.py
+++ b/systems/scripts/wallet.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+"""Wallet helper functions."""
+
+from systems.utils.addlog import addlog
+from systems.utils.resolve_symbol import split_tag, resolve_symbols, to_tag
+from systems.utils.load_config import load_config
+from .kraken_utils import get_kraken_balance
+import ccxt
+
+
+def show_wallet(account: str, market: str | None, verbose: int = 0) -> None:
+    """Display Kraken wallet balances for the given account and market."""
+
+    cfg = load_config()
+    acct_cfg = cfg.get("accounts", {}).get(account)
+    if not acct_cfg:
+        addlog(
+            f"[ERROR] Unknown account {account}",
+            verbose_int=1,
+            verbose_state=verbose,
+        )
+        return
+    markets = acct_cfg.get("markets", {})
+    market_symbol = market or next(iter(markets.keys()), None)
+    if not market_symbol or market_symbol not in markets:
+        addlog(
+            f"[ERROR] Market {market_symbol} not configured for account {account}",
+            verbose_int=1,
+            verbose_state=verbose,
+        )
+        return
+
+    client = ccxt.kraken({"enableRateLimit": True})
+    symbols = resolve_symbols(client, market_symbol)
+    tag = to_tag(symbols["kraken_name"])
+    _, quote_asset = split_tag(tag)
+    balances = get_kraken_balance(quote_asset, verbose)
+
+    if verbose >= 1:
+        addlog("[WALLET] Kraken Balance", verbose_int=1, verbose_state=verbose)
+        addlog(str(balances), verbose_int=2, verbose_state=verbose)
+        for asset, amount in balances.items():
+            val = float(amount)
+            if val == 0:
+                continue
+            fmt = f"{val:.2f}" if val > 1 else f"{val:.6f}"
+            if asset.upper() == quote_asset.upper():
+                addlog(f"{asset}: ${fmt}", verbose_int=1, verbose_state=verbose)
+            else:
+                addlog(f"{asset}: {fmt}", verbose_int=1, verbose_state=verbose)

--- a/systems/scripts/window_utils.py
+++ b/systems/scripts/window_utils.py
@@ -1,0 +1,231 @@
+from __future__ import annotations
+
+"""Helpers for window-based price normalisation."""
+
+from typing import Tuple, Dict, Any
+import pandas as pd
+
+from systems.utils.addlog import addlog
+
+
+def _parse_window_size(window_size: str) -> int:
+    """Return number of candles corresponding to ``window_size``.
+
+    Supported suffixes:
+    ``h`` for hours, ``d`` for days, ``w`` for weeks. The dataset is assumed to
+    use one-hour candles, so values are converted accordingly.
+    """
+    if not window_size:
+        return 0
+    try:
+        value = int(window_size[:-1])
+    except ValueError:  # pragma: no cover - invalid config
+        value = 0
+    unit = window_size[-1].lower()
+    if unit == "h":
+        factor = 1
+    elif unit == "d":
+        factor = 24
+    elif unit == "w":
+        factor = 24 * 7
+    else:  # pragma: no cover - unsupported unit
+        factor = 0
+    return value * factor
+
+
+def get_window_bounds(series: pd.DataFrame, t: int, window_size: str) -> Tuple[float, float]:
+    """Return the ``(low, high)`` price bounds for a trailing window.
+
+    The window spans ``window_size`` ending at index ``t`` (inclusive). If the
+    window extends before the start of ``series`` the available range is used.
+    """
+    span = _parse_window_size(window_size)
+    start = max(0, t - span + 1)
+    window = series.iloc[start : t + 1]
+    win_low = float(window["low"].min()) if "low" in window else float(window["close"].min())
+    win_high = float(window["high"].max()) if "high" in window else float(window["close"].max())
+    return win_low, win_high
+
+
+def get_window_position(price: float, win_low: float, win_high: float) -> float:
+    """Normalise ``price`` within the window bounds to a 0..1 range."""
+    if win_high == win_low:
+        return 0.5
+    return max(0.0, min(1.0, (price - win_low) / (win_high - win_low)))
+
+
+def check_buy_conditions(
+    candle: Any,
+    window_data: Dict[str, float],
+    settings: Dict[str, Any],
+    ledger_state: Dict[str, Any],
+) -> tuple[bool, Dict[str, float]]:
+    """Return whether buy conditions are met and related metadata."""
+
+    price = float(candle["close"])
+    win_low = float(window_data.get("low", 0.0))
+    win_high = float(window_data.get("high", 0.0))
+    p = get_window_position(price, win_low, win_high)
+
+    verbose = ledger_state.get("verbose", 0)
+    window_name = settings.get("window_name", "")
+    unlock_map = ledger_state.setdefault("buy_unlock_p", {})
+    open_notes = ledger_state.get("open_notes", [])
+
+    unlock_p = unlock_map.get(window_name)
+    if unlock_p is not None and open_notes:
+        if p >= unlock_p:
+            addlog(
+                f"[UNLOCK][{window_name} {settings.get('window_size', '')}] p={p:.3f} >= unlock_p={unlock_p:.3f} → buys re-enabled",
+                verbose_int=2,
+                verbose_state=verbose,
+            )
+            unlock_map.pop(window_name, None)
+        else:
+            addlog(
+                f"[GATE][{window_name} {settings.get('window_size', '')}] buy blocked; p={p:.3f} < unlock_p={unlock_p:.3f}",
+                verbose_int=2,
+                verbose_state=verbose,
+            )
+            return False, {}
+
+    trigger = settings.get("buy_trigger_position", 0.0)
+    if p > trigger:
+        addlog(
+            f"[SKIP][{window_name} {settings.get('window_size', '')}] p={p:.3f} > buy_trigger={trigger:.3f}",
+            verbose_int=3,
+            verbose_state=verbose,
+        )
+        return False, {}
+
+    p_target = settings.get("maturity_position", 1.0)
+    price_target = win_low + p_target * (win_high - win_low)
+    roi_target = (price_target - price) / price if price else 0.0
+    unlock_new = min(1.0, p + settings.get("reset_buy_percent", 0.0))
+
+    return True, {
+        "p_buy": p,
+        "target_price": price_target,
+        "target_roi": roi_target,
+        "unlock_p": unlock_new,
+    }
+
+
+def check_sell_conditions(
+    candle: Any,
+    note: Dict[str, Any],
+    settings: Dict[str, Any],
+    ledger_state: Dict[str, Any],
+) -> bool:
+    """Return ``True`` if the note should be sold on this candle."""
+
+    price = float(candle["close"])
+    verbose = ledger_state.get("verbose", 0)
+    window_name = ledger_state.get("window_name", "")
+    window_size = ledger_state.get("window_size", "")
+
+    if ledger_state.get("sell_count", 0) >= ledger_state.get(
+        "max_sells", settings.get("max_notes_sell_per_candle", 1)
+    ):
+        return False
+
+    if price < note.get("target_price", float("inf")) or price < note.get("entry_price", float("inf")):
+        return False
+
+    buy = note.get("entry_price", 0.0)
+    qty = note.get("entry_amount", 0.0)
+    target = note.get("target_price", 0.0)
+    roi = (price - buy) / buy if buy else 0.0
+
+    maturity_pos = settings.get("maturity_position", 1.0)
+    if maturity_pos >= 0.99 and target < buy:
+        addlog(
+            f"[WARN] SellTargetBelowBuy note=#{note.get('id', '')} buy=${buy:.4f} target=${target:.4f}",
+            verbose_int=1,
+            verbose_state=verbose,
+        )
+    if roi > 5.0:
+        addlog(
+            f"[WARN] UnusuallyHighROI note=#{note.get('id', '')} roi={roi*100:.2f}% (check scale/decimals)",
+            verbose_int=1,
+            verbose_state=verbose,
+        )
+
+    addlog(
+        f"[SELL][{window_name} {window_size}] note=#{note.get('id', '')} qty={qty:.6f} buy=${buy:.4f} now=${price:.4f} target=${target:.4f} roi={roi*100:.2f}%",
+        verbose_int=1,
+        verbose_state=verbose,
+    )
+
+    ledger_state["sell_count"] = ledger_state.get("sell_count", 0) + 1
+    return True
+
+
+def get_trade_params(
+    current_price,
+    window_high,
+    window_low,
+    config,
+    entry_price=None,
+):
+    """Compute position metrics and multipliers for buy/sell decisions.
+
+    Parameters
+    ----------
+    current_price:
+        Current market price.
+    window_high:
+        Upper boundary of the price window.
+    window_low:
+        Lower boundary of the price window.
+    config:
+        Strategy configuration containing multiplier scales and optional
+        ``dead_zone_pct`` and ``maturity_multiplier`` values.
+    entry_price:
+        Optional entry price used to calculate maturity ROI.
+
+    Returns
+    -------
+    dict
+        Dictionary containing ``pos_pct``, ``in_dead_zone``, buy multipliers,
+        buy/sell cooldown multipliers, and ``maturity_roi`` (``None`` if
+        ``entry_price`` is not provided).
+    """
+
+    window_range = window_high - window_low
+    if window_range == 0:
+        pos_pct = 0.0
+    else:
+        pos_pct = ((current_price - window_low) / window_range) * 2 - 1
+
+    dead_zone_pct = config.get("dead_zone_pct", 0.0)
+    dead_zone_half = dead_zone_pct / 2
+    in_dead_zone = abs(pos_pct) <= dead_zone_half if dead_zone_pct > 0 else False
+
+    buy_scale = config.get("buy_multiplier_scale", 1.0)
+    buy_multiplier = 1.0 + (abs(pos_pct) * (buy_scale - 1.0))
+
+    buy_cd_multiplier = 1.0 + (
+        abs(pos_pct)
+        * (config.get("buy_cooldown_multiplier_scale", 1.0) - 1.0)
+    )
+    sell_cd_multiplier = 1.0 + (
+        abs(pos_pct)
+        * (config.get("sell_cooldown_multiplier_scale", 1.0) - 1.0)
+    )
+
+    maturity_roi = None
+    if entry_price is not None and window_range != 0:
+        maturity_multiplier = config.get("maturity_multiplier", 1.0)
+        mirrored_pos = -pos_pct
+        target_price = window_low + ((mirrored_pos + 1) / 2) * window_range
+        maturity_roi = ((target_price - entry_price) / entry_price) * maturity_multiplier
+
+    return {
+        "pos_pct": pos_pct,
+        "in_dead_zone": in_dead_zone,
+        "buy_multiplier": buy_multiplier,
+        "buy_cooldown_multiplier": buy_cd_multiplier,
+        "sell_cooldown_multiplier": sell_cd_multiplier,
+        "maturity_roi": maturity_roi,
+    }

--- a/systems/sim_engine.py
+++ b/systems/sim_engine.py
@@ -1,0 +1,482 @@
+from __future__ import annotations
+
+"""Historical simulation engine for position-based strategy."""
+
+import shutil
+from datetime import datetime, timezone
+import csv
+import json
+import os
+
+import ccxt
+import pandas as pd
+from tqdm import tqdm
+from typing import Any, Dict
+
+from systems.scripts.ledger import Ledger, save_ledger
+from systems.scripts.candle_loader import load_candles_df
+from systems.scripts.evaluate_buy import evaluate_buy
+from systems.scripts.evaluate_sell import evaluate_sell
+from systems.scripts.runtime_state import build_runtime_state
+from systems.scripts.trade_apply import (
+    apply_buy,
+    apply_sell,
+    paper_execute_buy,
+    paper_execute_sell,
+)
+from systems.utils.addlog import addlog
+from pathlib import Path
+
+from systems.utils.config import (
+    resolve_path,
+    load_general,
+    load_coin_settings,
+    load_account_settings,
+)
+from systems.utils.resolve_symbol import (
+    split_tag,
+    resolve_symbols,
+    to_tag,
+    sim_path_csv,
+    candle_filename,
+)
+from systems.utils.time import parse_cutoff as parse_timeframe
+from systems.utils.trade_logger import init_logger as init_trade_logger, record_event
+
+
+def _run_single_sim(
+    *,
+    general,
+    coin_settings,
+    accounts_cfg,
+    account: str,
+    market: str,
+    client: ccxt.Exchange,
+    verbose: int = 0,
+    timeframe: str = "1m",
+    viz: bool = True,
+) -> None:
+    os.environ["WS_MODE"] = "sim"
+    os.environ["WS_ACCOUNT"] = account
+    addlog(
+        "[PARITY] Running in sim mode — strategy knobs identical, only execution differs",
+        verbose_int=1,
+        verbose_state=verbose,
+    )
+
+    symbols = resolve_symbols(client, market)
+    kraken_name = symbols["kraken_name"]
+    kraken_pair = symbols["kraken_pair"]
+    binance_name = symbols["binance_name"]
+
+    addlog(
+        f"[RESOLVE][{account}][{market}] KrakenName={kraken_name} KrakenPair={kraken_pair} BinanceName={binance_name}",
+        verbose_int=1,
+        verbose_state=verbose,
+    )
+
+    tag = to_tag(kraken_name)
+    file_tag = market.replace("/", "_")
+    ledger_name = f"{account}_{file_tag}"
+    init_trade_logger(ledger_name)
+    base, _ = split_tag(tag)
+    coin = base.upper()
+    csv_path = candle_filename(account, market)
+    df, removed = load_candles_df(account, market, verbose=verbose)
+    ts_col = "timestamp"
+
+    # Optional hard check
+    if not df[ts_col].is_monotonic_increasing:
+        raise ValueError(f"Candles not sorted by {ts_col}: {csv_path}")
+
+    if timeframe:
+        delta = parse_timeframe(timeframe)
+        cutoff_ts = (datetime.now(tz=timezone.utc) - delta).timestamp()
+        df = df[df[ts_col] >= cutoff_ts].reset_index(drop=True)
+
+    # Log one line so we always know what we ran on
+    first_ts = int(df[ts_col].iloc[0]) if len(df) else None
+    last_ts = int(df[ts_col].iloc[-1]) if len(df) else None
+    first_iso = (
+        datetime.fromtimestamp(first_ts, tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+        if first_ts is not None
+        else "n/a"
+    )
+    last_iso = (
+        datetime.fromtimestamp(last_ts, tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+        if last_ts is not None
+        else "n/a"
+    )
+    print(
+        f"[DATA][SIM] file={csv_path} rows={len(df)} first={first_iso} last={last_iso} dups_removed={removed}"
+    )
+
+    total = len(df)
+
+    runtime_state = build_runtime_state(
+        general,
+        coin_settings,
+        accounts_cfg,
+        account,
+        market,
+        mode="sim",
+        client=client,
+        prev={"verbose": verbose},
+    )
+    runtime_state["mode"] = "sim"
+    runtime_state["symbol"] = tag
+    runtime_state["buy_unlock_p"] = {}
+    strategy_cfg = runtime_state.get("strategy", {})
+
+
+    ledger_obj = Ledger()
+    ledger_obj.set_metadata({"capital": runtime_state.get("capital", 0.0)})
+    buy_points: list[tuple[float, float]] = []
+    sell_points: list[tuple[float, float]] = []
+    win_metrics = {
+        "strategy": {
+            "window_size": str(strategy_cfg.get("window_size", "")),
+            "buys": 0,
+            "sells": 0,
+            "gross_invested": 0.0,
+            "realized_cost": 0.0,
+            "realized_proceeds": 0.0,
+            "realized_trades": 0,
+            "realized_roi_accum": 0.0,
+        }
+    }
+    addlog(f"[SIM] Starting simulation for {coin}", verbose_int=1, verbose_state=verbose)
+
+    step = int(strategy_cfg.get("window_step", 1))
+    window_size = int(strategy_cfg.get("window_size", 0))
+    for start in tqdm(
+        range(0, total - window_size, step),
+        desc="📉 Sim Progress",
+        dynamic_ncols=True,
+    ):
+        t = start  # anchor candle for this window
+        price = float(df.iloc[t]["close"])
+        ts = int(df.iloc[t]["timestamp"]) if "timestamp" in df.columns else None
+        iso_ts = (
+            datetime.fromtimestamp(ts, tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+            if ts is not None
+            else datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+        )
+        decision = "HOLD"
+        trades_log: list[dict[str, Any]] = []
+        ctx = {"ledger": ledger_obj}
+        buy_res = evaluate_buy(
+            ctx,
+            t,
+            df,
+            cfg=strategy_cfg,
+            runtime_state=runtime_state,
+        )
+        if buy_res:
+            result = paper_execute_buy(price, buy_res["size_usd"], timestamp=ts)
+
+            note = apply_buy(
+                ledger=ledger_obj,
+                window_name="strategy",
+                t=t,
+                meta=buy_res,
+                result=result,
+                state=runtime_state,
+            )
+
+            runtime_state.setdefault("buy_unlock_p", {})["strategy"] = buy_res.get("unlock_p")
+
+            m_buy = win_metrics.get("strategy")
+            if m_buy is not None:
+                cost = result["filled_amount"] * result["avg_price"]
+                m_buy["buys"] += 1
+                m_buy["gross_invested"] += cost
+
+            trades_log.append(
+                {
+                    "action": "BUY",
+                    "amount": result["filled_amount"] * result["avg_price"],
+                    "price": result["avg_price"],
+                    "note_id": note.get("id"),
+                }
+            )
+            decision = "BUY"
+
+            if viz:
+                buy_points.append((float(df.iloc[t][ts_col]), price))
+
+        open_notes = ledger_obj.get_open_notes()
+        sell_notes = evaluate_sell(
+            ctx,
+            t,
+            df,
+            cfg=strategy_cfg,
+            open_notes=open_notes,
+            runtime_state=runtime_state,
+        )
+        if sell_notes:
+            decision = (
+                "FLAT"
+                if any(n.get("sell_mode") == "flat" for n in sell_notes)
+                else "SELL"
+            )
+
+        for note in sell_notes:
+            result = paper_execute_sell(
+                price, note.get("entry_amount", 0.0), timestamp=ts
+            )
+            if viz:
+                mode = note.get("sell_mode", "normal")
+                sell_points.append((float(df.iloc[t][ts_col]), price, mode))
+            closed = apply_sell(
+                ledger=ledger_obj,
+                note=note,
+                t=t,
+                result=result,
+                state=runtime_state,
+            )
+            trades_log.append(
+                {
+                    "action": "SELL",
+                    "amount": result["filled_amount"] * result["avg_price"],
+                    "price": result["avg_price"],
+                    "note_id": closed.get("id"),
+                }
+            )
+
+            qty = closed.get("entry_amount", 0.0)
+            buy_price = closed.get("entry_price", 0.0)
+            exit_price = closed.get("exit_price", 0.0)
+            cost = buy_price * qty
+            proceeds = exit_price * qty
+            roi_trade = (proceeds - cost) / cost if cost > 0 else 0.0
+            m_sell = win_metrics.get("strategy")
+            if m_sell is not None:
+                m_sell["sells"] += 1
+                m_sell["realized_cost"] += cost
+                m_sell["realized_proceeds"] += proceeds
+                m_sell["realized_trades"] += 1
+                m_sell["realized_roi_accum"] += roi_trade
+        features = runtime_state.get("last_features", {}).get("strategy", {})
+        pressures = runtime_state.get("pressures", {})
+        event = {
+            "timestamp": iso_ts,
+            "ledger": ledger_name,
+            "pair": tag,
+            "window": f"{strategy_cfg.get('window_size', 0)}h",
+            "decision": decision,
+            "features": {
+                "close": price,
+                "slope": features.get("slope"),
+                "volatility": features.get("volatility"),
+                "buy_pressure": pressures.get("buy", {}).get("strategy", 0.0),
+                "sell_pressure": pressures.get("sell", {}).get("strategy", 0.0),
+                "buy_trigger": strategy_cfg.get("buy_trigger", 0.0),
+                "sell_trigger": strategy_cfg.get("sell_trigger", 0.0),
+            },
+            "trades": trades_log,
+        }
+        record_event(event)
+
+    final_price = float(df.iloc[-1]["close"]) if total else 0.0
+    summary = ledger_obj.get_account_summary(final_price)
+
+    open_value = sum(
+        n.get("entry_amount", 0.0) * final_price for n in ledger_obj.get_open_notes()
+    )
+
+    wallet_cash = runtime_state["capital"]
+    m = win_metrics.get("strategy", {})
+    realized_roi = (
+        (m.get("realized_proceeds", 0.0) / m.get("realized_cost", 1.0) - 1.0)
+        if m.get("realized_cost", 0.0) > 0
+        else 0.0
+    )
+    avg_trade_roi = (
+        m.get("realized_roi_accum", 0.0) / m.get("realized_trades", 1)
+        if m.get("realized_trades", 0) > 0
+        else 0.0
+    )
+    total_value_at_liq = m.get("realized_proceeds", 0.0) + open_value
+    realized_pnl = m.get("realized_proceeds", 0.0) - m.get("realized_cost", 0.0)
+    addlog(
+        f"[REPORT][strategy] buys={m.get('buys',0)} sells={m.get('sells',0)} realized_pnl=${realized_pnl:.2f} realized_roi={(realized_roi*100):.2f}% avg_trade_roi={(avg_trade_roi*100):.2f}% open_notes_value=${open_value:.2f} strategy_total_at_liq=${total_value_at_liq:.2f}",
+        verbose_int=1,
+        verbose_state=verbose,
+    )
+    rows = [
+        {
+            "window": "strategy",
+            "window_size": m.get("window_size", ""),
+            "buys": m.get("buys", 0),
+            "sells": m.get("sells", 0),
+            "gross_invested": m.get("gross_invested", 0.0),
+            "realized_cost": m.get("realized_cost", 0.0),
+            "realized_proceeds": m.get("realized_proceeds", 0.0),
+            "realized_pnl": realized_pnl,
+            "realized_roi": realized_roi,
+            "avg_trade_roi": avg_trade_roi,
+            "open_value_now": open_value,
+            "window_total_at_liq": total_value_at_liq,
+        }
+    ]
+
+    global_total_at_liq = wallet_cash + open_value
+    addlog(
+        f"[REPORT][GLOBAL] cash=${wallet_cash:.2f} open_value=${open_value:.2f} total_at_liq=${global_total_at_liq:.2f}",
+        verbose_int=1,
+        verbose_state=verbose,
+    )
+    addlog(
+        f"Final Value (USD): ${summary['total_value']:.2f}",
+        verbose_int=1,
+        verbose_state=verbose,
+    )
+    ledger_obj.set_metadata({"capital": runtime_state.get("capital", 0.0)})
+    save_ledger(
+        ledger_name,
+        ledger_obj,
+        sim=True,
+        final_tick=total - 1,
+        summary=summary,
+        tag=file_tag,
+    )
+    root = resolve_path("")
+    default_path = root / "data" / "tmp" / "simulation" / f"{ledger_name}.json"
+    sim_path = root / "data" / "tmp" / f"simulation_{ledger_name}.json"
+    if default_path.exists() and default_path != sim_path:
+        sim_path.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copyfile(default_path, sim_path)
+    logs_dir = root / "logs"
+    logs_dir.mkdir(parents=True, exist_ok=True)
+    ts = datetime.now().strftime("%Y%m%d_%H%M%S")
+    csv_path = logs_dir / f"sim_report_{ledger_name}_{ts}.csv"
+    json_path = logs_dir / f"sim_report_{ledger_name}_{ts}.json"
+    with csv_path.open("w", newline="", encoding="utf-8") as f_csv:
+        writer = csv.DictWriter(
+            f_csv,
+            fieldnames=[
+                "window",
+                "window_size",
+                "buys",
+                "sells",
+                "gross_invested",
+                "realized_cost",
+                "realized_proceeds",
+                "realized_pnl",
+                "realized_roi",
+                "avg_trade_roi",
+                "open_value_now",
+                "window_total_at_liq",
+            ],
+        )
+        writer.writeheader()
+        writer.writerows(rows)
+    json_data = {
+        "windows": rows,
+        "global": {
+            "cash": wallet_cash,
+            "open_value_now": open_value,
+            "total_at_liq": global_total_at_liq,
+        },
+    }
+    with json_path.open("w", encoding="utf-8") as f_json:
+        json.dump(json_data, f_json, indent=2)
+    if viz:
+        import matplotlib.pyplot as plt
+
+        times = pd.to_datetime(df[ts_col], unit="s")
+        plt.figure()
+        plt.plot(times, df["close"], label="Close", color="gray", zorder=1)
+        # --- Plot buys (single block, no duplication) ---
+        if buy_points:
+            b_t, b_p = zip(*buy_points)
+            plt.scatter(
+                pd.to_datetime(b_t, unit="s"),
+                b_p,
+                marker="o", color="g", label="Buy", zorder=2,
+            )
+
+
+        # --- Plot sells (normal vs flat) ---
+        if sell_points:
+            times_normal = [t for t, p, m in sell_points if m == "normal"]
+            prices_normal = [p for t, p, m in sell_points if m == "normal"]
+            times_flat   = [t for t, p, m in sell_points if m == "flat"]
+            prices_flat  = [p for t, p, m in sell_points if m == "flat"]
+            times_all   = [t for t, p, m in sell_points if m == "all"]
+            prices_all  = [p for t, p, m in sell_points if m == "all"]
+
+            if times_normal:
+                plt.scatter(
+                    pd.to_datetime(times_normal, unit="s"),
+                    prices_normal,
+                    marker="o", color="r", label="Sell", zorder=2,
+                )
+            if times_flat:
+                plt.scatter(
+                    pd.to_datetime(times_flat, unit="s"),
+                    prices_flat,
+                    marker="o", color="orange", label="Flat Sell", zorder=2,
+                )
+            if times_all:
+                plt.scatter(
+                    pd.to_datetime(times_all, unit="s"),
+                    prices_all,
+                    marker="x", color="red", label="All Sell", zorder=3,
+                )
+
+
+        plt.xlabel("Time")
+        plt.ylabel("Price")
+        plt.legend()
+        plt.tight_layout()
+        plt.show()
+
+
+def run_simulation(
+    *,
+    account: str | None = None,
+    market: str | None = None,
+    all_accounts: bool = False,
+    verbose: int = 0,
+    timeframe: str = "1m",
+    viz: bool = True,
+) -> None:
+    """Iterate configured accounts/markets and run simulations."""
+    general = load_general()
+    coin_settings = load_coin_settings()
+    accounts_cfg = load_account_settings()
+    accounts = accounts_cfg
+    targets = accounts.keys() if (all_accounts or not account) else [account]
+    for acct_name in targets:
+        acct_cfg = accounts.get(acct_name)
+        if not acct_cfg:
+            addlog(
+                f"[ERROR] Unknown account {acct_name}",
+                verbose_int=1,
+                verbose_state=verbose,
+            )
+            continue
+        client = ccxt.kraken({"enableRateLimit": True})
+        markets_cfg = acct_cfg.get("market settings", {})
+        m_targets = [market] if market else list(markets_cfg.keys())
+        for m in m_targets:
+            if m not in markets_cfg:
+                continue
+            addlog(
+                f"[RUN][{acct_name}][{m}]",
+                verbose_int=1,
+                verbose_state=verbose,
+            )
+            _run_single_sim(
+                general=general,
+                coin_settings=coin_settings,
+                accounts_cfg=accounts_cfg,
+                account=acct_name,
+                market=m,
+                client=client,
+                verbose=verbose,
+                timeframe=timeframe,
+                viz=viz,
+            )

--- a/systems/utils/addlog.py
+++ b/systems/utils/addlog.py
@@ -1,0 +1,40 @@
+import os
+from tqdm import tqdm
+
+LOGFILE_PATH = "data/tmp/log.txt"
+LOGGING_ENABLED = False
+DEFAULT_VERBOSE_STATE = 1
+
+
+def init_logger(
+    logging_enabled: bool = False,
+    verbose_level: int = 1,
+) -> None:
+    """Initialize logger settings."""
+    global LOGGING_ENABLED, DEFAULT_VERBOSE_STATE
+
+    LOGGING_ENABLED = logging_enabled
+    DEFAULT_VERBOSE_STATE = verbose_level
+
+    if LOGGING_ENABLED:
+        os.makedirs("data/tmp", exist_ok=True)
+        open(LOGFILE_PATH, "w").close()
+
+
+def addlog(
+    message: str,
+    verbose_int: int = 1,
+    verbose_state: int | None = None,
+) -> None:
+    """Write a log message if ``verbose_int`` is within ``verbose_state``."""
+    if verbose_state is None:
+        verbose_state = DEFAULT_VERBOSE_STATE
+
+    should_output = verbose_int <= verbose_state
+
+    if should_output:
+        tqdm.write(message)
+
+    if LOGGING_ENABLED:
+        with open(LOGFILE_PATH, "a", encoding="utf-8") as f:
+            f.write(message + "\n")

--- a/systems/utils/asset_pairs.py
+++ b/systems/utils/asset_pairs.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import json
+from typing import Dict, Any
+
+import requests
+
+from .config import resolve_path
+
+CACHE_FILE = resolve_path("data/snapshots/asset_pairs.json")
+
+
+def load_asset_pairs() -> Dict[str, Any]:
+    """Load Kraken AssetPairs from cache or live API.
+
+    Returns
+    -------
+    dict
+        Mapping of pair keys to info dictionaries as provided by Kraken.
+    """
+    if CACHE_FILE.exists():
+        try:
+            with CACHE_FILE.open("r", encoding="utf-8") as fh:
+                return json.load(fh)
+        except Exception:
+            pass
+
+    resp = requests.get("https://api.kraken.com/0/public/AssetPairs", timeout=10)
+    data = resp.json().get("result", {})
+
+    try:
+        CACHE_FILE.parent.mkdir(parents=True, exist_ok=True)
+        with CACHE_FILE.open("w", encoding="utf-8") as fh:
+            json.dump(data, fh)
+    except Exception:
+        # Caching is best-effort; ignore failures.
+        pass
+
+    return data

--- a/systems/utils/cli.py
+++ b/systems/utils/cli.py
@@ -1,0 +1,47 @@
+import argparse
+import sys
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Return a configured argument parser for WindowSurfer CLI tools."""
+
+    if any(arg.startswith("--ledger") for arg in sys.argv[1:]):
+        raise SystemExit("[ERROR] --ledger is no longer supported. Use --account instead.")
+
+    parser = argparse.ArgumentParser(description="WindowSurfer command line interface")
+    parser.add_argument(
+        "--mode",
+        choices=["fetch", "sim", "live", "wallet", "view", "test", "email"],
+        help="Execution mode: fetch, sim, live, wallet, view, test, or email",
+    )
+    parser.add_argument(
+        "--account",
+        help="Account name defined in account_settings.json",
+    )
+    parser.add_argument(
+        "--market",
+        help="Specific market symbol to operate on (default: all for account)",
+    )
+    parser.add_argument(
+        "--all",
+        action="store_true",
+        help="Run all configured accounts and their markets",
+    )
+    parser.add_argument(
+        "--dry",
+        action="store_true",
+        help="Run live mode once immediately and exit",
+    )
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        action="count",
+        default=0,
+        help="Increase verbosity level (use -v or -vv)",
+    )
+    parser.add_argument(
+        "--log",
+        action="store_true",
+        help="Enable log file output",
+    )
+    return parser

--- a/systems/utils/config.py
+++ b/systems/utils/config.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+"""Basic configuration utilities and path helpers."""
+
+from pathlib import Path
+import json
+import sys
+from typing import Any, Dict
+
+import ccxt
+
+from systems.utils.addlog import addlog
+from systems.utils.resolve_symbol import resolve_symbols, to_tag
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[2]
+_SETTINGS_CACHE: Dict[str, Any] | None = None
+_GENERAL_CACHE: Dict[str, Any] | None = None
+_ACCOUNTS_CACHE: Dict[str, Any] | None = None
+_COIN_CACHE: Dict[str, Any] | None = None
+_KEYS_CACHE: Dict[str, Any] | None = None
+
+
+def resolve_path(rel_path: str) -> Path:
+    """Return an absolute path for ``rel_path`` from the project root."""
+    return _PROJECT_ROOT / rel_path
+
+
+def load_settings(*, reload: bool = False) -> Dict[str, Any]:
+    """Load ``settings/settings.json`` with optional caching."""
+    global _SETTINGS_CACHE
+    if _SETTINGS_CACHE is None or reload:
+        settings_path = resolve_path("settings/settings.json")
+        with settings_path.open("r", encoding="utf-8") as fh:
+            _SETTINGS_CACHE = json.load(fh)
+    return _SETTINGS_CACHE
+
+
+def load_general(*, reload: bool = False) -> Dict[str, Any]:
+    """Return the ``general_settings`` block from ``settings/settings.json``."""
+    global _GENERAL_CACHE
+    if _GENERAL_CACHE is None or reload:
+        data = load_settings(reload=reload)
+        _GENERAL_CACHE = data.get("general_settings", {})
+    return _GENERAL_CACHE
+
+
+def _missing_config() -> None:
+    print(
+        "[CONFIG][ERROR] Missing settings/account_settings.json or settings/coin_settings.json"
+    )
+    sys.exit(1)
+
+
+def load_account_settings(*, reload: bool = False) -> Dict[str, Any]:
+    """Load account configuration from ``settings/account_settings.json``."""
+    global _ACCOUNTS_CACHE
+    if _ACCOUNTS_CACHE is None or reload:
+        path = resolve_path("settings/account_settings.json")
+        if not path.exists():
+            _missing_config()
+        with path.open("r", encoding="utf-8") as fh:
+            _ACCOUNTS_CACHE = json.load(fh).get("accounts", {})
+    return _ACCOUNTS_CACHE
+
+
+def load_coin_settings(*, reload: bool = False) -> Dict[str, Any]:
+    """Load per-coin strategy defaults from ``settings/coin_settings.json``."""
+    global _COIN_CACHE
+    if _COIN_CACHE is None or reload:
+        path = resolve_path("settings/coin_settings.json")
+        if not path.exists():
+            _missing_config()
+        with path.open("r", encoding="utf-8") as fh:
+            _COIN_CACHE = json.load(fh).get("coin_settings", {})
+    return _COIN_CACHE
+
+
+def load_keys(*, reload: bool = False) -> Dict[str, Any]:
+    """Load API keys from ``settings/keys.json`` (best-effort)."""
+    global _KEYS_CACHE
+    if _KEYS_CACHE is None or reload:
+        path = resolve_path("settings/keys.json")
+        if not path.exists():
+            _KEYS_CACHE = {}
+        else:
+            with path.open("r", encoding="utf-8") as fh:
+                _KEYS_CACHE = json.load(fh)
+    return _KEYS_CACHE
+
+
+def resolve_coin_config(symbol: str, coin_settings: dict) -> dict:
+    d = dict(coin_settings.get("default", {}))
+    d.update(coin_settings.get(symbol, {}))
+    return d
+
+
+def resolve_account_market(account: str, symbol: str, accounts_cfg: dict) -> dict:
+    return (
+        accounts_cfg.get(account, {}).get("market settings", {}).get(symbol, {})
+    )
+
+
+def load_ledger_config(ledger_name: str) -> Dict[str, Any]:
+    """Deprecated ledger loader retained for backward compatibility."""
+    raise ValueError("load_ledger_config is deprecated; use load_config")
+
+
+def resolve_ccxt_symbols_by_coin(coin: str) -> tuple[str, str]:
+    """Return Kraken and Binance symbols for ``coin`` based on configured markets."""
+    from systems.utils.load_config import load_config
+
+    cfg = load_config()
+    client = ccxt.kraken({"enableRateLimit": True})
+    coin_up = coin.upper()
+    for acct in cfg.get("accounts", {}).values():
+        for market in acct.get("markets", {}).keys():
+            symbols = resolve_symbols(client, market)
+            tag = to_tag(symbols["kraken_name"])
+            base = symbols["kraken_name"].split("/")[0].upper()
+            if base.startswith(coin_up):
+                addlog(
+                    f"[CONFIG] coin={coin_up} resolved using tag={tag}",
+                    verbose_int=1,
+                    verbose_state=True,
+                )
+                return symbols["kraken_name"], symbols["binance_name"]
+    msg = f"[ERROR] No market maps coin={coin_up} to exchange symbols"
+    addlog(msg, verbose_int=1, verbose_state=True)
+    raise ValueError(msg)

--- a/systems/utils/load_config.py
+++ b/systems/utils/load_config.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+"""Unified configuration loader for accounts and strategy settings."""
+
+from typing import Any, Dict
+
+from systems.utils.config import (
+    load_general,
+    load_account_settings,
+    load_coin_settings,
+    load_keys,
+    resolve_coin_config,
+    resolve_account_market,
+)
+
+_CONFIG_CACHE: Dict[str, Any] | None = None
+
+
+def load_config(*, reload: bool = False) -> Dict[str, Any]:
+    """Load accounts and strategy settings from JSON files.
+
+    Returns
+    -------
+    dict
+        Dictionary with ``accounts`` and ``general_settings`` entries.
+    """
+    global _CONFIG_CACHE
+    if _CONFIG_CACHE is None or reload:
+        general = load_general(reload=reload)
+        coin_settings = load_coin_settings(reload=reload)
+        accounts_cfg = load_account_settings(reload=reload)
+        keys = load_keys(reload=reload)
+
+        accounts: Dict[str, Any] = {}
+        for acct_name, acct_cfg in accounts_cfg.items():
+            merged_markets: Dict[str, Any] = {}
+            for market in acct_cfg.get("market settings", {}).keys():
+                coin_cfg = resolve_coin_config(market, coin_settings)
+                acct_mkt_cfg = resolve_account_market(acct_name, market, accounts_cfg)
+                merged_markets[market] = {**coin_cfg, **acct_mkt_cfg}
+            accounts[acct_name] = {
+                "api_key": keys.get(acct_name, {}).get("api_key", ""),
+                "api_secret": keys.get(acct_name, {}).get("api_secret", ""),
+                "is_live": acct_cfg.get("is_live", False),
+                "reporting": acct_cfg.get("reporting", {}),
+                "markets": merged_markets,
+            }
+        _CONFIG_CACHE = {"accounts": accounts, "general_settings": general}
+    return _CONFIG_CACHE

--- a/systems/utils/price_fetcher.py
+++ b/systems/utils/price_fetcher.py
@@ -1,0 +1,16 @@
+import json
+import urllib.request
+
+
+def get_price(symbol: str) -> float | None:
+    """Fetch the latest close price for a trading pair from Kraken."""
+    url = f"https://api.kraken.com/0/public/Ticker?pair={symbol}"
+    try:
+        with urllib.request.urlopen(url) as response:
+            data = json.load(response)
+            result = list(data.get("result", {}).values())
+            if not result:
+                return None
+            return float(result[0]["c"][0])
+    except Exception:
+        return None

--- a/systems/utils/quote_norm.py
+++ b/systems/utils/quote_norm.py
@@ -1,0 +1,10 @@
+NORM_MAP = {
+    "ZUSD": "USD",
+    "ZEUR": "EUR",
+    "ZGBP": "GBP",
+    "ZJPY": "JPY",
+}
+
+def norm_quote(q: str) -> str:
+    q = (q or "").upper()
+    return NORM_MAP.get(q, q)

--- a/systems/utils/resolve_symbol.py
+++ b/systems/utils/resolve_symbol.py
@@ -1,0 +1,67 @@
+"""Helpers for resolving exchange symbols and tag conversions."""
+
+from __future__ import annotations
+
+import ccxt
+
+
+def resolve_symbols(client: ccxt.Exchange, config_name: str) -> dict[str, str]:
+    """Return exchange identifiers for ``config_name`` using CCXT."""
+
+    markets = client.load_markets()
+
+    if config_name not in markets:
+        raise RuntimeError(f"[ERROR] Invalid trading pair: {config_name}")
+
+    m = markets[config_name]
+
+    return {
+        "kraken_name": m["symbol"],
+        "kraken_pair": m["id"],
+        "binance_name": (
+            f"{m['base']}USDT" if m["quote"] == "USD" else f"{m['base']}{m['quote']}"
+        ),
+    }
+
+
+def candle_filename(account: str, market: str, live: bool = False) -> str:
+    """Return canonical candle CSV path for ``account``/``market``."""
+
+    base = f"{account}_{market.replace('/', '_')}_1h.csv"
+    folder = "data/live" if live else "data/sim"
+    return f"{folder}/{base}"
+
+
+# ---------------------------------------------------------------------------
+# Legacy helpers retained for compatibility
+
+def to_tag(symbol: str) -> str:
+    """Normalize exchange symbol to uppercase tag without separators."""
+    return symbol.replace("/", "").replace(" ", "").upper()
+
+
+def sim_path_csv(tag: str) -> str:
+    """Return canonical SIM CSV path for ``tag``."""
+    return f"data/sim/{tag}_1h.csv"
+
+
+def live_path_csv(tag: str) -> str:
+    """Return canonical LIVE CSV path for ``tag``."""
+    return f"data/live/{tag}_1h.csv"
+
+
+def split_tag(tag: str) -> tuple[str, str]:
+    """Return base symbol and Kraken quote asset code for ``tag``."""
+    tag = tag.upper()
+    mapping = {
+        "USDT": "USDT",
+        "USDC": "USDC",
+        "DAI": "DAI",
+        "USD": "ZUSD",
+        "EUR": "ZEUR",
+        "GBP": "ZGBP",
+    }
+    for suffix, asset_code in mapping.items():
+        if tag.endswith(suffix):
+            return tag[: -len(suffix)], asset_code
+    return tag, ""

--- a/systems/utils/snapshot.py
+++ b/systems/utils/snapshot.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import json
+import time
+import hmac
+import base64
+import hashlib
+from pathlib import Path
+from urllib.parse import urlencode
+from typing import Any, Dict
+
+import requests
+
+from .config import resolve_path
+
+
+def load_snapshot(ledger_name: str) -> Dict[str, Any]:
+    """Load a cached snapshot for ``ledger_name`` if it exists."""
+    path = resolve_path(f"data/snapshots/{ledger_name}.json")
+    if path.exists():
+        try:
+            with path.open("r", encoding="utf-8") as f:
+                return json.load(f)
+        except Exception:
+            return {}
+    return {}
+
+
+def _kraken_request(endpoint: str, data: dict, api_key: str, api_secret: str) -> dict:
+    url_path = f"/0/private/{endpoint}"
+    url = f"https://api.kraken.com{url_path}"
+
+    nonce = str(int(time.time() * 1000))
+    data["nonce"] = nonce
+
+    post_data = urlencode(data)
+    encoded = (nonce + post_data).encode()
+    message = url_path.encode() + hashlib.sha256(encoded).digest()
+
+    signature = hmac.new(base64.b64decode(api_secret), message, hashlib.sha512)
+    sig_digest = base64.b64encode(signature.digest())
+
+    headers = {
+        "API-Key": api_key,
+        "API-Sign": sig_digest.decode(),
+    }
+
+    resp = requests.post(url, headers=headers, data=data, timeout=10)
+    result = resp.json()
+    if "error" in result and result["error"]:
+        raise Exception(f"Kraken API error: {result['error']}")
+    return result
+
+
+def fetch_snapshot_from_kraken(api_key: str, api_secret: str) -> Dict[str, Any]:
+    """Fetch a fresh snapshot from Kraken."""
+    balance_resp = _kraken_request("Balance", {}, api_key, api_secret).get(
+        "result", {}
+    )
+    trades_resp = _kraken_request(
+        "TradesHistory", {"type": "all", "trades": True}, api_key, api_secret
+    ).get("result", {})
+    return {
+        "timestamp": int(time.time()),
+        "balance": balance_resp,
+        "trades": trades_resp.get("trades", trades_resp),
+    }
+
+
+def prime_snapshot(ledger_name: str, api_key: str, api_secret: str) -> Dict[str, Any]:
+    """Fetch and cache a fresh snapshot for ``ledger_name``."""
+    snap = fetch_snapshot_from_kraken(api_key, api_secret)
+    path = resolve_path(f"data/snapshots/{ledger_name}.json")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as f:
+        json.dump(snap, f, indent=2)
+    return snap

--- a/systems/utils/time.py
+++ b/systems/utils/time.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+
+def parse_cutoff(value: str) -> timedelta:
+    """Return a timedelta parsed from strings like '1d' or '2w'."""
+    if not value:
+        raise ValueError("cutoff value required")
+    value = value.strip().lower()
+    if len(value) < 2:
+        raise ValueError("cutoff must be in format <num><d|w|m|y>")
+    try:
+        num = int(value[:-1])
+    except ValueError as exc:
+        raise ValueError("invalid numeric portion for cutoff") from exc
+    unit = value[-1]
+    if unit == "h":
+        return timedelta(hours=num)
+    if unit == "d":
+        return timedelta(days=num)
+    if unit == "w":
+        return timedelta(weeks=num)
+    if unit == "m":
+        return timedelta(days=30 * num)
+    if unit == "y":
+        return timedelta(days=365 * num)
+    raise ValueError("cutoff unit must be one of h,d,w,m,y")
+
+
+def parse_duration(value: str) -> timedelta:
+    """Return a ``timedelta`` parsed from shorthand like ``'1m'`` or ``'7d'``."""
+    return parse_cutoff(value)
+
+
+def parse_relative_time(value: str) -> tuple[float, float]:
+    """Return (start_ts, end_ts) parsed from a relative time string."""
+    delta = parse_cutoff(value)
+    end = datetime.now(tz=timezone.utc).timestamp()
+    start = end - delta.total_seconds()
+    return start, end
+
+def duration_from_candle_count(candle_count: int, candle_interval_minutes: int = 60) -> str:
+    """
+    Converts a number of candles into a human-readable time duration.
+    Outputs years, months, days, hours (rounded, no zeroes).
+    """
+    total_minutes = candle_count * candle_interval_minutes
+    total_hours = total_minutes // 60
+
+    days, rem_hours = divmod(total_hours, 24)
+    years, rem_days = divmod(days, 365)
+    months, days = divmod(rem_days, 30)
+
+    parts = []
+    if years:
+        parts.append(f"{years}y")
+    if months:
+        parts.append(f"{months}mo")
+    if days:
+        parts.append(f"{days}d")
+    if rem_hours:
+        parts.append(f"{rem_hours}h")
+
+    return " ".join(parts)
+

--- a/systems/utils/top_hour_report.py
+++ b/systems/utils/top_hour_report.py
@@ -1,0 +1,40 @@
+"""Utilities for formatting top-of-hour live trading reports."""
+
+from datetime import datetime
+from typing import Dict, Tuple
+
+
+def format_top_of_hour_report(
+    symbol: str,
+    ts: datetime,
+    usd_balance: float,
+    coin_balance_usd: float,
+    coin_symbol: str,
+    total_liquid_value: float,
+    triggered_strategies: Dict[str, bool],
+    note_counts: Dict[str, Tuple[int, int]],
+) -> str:
+    """Return a formatted one line summary for the current hour."""
+
+    def strat_emoji(name: str) -> str:
+        if triggered_strategies.get(name, False):
+            return {"Fish": "🐟", "Whale": "🐳", "Knife": "🔪"}.get(name, "❓")
+        return "❌"
+
+    fish = strat_emoji("Fish")
+    whale = strat_emoji("Whale")
+    knife = strat_emoji("Knife")
+    trigger_str = f"🎣{fish}{whale}{knife}" if any(triggered_strategies.values()) else "❌❌❌"
+
+    def fmt_notes(name: str) -> str:
+        open_n, closed_n = note_counts.get(name, (0, 0))
+        emoji = {"Fish": "🐟", "Whale": "🐳", "Knife": "🔪"}.get(name, name)
+        return f"{emoji} {open_n}/{closed_n}"
+
+    notes_str = " | ".join([fmt_notes("Fish"), fmt_notes("Whale"), fmt_notes("Knife")])
+    hour_str = ts.strftime("%I:%M%p")
+
+    return (
+        f"[My Ledger] {hour_str} | {symbol} | 💰${total_liquid_value:.2f} | "
+        f"💵${usd_balance:.2f} | 🪙${coin_balance_usd:.2f} | {trigger_str} | Notes: {notes_str}"
+    )

--- a/systems/utils/trade_eval.py
+++ b/systems/utils/trade_eval.py
@@ -1,0 +1,172 @@
+from __future__ import annotations
+
+"""Unified trade evaluation helper for buy and sell paths."""
+
+from typing import Dict, List, Tuple
+
+from systems.scripts.window_utils import get_trade_params
+from systems.utils.addlog import addlog
+from systems.scripts.trade_apply import apply_buy, apply_sell
+
+
+def evaluate_trade(
+    trade_type: str,
+    current_price: float,
+    ledger,
+    strategy_cfg: Dict,
+    cooldown_tracker: Dict[str, int],
+    tick: int,
+    verbose: int,
+):
+    """Evaluate and execute a trade of ``trade_type``.
+
+    Parameters
+    ----------
+    trade_type: ``"buy"`` or ``"sell"``
+    current_price: float
+    ledger: Ledger instance
+    strategy_cfg: Dict containing window/config information
+    cooldown_tracker: mapping of window -> last tick executed
+    tick: current tick
+    verbose: verbosity level
+    """
+
+    name = strategy_cfg["name"]
+    cfg = strategy_cfg["cfg"]
+    wave = strategy_cfg["wave"]
+    sim_capital = strategy_cfg["sim_capital"]
+
+    if trade_type == "buy":
+        max_note_usdt = strategy_cfg["max_note_usdt"]
+        min_note_usdt = strategy_cfg["min_note_usdt"]
+
+        trade_params = get_trade_params(
+            current_price=current_price,
+            window_high=wave["ceiling"],
+            window_low=wave["floor"],
+            config=cfg,
+        )
+        if verbose >= 3:
+            addlog(
+                f"[DEBUG][BUY] Window={name} price={current_price:.6f} pos_pct={trade_params['pos_pct']:.2f} "
+                f"ceiling={wave['ceiling']:.6f} floor={wave['floor']:.6f} "
+                f"buy_mult={trade_params['buy_multiplier']:.2f} "
+                f"buy_cd_mult={trade_params['buy_cooldown_multiplier']:.2f}",
+                verbose_int=3,
+                verbose_state=verbose,
+            )
+
+        if trade_params["in_dead_zone"]:
+            return sim_capital, False
+
+        base_cd = cfg.get("buy_cooldown", 0)
+        adjusted_cd = int(base_cd / trade_params["buy_cooldown_multiplier"])
+        if tick - cooldown_tracker.get(name, float("-inf")) < adjusted_cd:
+            return sim_capital, True
+
+        base_note_count = sim_capital * cfg.get("investment_fraction", 0)
+        adjusted_note_count = base_note_count * trade_params["buy_multiplier"]
+        invest = min(adjusted_note_count, max_note_usdt)
+        if invest >= min_note_usdt and invest <= sim_capital:
+            amount = invest / current_price
+            result = {
+                "filled_amount": amount,
+                "avg_price": current_price,
+                "timestamp": tick,
+            }
+            meta = {
+                "window_name": name,
+                "window_size": cfg.get("window_size"),
+            }
+            state = {"capital": sim_capital}
+            apply_buy(
+                ledger=ledger,
+                window_name=name,
+                t=tick,
+                meta=meta,
+                result=result,
+                state=state,
+            )
+            sim_capital = state.get("capital", sim_capital)
+            cooldown_tracker[name] = tick
+            addlog(
+                f"[BUY] {name} tick {tick} price={current_price:.6f}",
+                verbose_int=2,
+                verbose_state=verbose,
+            )
+        return sim_capital, False
+
+    if trade_type == "sell":
+        base_sell_cooldown = strategy_cfg["base_sell_cooldown"]
+        trade = get_trade_params(current_price, wave["ceiling"], wave["floor"], cfg)
+        if trade["in_dead_zone"]:
+            return sim_capital, [], 0
+
+        to_close: List[Dict] = []
+        roi_skipped = 0
+        notes = [n for n in ledger.get_active_notes() if n["window"] == name]
+        notes.sort(
+            key=lambda n: (current_price - n["entry_price"]) / n["entry_price"],
+            reverse=True,
+        )
+        for note in notes:
+            gain_pct = (current_price - note["entry_price"]) / note["entry_price"]
+            trade_note = get_trade_params(
+                current_price,
+                wave["ceiling"],
+                wave["floor"],
+                cfg,
+                entry_price=note["entry_price"],
+            )
+            maturity_roi = trade_note["maturity_roi"]
+            if maturity_roi is not None:
+                addlog(
+                    f"[DEBUG][SELL] gain_pct={gain_pct:.2%} maturity_roi={maturity_roi:.2%}",
+                    verbose_int=3,
+                    verbose_state=verbose,
+                )
+            else:
+                addlog(
+                    f"[DEBUG][SELL] gain_pct={gain_pct:.2%} maturity_roi=None",
+                    verbose_int=3,
+                    verbose_state=verbose,
+                )
+            if (
+                maturity_roi is None
+                or maturity_roi <= 0
+                or gain_pct < 0
+                or gain_pct < maturity_roi
+            ):
+                roi_skipped += 1
+                continue
+            adjusted_cd = int(
+                base_sell_cooldown / trade_note["sell_cooldown_multiplier"]
+            )
+            if tick - cooldown_tracker.get(name, float("-inf")) < adjusted_cd:
+                continue
+            gain = (current_price - note["entry_price"]) * note["entry_amount"]
+            note["exit_tick"] = tick
+            note["exit_price"] = current_price
+            note["exit_ts"] = tick
+            note["gain"] = gain
+            base = note["entry_price"] * note["entry_amount"] or 1
+            note["gain_pct"] = gain / base
+            note["status"] = "Closed"
+            to_close.append(note)
+            cooldown_tracker[name] = tick
+
+        closed: List[Dict] = []
+        for note in to_close:
+            res = {
+                "filled_amount": note.get("entry_amount", 0.0),
+                "avg_price": current_price,
+                "timestamp": tick,
+            }
+            state = {"capital": sim_capital}
+            apply_sell(ledger=ledger, note=note, t=tick, result=res, state=state)
+            sim_capital = state.get("capital", sim_capital)
+            closed.append(note)
+        return sim_capital, closed, roi_skipped
+
+    raise ValueError("trade_type must be 'buy' or 'sell'")
+

--- a/systems/utils/trade_logger.py
+++ b/systems/utils/trade_logger.py
@@ -1,0 +1,39 @@
+import json
+import os
+from typing import Any, Dict, List
+
+_log_path: str | None = None
+
+
+def init_logger(ledger_name: str) -> None:
+    """Initialize JSON log file for a given ledger."""
+    global _log_path
+    os.makedirs("data/logs", exist_ok=True)
+    _log_path = os.path.join("data", "logs", f"{ledger_name}.json")
+    if not os.path.exists(_log_path):
+        with open(_log_path, "w", encoding="utf-8") as f:
+            json.dump([], f)
+
+
+def _load_events() -> List[Dict[str, Any]]:
+    if not _log_path:
+        raise RuntimeError("Logger not initialized")
+    if os.path.exists(_log_path):
+        with open(_log_path, "r", encoding="utf-8") as f:
+            try:
+                data = json.load(f)
+            except json.JSONDecodeError:
+                data = []
+    else:
+        data = []
+    return data
+
+
+def record_event(event: Dict[str, Any]) -> None:
+    """Append ``event`` to the current ledger's JSON log."""
+    if not _log_path:
+        raise RuntimeError("Logger not initialized")
+    data = _load_events()
+    data.append(event)
+    with open(_log_path, "w", encoding="utf-8") as f:
+        json.dump(data, f, indent=2)

--- a/test.py
+++ b/test.py
@@ -1,5 +1,11 @@
 #!/usr/bin/env python3
-"""Connectivity and configuration checks."""
+"""Connectivity and configuration checks.
+
+Example:
+    python test.py --account Kris --market DOGEUSD --smoketest
+
+Use ``--help`` to see available options.
+"""
 
 from __future__ import annotations
 


### PR DESCRIPTION
## Summary
- add usage examples and help hints to `sim.py`, `live.py`, and `test.py`
- create a unified `bot.py` entry point with `sim`, `live`, and `test` subcommands
- port `systems` package from legacy and provide lightweight plotting wrappers

## Testing
- `python sim.py --help`
- `python live.py --help`
- `python test.py --help`
- `python test.py --account Kris --market DOGEUSD --smoketest` *(fails: kraken GET https://api.kraken.com/0/public/Time)*
- `python sim.py --coin DOGEUSD --time 1w --viz` *(fails: NetworkError: kraken GET https://api.kraken.com/0/public/Assets)*
- `python live.py --account Kris --market DOGEUSD` *(keyboard interrupted)*
- `python bot.py --help`


------
https://chatgpt.com/codex/tasks/task_e_68ac3e26346883269049cb923b2d10f7