### PR TITLE
refactor: centralize time utilities

### DIFF
--- a/systems/utils/time.py
+++ b/systems/utils/time.py
@@ -1,6 +1,32 @@
 from __future__ import annotations
 
+import os
+import re
 from datetime import datetime, timedelta, timezone
+
+import pandas as pd
+
+
+_INTERVAL_RE = re.compile(r'[_\-]((\d+)([smhdw]))(?=\.|_|$)', re.I)
+
+TIMEFRAME_SECONDS = {
+    "s": 1,
+    "m": 30 * 24 * 3600,
+    "h": 3600,
+    "d": 86400,
+    "w": 604800,
+}
+
+INTERVAL_SECONDS = {
+    "s": 1,
+    "m": 60,
+    "h": 3600,
+    "d": 86400,
+    "w": 604800,
+}
+
+# Minimum rows required for indicators that need lookback
+_MIN_REQUIRED_ROWS = 368
 
 
 def parse_cutoff(value: str) -> timedelta:
@@ -63,4 +89,49 @@ def duration_from_candle_count(candle_count: int, candle_interval_minutes: int =
         parts.append(f"{rem_hours}h")
 
     return " ".join(parts)
+
+
+def parse_timeframe(tf: str):
+    if not tf:
+        return None
+    m = re.match(r"(?i)^\s*(\d+)\s*([smhdw])\s*$", tf)
+    if not m:
+        return None
+    n, u = int(m.group(1)), m.group(2).lower()
+    return timedelta(seconds=n * TIMEFRAME_SECONDS[u])
+
+
+def infer_candle_seconds_from_filename(path: str) -> int | None:
+    m = _INTERVAL_RE.search(os.path.basename(path))
+    if not m:
+        return None
+    n, u = int(m.group(2)), m.group(3).lower()
+    return n * INTERVAL_SECONDS[u]
+
+
+def apply_time_filter(df: pd.DataFrame, delta: timedelta, file_path: str) -> pd.DataFrame:
+    if delta is None:
+        return df
+    if "timestamp" in df.columns:
+        ts = df["timestamp"]
+        ts_max = float(ts.iloc[-1])
+        is_ms = ts_max > 1e12
+        to_seconds = (ts / 1000.0) if is_ms else ts
+        cutoff = (datetime.now(timezone.utc).timestamp() - delta.total_seconds())
+        mask = to_seconds >= cutoff
+        return df.loc[mask]
+    for col in ("datetime", "date", "time"):
+        if col in df.columns:
+            try:
+                dt = pd.to_datetime(df[col], utc=True, errors="coerce")
+                cutoff_dt = pd.Timestamp.utcnow() - delta
+                mask = dt >= cutoff_dt
+                return df.loc[mask]
+            except Exception:
+                pass
+    sec = infer_candle_seconds_from_filename(file_path) or 3600
+    need = int(max(_MIN_REQUIRED_ROWS, delta.total_seconds() // sec))
+    if need <= 0 or need >= len(df):
+        return df
+    return df.iloc[-need:]
 


### PR DESCRIPTION
## Summary
- use shared time utilities for timeframe parsing and filtering
- remove duplicated time conversion logic from sim engine

## Testing
- `python sim.py --coin SOLUSD --time 1m --viz` *(fails: No module named 'systems.scripts.plot')*
- `python sim.py --coin SOLUSD --viz` *(fails: No module named 'systems.scripts.plot')*
- `python sim.py --coin SOLUSD --time 1w` *(fails: No module named 'systems.scripts.plot')*
- `python - <<'PY' from systems.sim_engine import run_simulation\ntry:\n    run_simulation(timeframe='1m', viz=False)\nexcept Exception as e:\n    print('error:', e)\nPY` *(fails: [Errno 2] No such file or directory: 'data/sim/SOLUSD_1h.csv')*


------
https://chatgpt.com/codex/tasks/task_e_68ac4801979c832698fc9930e0a0f967