### PR TITLE
Load trading params from coin settings

### DIFF
--- a/systems/live_engine.py
+++ b/systems/live_engine.py
@@ -5,9 +5,10 @@ from __future__ import annotations
 import json
 import pathlib
 
+import systems.scripts.evaluate_buy as buy_module
 from systems.scripts.evaluate_sell import evaluate_sell
 from systems.utils.graph_feed import GraphFeed
-from systems.utils.settings_loader import get_coin_setting
+from systems.utils.config_loader import get_coin_setting
 
 
 SETTINGS_PATH = pathlib.Path("settings/settings.json")
@@ -27,7 +28,53 @@ def run_live(
     graph_downsample: int = 5,
 ) -> None:
     coin = market.replace("/", "").upper()
-    slope_sale = float(get_coin_setting(coin, "slope_sale", 1.0))
+
+    EXHAUSTION_LOOKBACK = int(get_coin_setting(coin, "exhaustion_lookback", 184))
+    WINDOW_STEP = int(get_coin_setting(coin, "window_step", 12))
+
+    BUY_MIN_BUBBLE = float(get_coin_setting(coin, "buy_min_bubble", 100))
+    BUY_MAX_BUBBLE = float(get_coin_setting(coin, "buy_max_bubble", 500))
+    MIN_NOTE_SIZE_PCT = float(get_coin_setting(coin, "min_note_size_pct", 0.03))
+    MAX_NOTE_SIZE_PCT = float(get_coin_setting(coin, "max_note_size_pct", 0.25))
+
+    SELL_MIN_BUBBLE = float(get_coin_setting(coin, "sell_min_bubble", 150))
+    SELL_MAX_BUBBLE = float(get_coin_setting(coin, "sell_max_bubble", 800))
+    MIN_MATURITY = float(get_coin_setting(coin, "min_maturity", 0.05))
+    MAX_MATURITY = float(get_coin_setting(coin, "max_maturity", 0.25))
+
+    BUY_MIN_VOL_BUBBLE = float(get_coin_setting(coin, "buy_min_vol_bubble", 0.0))
+    BUY_MAX_VOL_BUBBLE = float(get_coin_setting(coin, "buy_max_vol_bubble", 0.01))
+    BUY_MULT_VOL_MIN = float(get_coin_setting(coin, "buy_mult_vol_min", 2.5))
+    BUY_MULT_VOL_MAX = float(get_coin_setting(coin, "buy_mult_vol_max", 0.0))
+    VOL_LOOKBACK = int(get_coin_setting(coin, "vol_lookback", 48))
+
+    ANGLE_UP_MIN = float(get_coin_setting(coin, "angle_up_min", 0.1))
+    ANGLE_DOWN_MIN = float(get_coin_setting(coin, "angle_down_min", -0.5))
+    ANGLE_LOOKBACK = int(get_coin_setting(coin, "angle_lookback", 48))
+
+    SLOPE_SALE = float(get_coin_setting(coin, "slope_sale", 1.0))
+    slope_sale = SLOPE_SALE
+
+    BUY_MULT_TREND_UP = float(get_coin_setting(coin, "buy_mult_trend_up", 1.0))
+    BUY_MULT_TREND_FLOOR = float(get_coin_setting(coin, "buy_mult_trend_floor", 0.25))
+    BUY_MULT_TREND_DOWN = float(get_coin_setting(coin, "buy_mult_trend_down", 0.0))
+
+    buy_module.BUY_MIN_BUBBLE = BUY_MIN_BUBBLE
+    buy_module.BUY_MAX_BUBBLE = BUY_MAX_BUBBLE
+    buy_module.MIN_NOTE_SIZE_PCT = MIN_NOTE_SIZE_PCT
+    buy_module.MAX_NOTE_SIZE_PCT = MAX_NOTE_SIZE_PCT
+    buy_module.SELL_MIN_BUBBLE = SELL_MIN_BUBBLE
+    buy_module.SELL_MAX_BUBBLE = SELL_MAX_BUBBLE
+    buy_module.MIN_MATURITY = MIN_MATURITY
+    buy_module.MAX_MATURITY = MAX_MATURITY
+    buy_module.BUY_MIN_VOL_BUBBLE = BUY_MIN_VOL_BUBBLE
+    buy_module.BUY_MAX_VOL_BUBBLE = BUY_MAX_VOL_BUBBLE
+    buy_module.BUY_MULT_VOL_MIN = BUY_MULT_VOL_MIN
+    buy_module.BUY_MULT_VOL_MAX = BUY_MULT_VOL_MAX
+    buy_module.BUY_MULT_TREND_UP = BUY_MULT_TREND_UP
+    buy_module.BUY_MULT_TREND_FLOOR = BUY_MULT_TREND_FLOOR
+    buy_module.BUY_MULT_TREND_DOWN = BUY_MULT_TREND_DOWN
+
     capital = START_CAPITAL
 
     # Placeholder angle computation for parity with simulation engine

