### PR TITLE
Refactor sim engine to load settings and modular scripts

### DIFF
--- a/systems/scripts/chart.py
+++ b/systems/scripts/chart.py
@@ -15,9 +15,10 @@ def plot_trades(
     trades: List[Dict[str, float]],
     start_capital: float,
     final_value: float,
-    angle_lookback: int = 48,
+    cfg: Dict[str, float],
 ) -> None:
     """Plot price, exhaustion points, volatility, and trade markers."""
+    angle_lookback = int(cfg.get("angle_lookback", 48))
     fig, ax1 = plt.subplots(figsize=(12, 6))
     ax1.plot(df["candle_index"], df["close"], lw=1, label="Close Price", color="blue")
     ax1.set_title(f"Exhaustion Trades\nStart {start_capital}, End {final_value:.2f}")

--- a/systems/scripts/evaluate_buy.py
+++ b/systems/scripts/evaluate_buy.py
@@ -5,61 +5,54 @@ from __future__ import annotations
 from typing import Any, Dict, List, Tuple
 
 
-# Buy scaling constants
-BUY_MIN_BUBBLE    = 100
-BUY_MAX_BUBBLE    = 500
-MIN_NOTE_SIZE_PCT = 0.03    # 1% of portfolio
-MAX_NOTE_SIZE_PCT = 0.25    # 5% of portfolio
-
-# Sell scaling (baked into note at buy time)
-SELL_MIN_BUBBLE   = 150
-SELL_MAX_BUBBLE   = 800
-MIN_MATURITY      = 0.05    # 0% gain (sell at entry)
-MAX_MATURITY      = .25     # 100% gain (2x entry)
-
-# Volatility buy scaling
-BUY_MIN_VOL_BUBBLE = 0
-BUY_MAX_VOL_BUBBLE = .01
-BUY_MULT_VOL_MIN   = 2.5
-BUY_MULT_VOL_MAX   = 0
-
-# Trend multipliers
-BUY_MULT_TREND_UP   = 1   # strong up-trend multiplier (cap at +1 normalized)
-BUY_MULT_TREND_FLOOR = .25  # keep 0 so flat maps to 0, no forced minimum
-BUY_MULT_TREND_DOWN = 0   # strong down-trend multiplier (cap at -1 normalized)
-
-
-def scale_buy_size(s: float, total_cap: float) -> float:
-    if s < BUY_MIN_BUBBLE:
+def scale_buy_size(s: float, total_cap: float, cfg: Dict[str, float]) -> float:
+    """Scale buy size based on bubble magnitude and portfolio."""
+    min_bubble = cfg.get("buy_min_bubble", 0)
+    max_bubble = cfg.get("buy_max_bubble", 0)
+    if s < min_bubble:
         return 0.0
-    s_clamped = min(max(s, BUY_MIN_BUBBLE), BUY_MAX_BUBBLE)
-    frac = (s_clamped - BUY_MIN_BUBBLE) / (BUY_MAX_BUBBLE - BUY_MIN_BUBBLE)
-    pct = MIN_NOTE_SIZE_PCT + frac * (MAX_NOTE_SIZE_PCT - MIN_NOTE_SIZE_PCT)
+    s_clamped = min(max(s, min_bubble), max_bubble)
+    frac = (s_clamped - min_bubble) / max(1e-9, (max_bubble - min_bubble))
+    pct = cfg.get("min_note_size_pct", 0.0) + frac * (
+        cfg.get("max_note_size_pct", 0.0) - cfg.get("min_note_size_pct", 0.0)
+    )
     return total_cap * pct
 
 
-def sell_target_from_bubble(entry_price: float, s: float) -> float:
-    if s < SELL_MIN_BUBBLE:
-        return float("inf")  # effectively never sell
-    s_clamped = min(max(s, SELL_MIN_BUBBLE), SELL_MAX_BUBBLE)
-    frac = (s_clamped - SELL_MIN_BUBBLE) / (SELL_MAX_BUBBLE - SELL_MIN_BUBBLE)
-    maturity = MIN_MATURITY + frac * (MAX_MATURITY - MIN_MATURITY)
+def sell_target_from_bubble(entry_price: float, s: float, cfg: Dict[str, float]) -> float:
+    """Compute sell target price from bubble size."""
+    min_bubble = cfg.get("sell_min_bubble", 0)
+    max_bubble = cfg.get("sell_max_bubble", 0)
+    if s < min_bubble:
+        return float("inf")
+    s_clamped = min(max(s, min_bubble), max_bubble)
+    frac = (s_clamped - min_bubble) / max(1e-9, (max_bubble - min_bubble))
+    maturity = cfg.get("min_maturity", 0.0) + frac * (
+        cfg.get("max_maturity", 0.0) - cfg.get("min_maturity", 0.0)
+    )
     return entry_price * (1 + maturity)
 
 
