### PR TITLE
Move simulation plotting into graph_engine

### DIFF
--- a/graph.py
+++ b/graph.py
@@ -1,29 +1,30 @@
 #!/usr/bin/env python3
+"""Thin CLI wrapper for simulation visualization."""
+
 from __future__ import annotations
 
-"""Minimal plotting utilities for ledgers and candles."""
+import argparse
+from typing import Optional
 
-import json
-from pathlib import Path
-
-import matplotlib.pyplot as plt  # type: ignore
-import pandas as pd
+from systems.graph_engine import render_simulation
 
 
-def plot(ledger_path: str, candles_path: str) -> None:
-    """Plot candle close prices with optional trade markers."""
-    df = pd.read_csv(candles_path)
-    plt.plot(df["timestamp"], df["close"], label="Close", color="blue")
-    try:
-        with open(ledger_path, "r", encoding="utf-8") as f:
-            ledger = json.load(f)
-        for note in ledger.get("closed_notes", []):
-            if "created_ts" in note and "entry_price" in note:
-                plt.scatter(note["created_ts"], note["entry_price"], color="green", marker="^")
-            if "exit_ts" in note and "exit_price" in note:
-                plt.scatter(note["exit_ts"], note["exit_price"], color="red", marker="v")
-    except FileNotFoundError:
-        pass
-    plt.legend()
-    plt.tight_layout()
-    plt.show()
+def main(argv: Optional[list[str]] = None) -> None:
+    parser = argparse.ArgumentParser(description="Render simulation ledger")
+    parser.add_argument(
+        "--ledger",
+        default="data/temp/sim_data.json",
+        help="Path to simulation ledger JSON",
+    )
+    parser.add_argument(
+        "--viz", action="store_true", help="Render visualization"
+    )
+    args = parser.parse_args(argv)
+
+    if args.viz:
+        render_simulation(args.ledger)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()
+

--- a/sim.py
+++ b/sim.py
@@ -8,7 +8,6 @@ from pathlib import Path
 from typing import Optional
 import json
 
-from systems.scripts.plot import plot_from_json
 
 
 def _ensure_candles(coin: str) -> Path:
@@ -72,7 +71,9 @@ def main(argv: Optional[list[str]] = None) -> None:
 
     if args.viz:
         try:
-            plot_from_json(str(sim_path))
+            from systems.graph_engine import render_simulation
+
+            render_simulation(str(sim_path))
         except Exception as exc:  # pragma: no cover - plotting best effort
             print(f"[WARN] Plotting failed: {exc}")
 

--- a/systems/graph_engine.py
+++ b/systems/graph_engine.py
@@ -1,0 +1,29 @@
+"""Visualization engine for simulation outputs."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict, List
+
+import pandas as pd
+
+from systems.scripts.chart import plot_trades
+
+
+def render_simulation(sim_path: str) -> None:
+    """Load simulation data from ``sim_path`` and render plots."""
+    path = Path(sim_path)
+    with path.open("r", encoding="utf-8") as fh:
+        data = json.load(fh)
+
+    df = pd.DataFrame(data.get("df", {}))
+    pts: Dict[str, Dict[str, List[float]]] = data.get("pts", {})
+    vol_pts: Dict[str, List[float]] = data.get("vol_pts", {})
+    trades: List[Dict[str, float]] = data.get("trades", [])
+    meta: Dict[str, Any] = data.get("meta", {})
+    start_capital = float(meta.get("start_capital", 0.0))
+    final_value = float(meta.get("final_value", 0.0))
+
+    plot_trades(df, pts, vol_pts, trades, start_capital, final_value)
+


### PR DESCRIPTION
## Summary
- add `systems/graph_engine.render_simulation` to load simulation JSON and plot via `chart.py`
- make `sim.py` and `graph.py` thin CLIs that delegate visualization to `graph_engine`

## Testing
- `python -m py_compile graph.py sim.py systems/graph_engine.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'systems' in legacy tests)*
- `pytest --ignore=legacy -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac494cef0c83269a4ffa3cb866e27f