--- a/systems/sim_engine.py
+++ b/systems/sim_engine.py
@@ -7,12 +7,12 @@ import json
 import pathlib
 import numpy as np
 
-from systems.scripts.evaluate_buy import evaluate_buy
+import systems.scripts.evaluate_buy as buy_module
 from systems.scripts.evaluate_sell import evaluate_sell
 from systems.utils.time import parse_timeframe, apply_time_filter
 from systems.utils import log
 from systems.utils.graph_feed import GraphFeed
-from systems.utils.settings_loader import get_coin_setting
+from systems.utils.config_loader import get_coin_setting
 
 
 SETTINGS_PATH = pathlib.Path("settings/settings.json")
@@ -24,18 +24,12 @@ else:
     START_CAPITAL = 10_000
 
 # ===================== Parameters =====================
-# Lookbacks
+# Lookbacks and scalars
 
 SIZE_SCALAR      = 1_000_000
 SIZE_POWER       = 3
 
 MONTHLY_TOPUP    = 000    # fixed USDT injected each calendar month
-
-EXHAUSTION_LOOKBACK = 184   # used for bubble delta
-WINDOW_STEP = 12
-
-VOL_LOOKBACK = 48   # rolling window for volatility
-ANGLE_LOOKBACK = 48     # used for slope angle
 
 
 