-def trend_multiplier_lerp(v: float) -> float:
+def trend_multiplier_lerp(v: float, cfg: Dict[str, float]) -> float:
     """Linear interpolation of trend multiplier from normalized angle."""
     v = max(-1.0, min(1.0, float(v)))
+    down = cfg.get("buy_mult_trend_down", 0.0)
+    floor = cfg.get("buy_mult_trend_floor", 0.0)
+    up = cfg.get("buy_mult_trend_up", 0.0)
     if v < 0:
-        return BUY_MULT_TREND_DOWN + (BUY_MULT_TREND_FLOOR - BUY_MULT_TREND_DOWN) * (v + 1)
-    return BUY_MULT_TREND_FLOOR + (BUY_MULT_TREND_UP - BUY_MULT_TREND_FLOOR) * v
+        return down + (floor - down) * (v + 1)
+    return floor + (up - floor) * v
 
 
-def vol_multiplier(vol: float) -> float:
+def vol_multiplier(vol: float, cfg: Dict[str, float]) -> float:
     """Map rolling volatility into a buy multiplier."""
-    v = min(max(vol, BUY_MIN_VOL_BUBBLE), BUY_MAX_VOL_BUBBLE)
-    frac = (v - BUY_MIN_VOL_BUBBLE) / max(1e-9, (BUY_MAX_VOL_BUBBLE - BUY_MIN_VOL_BUBBLE))
-    return BUY_MULT_VOL_MIN + frac * (BUY_MULT_VOL_MAX - BUY_MULT_VOL_MIN)
+    min_b = cfg.get("buy_min_vol_bubble", 0.0)
+    max_b = cfg.get("buy_max_vol_bubble", 0.0)
+    v = min(max(vol, min_b), max_b)
+    frac = (v - min_b) / max(1e-9, (max_b - min_b))
+    return cfg.get("buy_mult_vol_min", 0.0) + frac * (
+        cfg.get("buy_mult_vol_max", 0.0) - cfg.get("buy_mult_vol_min", 0.0)
+    )
 
 
 def evaluate_buy(
@@ -68,13 +61,11 @@ def evaluate_buy(
     pts: Dict[str, Dict[str, List[float]]],
     capital: float,
     open_notes: List[Dict[str, float]],
-) -> Tuple[Dict[str, Any] | None, float, List[Dict[str, float]]]:
-    """Evaluate a potential buy at the given candle index.
-
-    Returns a tuple of (trade_dict_or_None, new_capital, new_open_notes).
-    """
+    cfg: Dict[str, float],
+) -> Tuple[List[Dict[str, Any]], float, List[Dict[str, float]]]:
+    """Evaluate a potential buy at the given candle index."""
     updated_notes = list(open_notes)
-    maybe_trade: Dict[str, Any] | None = None
+    trades: List[Dict[str, Any]] = []
     updated_capital = capital
 
     price = row["close"]
