### PR TITLE
feat: add visualization filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Changelog
+
+## Unreleased
+- Add viz_filters to control visibility of small bubbles and downsample angle markers; default is no filtering for backward compatibility.

--- a/settings/settings.json
+++ b/settings/settings.json
@@ -1,5 +1,10 @@
 {
   "general_settings": {
     "simulation_capital": 1000
+  },
+  "viz_filters": {
+    "volatility_min_size": 0,
+    "pressure_min_size": 0,
+    "angle_skip_n": 1
   }
 }

--- a/systems/scripts/chart.py
+++ b/systems/scripts/chart.py
@@ -7,6 +7,8 @@ from typing import Dict, List
 import matplotlib.pyplot as plt
 import pandas as pd
 
+from .viz_filters import VizFilters
+
 
 def plot_trades(
     df: pd.DataFrame,
@@ -19,6 +21,7 @@ def plot_trades(
 ) -> None:
     """Plot price, exhaustion points, volatility, and trade markers."""
     fig, ax1 = plt.subplots(figsize=(12, 6))
+    filters = VizFilters.from_settings()
     ax1.plot(df["candle_index"], df["close"], lw=1, label="Close Price", color="blue")
     ax1.set_title(f"Exhaustion Trades\nStart {start_capital}, End {final_value:.2f}")
     ax1.set_xlabel("Candles (Index)")
@@ -27,7 +30,7 @@ def plot_trades(
 
     for i, r in df.iterrows():
         v = r["angle"]
-        if i < angle_lookback:
+        if i < angle_lookback or not filters.allow_angle(i):
             continue
         if v > 0.05:
             color = "orange"
@@ -40,23 +43,27 @@ def plot_trades(
         y1 = y0 + v * 5
         ax1.plot([x0, x1], [y0, y1], color=color, lw=1.5, alpha=0.7)
 
-    ax1.scatter(
-        pts["exhaustion_down"]["x"],
-        pts["exhaustion_down"]["y"],
-        s=pts["exhaustion_down"]["s"],
-        c="green",
-        alpha=0.3,
-        edgecolor="black",
-    )
+    pb_data = [
+        (x, y, s)
+        for x, y, s in zip(
+            pts["exhaustion_down"]["x"],
+            pts["exhaustion_down"]["y"],
+            pts["exhaustion_down"]["s"],
+        )
+        if filters.allow_pressure(s)
+    ]
+    if pb_data:
+        x_p, y_p, s_p = zip(*pb_data)
+        ax1.scatter(x_p, y_p, s=s_p, c="green", alpha=0.3, edgecolor="black")
 
-    ax1.scatter(
-        vol_pts["x"],
-        vol_pts["y"],
-        s=vol_pts["s"],
-        c="red",
-        alpha=0.3,
-        edgecolor="black",
-    )
+    vb_data = [
+        (x, y, s)
+        for x, y, s in zip(vol_pts["x"], vol_pts["y"], vol_pts["s"])
+        if filters.allow_volatility(s)
+    ]
+    if vb_data:
+        x_v, y_v, s_v = zip(*vb_data)
+        ax1.scatter(x_v, y_v, s=s_v, c="red", alpha=0.3, edgecolor="black")
 
     for t in trades:
         if t["side"] == "BUY":

--- a/systems/scripts/viz_filters.py
+++ b/systems/scripts/viz_filters.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+"""Centralized logic for visualization filters."""
+
+from dataclasses import dataclass
+import math
+from typing import Any
+
+from systems.utils import log
+from systems.utils.config_loader import get_viz_filters
+
+
+@dataclass
+class VizFilters:
+    volatility_min_size: float = 0.0
+    pressure_min_size: float = 0.0
+    angle_skip_n: int = 1
+
+    _logged: bool = False
+
+    @classmethod
+    def from_settings(cls) -> "VizFilters":
+        cfg = get_viz_filters()
+        filt = cls(**cfg)
+        if not cls._logged:
+            msg = (
+                f"[VIZ_FILTERS] vol_min={filt.volatility_min_size} "
+                f"pressure_min={filt.pressure_min_size} "
+                f"angle_skip_n={filt.angle_skip_n}"
+            )
+            log.logic(msg)
+            cls._logged = True
+        return filt
+
+    @staticmethod
+    def _norm(size: Any) -> float:
+        try:
+            val = float(size)
+        except (TypeError, ValueError):
+            return 0.0
+        if math.isnan(val) or val < 0:
+            return 0.0
+        return val
+
+    def allow_volatility(self, size: Any) -> bool:
+        return self._norm(size) >= self.volatility_min_size
+
+    def allow_pressure(self, size: Any) -> bool:
+        return self._norm(size) >= self.pressure_min_size
+
+    def allow_angle(self, idx: int) -> bool:
+        return idx % self.angle_skip_n == 0
+

--- a/systems/utils/config_loader.py
+++ b/systems/utils/config_loader.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+"""Load application settings with caching."""
+
+import json
+from pathlib import Path
+from typing import Any, Dict
+
+_SETTINGS_CACHE: Dict[str, Any] | None = None
+
+
+def load_settings(*, reload: bool = False) -> Dict[str, Any]:
+    """Return the contents of settings/settings.json."""
+    global _SETTINGS_CACHE
+    if _SETTINGS_CACHE is None or reload:
+        path = Path(__file__).resolve().parents[2] / "settings" / "settings.json"
+        with path.open("r", encoding="utf-8") as fh:
+            _SETTINGS_CACHE = json.load(fh)
+    return _SETTINGS_CACHE
+
+
+def get_viz_filters() -> Dict[str, Any]:
+    """Return visualization filter settings with safe defaults."""
+    data = load_settings()
+    vf = data.get("viz_filters", {})
+    try:
+        vol = float(vf.get("volatility_min_size", 0) or 0)
+    except (TypeError, ValueError):
+        vol = 0.0
+    try:
+        pres = float(vf.get("pressure_min_size", 0) or 0)
+    except (TypeError, ValueError):
+        pres = 0.0
+    try:
+        ang = int(vf.get("angle_skip_n", 1) or 1)
+    except (TypeError, ValueError):
+        ang = 1
+    return {
+        "volatility_min_size": max(0.0, vol),
+        "pressure_min_size": max(0.0, pres),
+        "angle_skip_n": max(1, ang),
+    }


### PR DESCRIPTION
## Summary
- add `viz_filters` block in settings to toggle bubble and angle marker visibility
- centralize visualization filter logic and config loading
- gate bubble sizes and angle density in chart and graph rendering

## Testing
- `python -m py_compile settings/settings.json systems/graph_engine.py systems/scripts/chart.py systems/scripts/viz_filters.py systems/utils/config_loader.py`


------
https://chatgpt.com/codex/tasks/task_e_68ac76c31fd08326b968c8fba6d19275