@@ -61,6 +55,55 @@ def run_simulation(
     """
 
     coin = coin.replace("/", "").upper()
+
+    # Load per-coin settings with safe fallbacks
+    EXHAUSTION_LOOKBACK = int(get_coin_setting(coin, "exhaustion_lookback", 184))
+    WINDOW_STEP = int(get_coin_setting(coin, "window_step", 12))
+
+    BUY_MIN_BUBBLE = float(get_coin_setting(coin, "buy_min_bubble", 100))
+    BUY_MAX_BUBBLE = float(get_coin_setting(coin, "buy_max_bubble", 500))
+    MIN_NOTE_SIZE_PCT = float(get_coin_setting(coin, "min_note_size_pct", 0.03))
+    MAX_NOTE_SIZE_PCT = float(get_coin_setting(coin, "max_note_size_pct", 0.25))
+
+    SELL_MIN_BUBBLE = float(get_coin_setting(coin, "sell_min_bubble", 150))
+    SELL_MAX_BUBBLE = float(get_coin_setting(coin, "sell_max_bubble", 800))
+    MIN_MATURITY = float(get_coin_setting(coin, "min_maturity", 0.05))
+    MAX_MATURITY = float(get_coin_setting(coin, "max_maturity", 0.25))
+
+    BUY_MIN_VOL_BUBBLE = float(get_coin_setting(coin, "buy_min_vol_bubble", 0.0))
+    BUY_MAX_VOL_BUBBLE = float(get_coin_setting(coin, "buy_max_vol_bubble", 0.01))
+    BUY_MULT_VOL_MIN = float(get_coin_setting(coin, "buy_mult_vol_min", 2.5))
+    BUY_MULT_VOL_MAX = float(get_coin_setting(coin, "buy_mult_vol_max", 0.0))
+    VOL_LOOKBACK = int(get_coin_setting(coin, "vol_lookback", 48))
+
+    ANGLE_UP_MIN = float(get_coin_setting(coin, "angle_up_min", 0.1))
+    ANGLE_DOWN_MIN = float(get_coin_setting(coin, "angle_down_min", -0.5))
+    ANGLE_LOOKBACK = int(get_coin_setting(coin, "angle_lookback", 48))
+
+    SLOPE_SALE = float(get_coin_setting(coin, "slope_sale", 1.0))
+    slope_sale = SLOPE_SALE
+
+    BUY_MULT_TREND_UP = float(get_coin_setting(coin, "buy_mult_trend_up", 1.0))
+    BUY_MULT_TREND_FLOOR = float(get_coin_setting(coin, "buy_mult_trend_floor", 0.25))
+    BUY_MULT_TREND_DOWN = float(get_coin_setting(coin, "buy_mult_trend_down", 0.0))
+
+    # Inject settings into buy evaluation module
+    buy_module.BUY_MIN_BUBBLE = BUY_MIN_BUBBLE
+    buy_module.BUY_MAX_BUBBLE = BUY_MAX_BUBBLE
+    buy_module.MIN_NOTE_SIZE_PCT = MIN_NOTE_SIZE_PCT
+    buy_module.MAX_NOTE_SIZE_PCT = MAX_NOTE_SIZE_PCT
+    buy_module.SELL_MIN_BUBBLE = SELL_MIN_BUBBLE
+    buy_module.SELL_MAX_BUBBLE = SELL_MAX_BUBBLE
+    buy_module.MIN_MATURITY = MIN_MATURITY
+    buy_module.MAX_MATURITY = MAX_MATURITY
+    buy_module.BUY_MIN_VOL_BUBBLE = BUY_MIN_VOL_BUBBLE
+    buy_module.BUY_MAX_VOL_BUBBLE = BUY_MAX_VOL_BUBBLE
+    buy_module.BUY_MULT_VOL_MIN = BUY_MULT_VOL_MIN
+    buy_module.BUY_MULT_VOL_MAX = BUY_MULT_VOL_MAX
+    buy_module.BUY_MULT_TREND_UP = BUY_MULT_TREND_UP
+    buy_module.BUY_MULT_TREND_FLOOR = BUY_MULT_TREND_FLOOR
+    buy_module.BUY_MULT_TREND_DOWN = BUY_MULT_TREND_DOWN
+
     file_path = f"data/sim/{coin}.csv"
     try_alt = f"data/candles/sim/{coin}.csv"
     import os, pandas as pd
@@ -139,8 +182,6 @@ def run_simulation(
         for x, y, s in zip(vol_pts["x"], vol_pts["y"], vol_pts["s"]):
             feed.vol_bubble(int(x), float(y), float(s))
 
-    slope_sale = float(get_coin_setting(coin, "slope_sale", 1.0))
-
     # ===== Candle-by-candle simulation =====
     trades = []
     capital = START_CAPITAL
@@ -186,7 +227,9 @@ def run_simulation(
                 feed.indicator(int(row["candle_index"]), "vol", float(row.get("volatility", 0.0)))
 
         prev_len = len(open_notes)
-        trade, capital, open_notes = evaluate_buy(idx, row, pts, capital, open_notes)
+        trade, capital, open_notes = buy_module.evaluate_buy(
+            idx, row, pts, capital, open_notes
+        )
         if trade:
             trades.append(trade)
             if feed and len(open_notes) > prev_len:


### PR DESCRIPTION
## Summary
- Read per-coin trading parameters from `coin_settings.json` via `config_loader.get_coin_setting`
- Inject dynamic buy/sell sizing and lookbacks into simulation and live engines
- Expose `get_coin_setting` helper in `config_loader`

## Testing
- `python -m py_compile systems/sim_engine.py systems/live_engine.py systems/utils/config_loader.py`


------
https://chatgpt.com/codex/tasks/task_e_68ac89b2c8f4832687ba448faba61fe6