### PR TITLE
Load start capital from settings file

### DIFF
--- a/systems/live_engine.py
+++ b/systems/live_engine.py
@@ -2,9 +2,19 @@ from __future__ import annotations
 
 """Minimal live engine stub emitting graph feed."""
 
+import json
+import pathlib
+
 from systems.scripts.evaluate_sell import evaluate_sell
 from systems.utils.graph_feed import GraphFeed
 from systems.utils.settings_loader import get_coin_setting
+
+SETTINGS_PATH = pathlib.Path("settings.json")
+if SETTINGS_PATH.exists():
+    _settings = json.loads(SETTINGS_PATH.read_text())
+    START_CAPITAL = _settings.get("general_settings", {}).get("simulation_capital", 10_000)
+else:
+    START_CAPITAL = 10_000
 
 
 def run_live(
@@ -16,6 +26,7 @@ def run_live(
 ) -> None:
     coin = market.replace("/", "").upper()
     slope_sale = float(get_coin_setting(coin, "slope_sale", 1.0))
+    capital = START_CAPITAL
 
     # Placeholder angle computation for parity with simulation engine
     angle = 0.0

--- a/systems/sim_engine.py
+++ b/systems/sim_engine.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import argparse
 from datetime import datetime, timezone
 
+import json
+import pathlib
 import numpy as np
 
 from systems.scripts.evaluate_buy import evaluate_buy
@@ -12,13 +14,19 @@ from systems.utils import log
 from systems.utils.graph_feed import GraphFeed
 from systems.utils.settings_loader import get_coin_setting
 
+SETTINGS_PATH = pathlib.Path("settings.json")
+if SETTINGS_PATH.exists():
+    _settings = json.loads(SETTINGS_PATH.read_text())
+    START_CAPITAL = _settings.get("general_settings", {}).get("simulation_capital", 10_000)
+else:
+    START_CAPITAL = 10_000
+
 # ===================== Parameters =====================
 # Lookbacks
 
 SIZE_SCALAR      = 1_000_000
 SIZE_POWER       = 3
 
-START_CAPITAL    = 10_000   # starting cash in USDT
 MONTHLY_TOPUP    = 000    # fixed USDT injected each calendar month
 
 EXHAUSTION_LOOKBACK = 184   # used for bubble delta


### PR DESCRIPTION
## Summary
- Read simulation starting capital from `settings.json` rather than a constant
- Apply same configurable capital to live engine for parity

## Testing
- `python sim.py --coin DOGEUSD --time 1m --viz` *(interrupted after graph rendering, capital initialized to 1000 as configured)*

------
https://chatgpt.com/codex/tasks/task_e_68ac797cfc4883269710ab07f650b0d5