@@ -83,25 +74,27 @@ def evaluate_buy(
         i = pts["exhaustion_down"]["x"].index(idx)
         bubble = pts["exhaustion_down"]["s"][i]
         total_cap = capital + sum(n["units"] * price for n in open_notes)
-        trade_usd = scale_buy_size(bubble, total_cap)
+        trade_usd = scale_buy_size(bubble, total_cap, cfg)
 
         v = row["angle"]
-        trend_mult = trend_multiplier_lerp(v)
+        trend_mult = trend_multiplier_lerp(v, cfg)
 
         vol = row.get("volatility", 0)
-        vol_mult = vol_multiplier(vol)
+        vol_mult = vol_multiplier(vol, cfg)
 
-        trade_usd *= max(BUY_MULT_TREND_FLOOR, trend_mult)
+        trend_floor = cfg.get("buy_mult_trend_floor", 0.0)
+        trade_usd *= max(trend_floor, trend_mult)
         trade_usd *= vol_mult
 
         if trade_usd > 0 and capital >= trade_usd:
             units = trade_usd / price
             updated_capital -= trade_usd
-            sell_price = sell_target_from_bubble(price, bubble)
+            sell_price = sell_target_from_bubble(price, bubble, cfg)
             updated_notes.append({"entry_price": price, "units": units, "sell_price": sell_price})
-            maybe_trade = {"idx": idx, "price": price, "side": "BUY", "usd": trade_usd}
+            trades.append({"idx": idx, "price": price, "side": "BUY", "usd": trade_usd})
             print(
                 f"BUY @ idx={idx}, price={price:.2f}, angle_mult={trend_mult:.2f}, vol_mult={vol_mult:.2f}, target={sell_price:.2f}"
             )
 
-    return maybe_trade, updated_capital, updated_notes
+    return trades, updated_capital, updated_notes
+

--- a/systems/scripts/evaluate_sell.py
+++ b/systems/scripts/evaluate_sell.py
@@ -10,6 +10,7 @@ def evaluate_sell(
     price: float,
     open_notes: List[Dict[str, float]],
     capital: float,
+    cfg: Dict[str, Any] | None = None,
 ) -> Tuple[List[Dict[str, Any]], float, List[Dict[str, float]]]:
     """Return closed trade records and updated portfolio state."""
     trades_closed: List[Dict[str, Any]] = []

--- a/systems/sim_engine.py
+++ b/systems/sim_engine.py
@@ -8,24 +8,16 @@ import os
 import pandas as pd
 import numpy as np
 
+from typing import Any, Dict, List
+
+from systems.utils.settings_loader import load_coin_settings, load_general_settings
 from systems.scripts.evaluate_buy import evaluate_buy
 from systems.scripts.evaluate_sell import evaluate_sell
 from systems.scripts.chart import plot_trades
 
 # ===================== Parameters =====================
-# Lookbacks
-
-SIZE_SCALAR      = 1_000_000
-SIZE_POWER       = 3
-
-START_CAPITAL    = 10_000   # starting cash in USDT
-MONTHLY_TOPUP    = 000    # fixed USDT injected each calendar month
-
-EXHAUSTION_LOOKBACK = 184   # used for bubble delta
-WINDOW_STEP = 12
-
-VOL_LOOKBACK = 48   # rolling window for volatility
-ANGLE_LOOKBACK = 48     # used for slope angle
+SIZE_SCALAR = 1_000_000
+SIZE_POWER = 3
 
 
 _INTERVAL_RE = re.compile(r'[_\-]((\d+)([smhdw]))(?=\.|_|$)', re.I)
@@ -62,7 +54,9 @@ def infer_candle_seconds_from_filename(path: str) -> int | None:
     n, u = int(m.group(2)), m.group(3).lower()
     return n * INTERVAL_SECONDS[u]
 
-def apply_time_filter(df: pd.DataFrame, delta: timedelta, file_path: str) -> pd.DataFrame:
+def apply_time_filter(
+    df: pd.DataFrame, delta: timedelta, file_path: str, exhaustion_lookback: int
+) -> pd.DataFrame:
     if delta is None:
         return df
     if 'timestamp' in df.columns:
@@ -83,46 +77,58 @@ def apply_time_filter(df: pd.DataFrame, delta: timedelta, file_path: str) -> pd.
             except Exception:
                 pass
     sec = infer_candle_seconds_from_filename(file_path) or 3600
-    need = int(max(EXHAUSTION_LOOKBACK*2, delta.total_seconds() // sec))
+    need = int(max(exhaustion_lookback * 2, delta.total_seconds() // sec))
     if need <= 0 or need >= len(df):
         return df
     return df.iloc[-need:]
 
 # ===================== Exhaustion Plot + Trades =====================
-def run_simulation(*, timeframe: str = "1m", viz: bool = True) -> None:
-    file_path = "data/sim/SOLUSD_1h.csv"
+def run_simulation(*, coin: str, timeframe: str = "1m", viz: bool = True) -> None:
+    general_cfg = load_general_settings()
+    coin_cfg = load_coin_settings(coin)
+
+    start_capital = general_cfg.get("simulation_capital", 1000)
+    monthly_topup = general_cfg.get("monthly_topup", 0)
+    exhaustion_lookback = int(coin_cfg.get("exhaustion_lookback", 0))
+    window_step = int(coin_cfg.get("window_step", 1))
+    vol_lookback = int(coin_cfg.get("vol_lookback", 1))
+    angle_lookback = int(coin_cfg.get("angle_lookback", 1))
+
+    file_path = f"data/candles/sim/{coin}.csv"
+    if not os.path.exists(file_path):
+        file_path = f"data/sim/{coin}.csv"
     df = pd.read_csv(file_path)
 
     delta = parse_timeframe(timeframe)
     if delta is not None:
-        df = apply_time_filter(df, delta, file_path)
+        df = apply_time_filter(df, delta, file_path, exhaustion_lookback)
 
     df = df.reset_index(drop=True)
     df["candle_index"] = range(len(df))
 
     df["returns"] = df["close"].pct_change()
-    df["volatility"] = df["returns"].rolling(VOL_LOOKBACK).std().fillna(0)
+    df["volatility"] = df["returns"].rolling(vol_lookback).std().fillna(0)
 
     # ----- Exhaustion points and rolling angles -----
     pts = {
-        "exhaustion_up":   {"x": [], "y": [], "s": []},
+        "exhaustion_up": {"x": [], "y": [], "s": []},
         "exhaustion_down": {"x": [], "y": [], "s": []},
     }
     df["angle"] = 0.0
     vol_pts = {"x": [], "y": [], "s": []}
 
     # Rolling slope calculation
-    for t in range(ANGLE_LOOKBACK, len(df)):
-        dy = df["close"].iloc[t] - df["close"].iloc[t - ANGLE_LOOKBACK]
-        dx = ANGLE_LOOKBACK
+    for t in range(angle_lookback, len(df)):
+        dy = df["close"].iloc[t] - df["close"].iloc[t - angle_lookback]
+        dx = angle_lookback
         angle = np.arctan2(dy, dx)
         norm = angle / (np.pi / 4)
         df.at[t, "angle"] = max(-1.0, min(1.0, norm))
 
     # Exhaustion bubbles
-    for t in range(EXHAUSTION_LOOKBACK, len(df), WINDOW_STEP):
+    for t in range(exhaustion_lookback, len(df), window_step):
         now_price = float(df["close"].iloc[t])
-        past_price = float(df["close"].iloc[t - EXHAUSTION_LOOKBACK])
+        past_price = float(df["close"].iloc[t - exhaustion_lookback])
         end_idx = int(df["candle_index"].iloc[t])
 
         if now_price > past_price:
@@ -141,19 +147,19 @@ def run_simulation(*, timeframe: str = "1m", viz: bool = True) -> None:
             pts["exhaustion_down"]["y"].append(now_price)
             pts["exhaustion_down"]["s"].append(size)
 
-    for t in range(VOL_LOOKBACK, len(df), WINDOW_STEP):
+    for t in range(vol_lookback, len(df), window_step):
         vol = df["volatility"].iloc[t]
         if pd.isna(vol):
             continue
-        size = SIZE_SCALAR * (vol * .4 ** SIZE_POWER)
+        size = SIZE_SCALAR * (vol * 0.4 ** SIZE_POWER)
         vol_pts["x"].append(int(df["candle_index"].iloc[t]))
         vol_pts["y"].append(float(df["close"].iloc[t]))
         vol_pts["s"].append(size)
 
     # ===== Candle-by-candle simulation =====
-    trades = []
-    capital = START_CAPITAL
-    open_notes = []
+    trades: List[Dict[str, Any]] = []
+    capital = start_capital
+    open_notes: List[Dict[str, float]] = []
     last_month = None
 
     for idx, row in df.iterrows():
@@ -170,41 +176,43 @@ def run_simulation(*, timeframe: str = "1m", viz: bool = True) -> None:
         if dt is not None:
             current_month = (dt.year, dt.month)
             if current_month != last_month:
-                capital += MONTHLY_TOPUP
+                capital += monthly_topup
                 last_month = current_month
-                print(f"Monthly top-up: +{MONTHLY_TOPUP} USDT at {dt.date()} → Capital={capital:.2f}")
+                if monthly_topup:
+                    print(
+                        f"Monthly top-up: +{monthly_topup} USDT at {dt.date()} → Capital={capital:.2f}"
+                    )
 
         price = row["close"]
 
-        trade, capital, open_notes = evaluate_buy(idx, row, pts, capital, open_notes)
-        if trade:
-            trades.append(trade)
+        new_trades, capital, open_notes = evaluate_buy(
+            idx, row, pts, capital, open_notes, coin_cfg
+        )
+        trades.extend(new_trades)
 
-        closed, capital, open_notes = evaluate_sell(idx, price, open_notes, capital)
-        trades.extend(closed)
+        closed_trades, capital, open_notes = evaluate_sell(
+            idx, price, open_notes, capital, coin_cfg
+        )
+        trades.extend(closed_trades)
 
     # Final portfolio value
     final_value = capital + sum(n["units"] * float(df["close"].iloc[-1]) for n in open_notes)
 
     if viz:
-        plot_trades(
-            df,
-            pts,
-            vol_pts,
-            trades,
-            START_CAPITAL,
-            final_value,
-            angle_lookback=ANGLE_LOOKBACK,
-        )
+        plot_trades(df, pts, vol_pts, trades, start_capital, final_value, coin_cfg)
 
-    print(f"Final Capital: {capital:.2f}, Open Notes: {len(open_notes)}, Final Value: {final_value:.2f}")
+    print(
+        f"Final Capital: {capital:.2f}, Open Notes: {len(open_notes)}, Final Value: {final_value:.2f}"
+    )
 
 def main() -> None:
     p = argparse.ArgumentParser()
+    p.add_argument("--coin", required=True)
     p.add_argument("--time", type=str, default="1m")
     p.add_argument("--viz", action="store_true")
     args = p.parse_args()
-    run_simulation(timeframe=args.time, viz=args.viz)
+    run_simulation(coin=args.coin, timeframe=args.time, viz=args.viz)
+
 
 if __name__ == "__main__":
     main()

--- a/systems/utils/settings_loader.py
+++ b/systems/utils/settings_loader.py
@@ -7,13 +7,12 @@ from pathlib import Path
 from typing import Any, Dict
 
 COIN_SETTINGS_PATH = Path(__file__).resolve().parents[2] / "settings" / "coin_settings.json"
+GENERAL_SETTINGS_PATH = Path(__file__).resolve().parents[2] / "settings" / "settings.json"
+ACCOUNT_SETTINGS_PATH = Path(__file__).resolve().parents[2] / "settings" / "account_settings.json"
 
 
 def load_coin_settings(market: str) -> Dict[str, Any]:
-    """
-    Load coin-specific settings from coin_settings.json.
-    Merge 'default' with overrides for given market.
-    """
+    """Load coin-specific settings merging defaults with market overrides."""
     with COIN_SETTINGS_PATH.open("r", encoding="utf-8") as f:
         data = json.load(f).get("coin_settings", {})
 
@@ -22,3 +21,15 @@ def load_coin_settings(market: str) -> Dict[str, Any]:
     if overrides:
         cfg.update(overrides)
     return cfg
+
+
+def load_general_settings() -> Dict[str, Any]:
+    """Return general simulation settings."""
+    with GENERAL_SETTINGS_PATH.open("r", encoding="utf-8") as f:
+        return json.load(f).get("general_settings", {})
+
+
+def load_account_settings() -> Dict[str, Any]:
+    """Return account configuration mapping."""
+    with ACCOUNT_SETTINGS_PATH.open("r", encoding="utf-8") as f:
+        return json.load(f).get("accounts", {})


### PR DESCRIPTION
## Summary
- externalize simulation config loading for coin, general, and account settings
- drive buy/sell/chart logic via modular scripts using settings
- refactor simulation engine to use loaded settings and modular helpers

## Testing
- `python sim.py --coin DOGEUSD --time 1m --viz` *(fails: No module named 'systems.scripts.plot')*
- `python -m systems.sim_engine --coin DOGEUSD --time 1m --viz`
- `pytest` *(fails: ModuleNotFoundError: No module named 'systems')*

------
https://chatgpt.com/codex/tasks/task_e_68ac44eddb4083268cdccda9cba0dc63