### PR TITLE
feat: add shared candle loop and parity improvements

### DIFF
--- a/settings/settings.json
+++ b/settings/settings.json
@@ -1,6 +1,7 @@
 {
   "general_settings": {
-    "simulation_capital": 1000
+    "simulation_capital": 1000,
+    "monthly_topup": 0
   },
   "viz_filters": {
     "volatility_min_size": 50,

--- a/systems/live_engine.py
+++ b/systems/live_engine.py
@@ -1,23 +1,31 @@
 from __future__ import annotations
 
-"""Minimal live engine stub emitting graph feed."""
+"""Live trading loop sharing candle logic with simulation."""
 
 import json
 import pathlib
+import time
+
+import ccxt  # type: ignore
+import pandas as pd
+import numpy as np
 
 import systems.scripts.evaluate_buy as buy_module
 from systems.scripts.evaluate_sell import evaluate_sell
-from systems.utils.graph_feed import GraphFeed
-from systems.utils.config_loader import get_coin_setting
+from systems.scripts.candle_loop import run_candle_loop
+from systems.utils.config_loader import load_coin_settings
 
 
 SETTINGS_PATH = pathlib.Path("settings/settings.json")
 
 if SETTINGS_PATH.exists():
     _settings = json.loads(SETTINGS_PATH.read_text())
-    START_CAPITAL = _settings.get("general_settings", {}).get("simulation_capital", 10_000)
+    _general = _settings.get("general_settings", {})
+    START_CAPITAL = _general.get("simulation_capital", 10_000)
+    MONTHLY_TOPUP = _general.get("monthly_topup", 0)
 else:
     START_CAPITAL = 10_000
+    MONTHLY_TOPUP = 0
 
 
 def run_live(
@@ -25,72 +33,181 @@ def run_live(
     account: str,
     market: str,
     graph_feed: bool = False,
-    graph_downsample: int = 5,
 ) -> None:
     coin = market.replace("/", "").upper()
 
-    EXHAUSTION_LOOKBACK = int(get_coin_setting(coin, "exhaustion_lookback", 184))
-    WINDOW_STEP = int(get_coin_setting(coin, "window_step", 12))
-
-    BUY_MIN_BUBBLE = float(get_coin_setting(coin, "buy_min_bubble", 100))
-    BUY_MAX_BUBBLE = float(get_coin_setting(coin, "buy_max_bubble", 500))
-    MIN_NOTE_SIZE_PCT = float(get_coin_setting(coin, "min_note_size_pct", 0.03))
-    MAX_NOTE_SIZE_PCT = float(get_coin_setting(coin, "max_note_size_pct", 0.25))
-
-    SELL_MIN_BUBBLE = float(get_coin_setting(coin, "sell_min_bubble", 150))
-    SELL_MAX_BUBBLE = float(get_coin_setting(coin, "sell_max_bubble", 800))
-    MIN_MATURITY = float(get_coin_setting(coin, "min_maturity", 0.05))
-    MAX_MATURITY = float(get_coin_setting(coin, "max_maturity", 0.25))
-
-    BUY_MIN_VOL_BUBBLE = float(get_coin_setting(coin, "buy_min_vol_bubble", 0.0))
-    BUY_MAX_VOL_BUBBLE = float(get_coin_setting(coin, "buy_max_vol_bubble", 0.01))
-    BUY_MULT_VOL_MIN = float(get_coin_setting(coin, "buy_mult_vol_min", 2.5))
-    BUY_MULT_VOL_MAX = float(get_coin_setting(coin, "buy_mult_vol_max", 0.0))
-    VOL_LOOKBACK = int(get_coin_setting(coin, "vol_lookback", 48))
-
-    ANGLE_UP_MIN = float(get_coin_setting(coin, "angle_up_min", 0.1))
-    ANGLE_DOWN_MIN = float(get_coin_setting(coin, "angle_down_min", -0.5))
-    ANGLE_LOOKBACK = int(get_coin_setting(coin, "angle_lookback", 48))
-
-    SLOPE_SALE = float(get_coin_setting(coin, "slope_sale", 1.0))
+    settings = load_coin_settings(coin)
+    EXHAUSTION_LOOKBACK = int(settings.get("exhaustion_lookback", 184))
+    WINDOW_STEP = int(settings.get("window_step", 12))
+    VOL_LOOKBACK = int(settings.get("vol_lookback", 48))
+    ANGLE_LOOKBACK = int(settings.get("angle_lookback", 48))
+    ANGLE_UP_MIN = float(settings.get("angle_up_min", 0.1))
+    ANGLE_DOWN_MIN = float(settings.get("angle_down_min", -0.5))
+    SLOPE_SALE = float(settings.get("slope_sale", 1.0))
     slope_sale = SLOPE_SALE
 
-    BUY_MULT_TREND_UP = float(get_coin_setting(coin, "buy_mult_trend_up", 1.0))
-    BUY_MULT_TREND_FLOOR = float(get_coin_setting(coin, "buy_mult_trend_floor", 0.25))
-    BUY_MULT_TREND_DOWN = float(get_coin_setting(coin, "buy_mult_trend_down", 0.0))
+    buy_module.BUY_MIN_BUBBLE = float(settings.get("buy_min_bubble", 100))
+    buy_module.BUY_MAX_BUBBLE = float(settings.get("buy_max_bubble", 500))
+    buy_module.MIN_NOTE_SIZE_PCT = float(settings.get("min_note_size_pct", 0.03))
+    buy_module.MAX_NOTE_SIZE_PCT = float(settings.get("max_note_size_pct", 0.25))
+    buy_module.SELL_MIN_BUBBLE = float(settings.get("sell_min_bubble", 150))
+    buy_module.SELL_MAX_BUBBLE = float(settings.get("sell_max_bubble", 800))
+    buy_module.MIN_MATURITY = float(settings.get("min_maturity", 0.05))
+    buy_module.MAX_MATURITY = float(settings.get("max_maturity", 0.25))
+    buy_module.BUY_MIN_VOL_BUBBLE = float(settings.get("buy_min_vol_bubble", 0.0))
+    buy_module.BUY_MAX_VOL_BUBBLE = float(settings.get("buy_max_vol_bubble", 0.01))
+    buy_module.BUY_MULT_VOL_MIN = float(settings.get("buy_mult_vol_min", 2.5))
+    buy_module.BUY_MULT_VOL_MAX = float(settings.get("buy_mult_vol_max", 0.0))
+    buy_module.BUY_MULT_TREND_UP = float(settings.get("buy_mult_trend_up", 1.0))
+    buy_module.BUY_MULT_TREND_FLOOR = float(settings.get("buy_mult_trend_floor", 0.25))
+    buy_module.BUY_MULT_TREND_DOWN = float(settings.get("buy_mult_trend_down", 0.0))
 
-    buy_module.BUY_MIN_BUBBLE = BUY_MIN_BUBBLE
-    buy_module.BUY_MAX_BUBBLE = BUY_MAX_BUBBLE
-    buy_module.MIN_NOTE_SIZE_PCT = MIN_NOTE_SIZE_PCT
-    buy_module.MAX_NOTE_SIZE_PCT = MAX_NOTE_SIZE_PCT
-    buy_module.SELL_MIN_BUBBLE = SELL_MIN_BUBBLE
-    buy_module.SELL_MAX_BUBBLE = SELL_MAX_BUBBLE
-    buy_module.MIN_MATURITY = MIN_MATURITY
-    buy_module.MAX_MATURITY = MAX_MATURITY
-    buy_module.BUY_MIN_VOL_BUBBLE = BUY_MIN_VOL_BUBBLE
-    buy_module.BUY_MAX_VOL_BUBBLE = BUY_MAX_VOL_BUBBLE
-    buy_module.BUY_MULT_VOL_MIN = BUY_MULT_VOL_MIN
-    buy_module.BUY_MULT_VOL_MAX = BUY_MULT_VOL_MAX
-    buy_module.BUY_MULT_TREND_UP = BUY_MULT_TREND_UP
-    buy_module.BUY_MULT_TREND_FLOOR = BUY_MULT_TREND_FLOOR
-    buy_module.BUY_MULT_TREND_DOWN = BUY_MULT_TREND_DOWN
+    print(
+        f"[DEBUG] Loaded coin settings for {coin}: angle_up={ANGLE_UP_MIN:.2f}, "
+        f"angle_down={ANGLE_DOWN_MIN:.2f}, vol_lookback={VOL_LOOKBACK}, slope_sale={SLOPE_SALE}"
+    )
+    default_cfg = load_coin_settings("default")
+    for key, val in [
+        ("angle_up_min", ANGLE_UP_MIN),
+        ("angle_down_min", ANGLE_DOWN_MIN),
+        ("angle_lookback", ANGLE_LOOKBACK),
+        ("slope_sale", SLOPE_SALE),
+    ]:
+        if default_cfg.get(key) != val:
+            print(
+                f"[DEBUG] default {key}={default_cfg.get(key)} differs from {val} for {coin}"
+            )
 
+    exchange = ccxt.kraken({"enableRateLimit": True})
     capital = START_CAPITAL
+    open_notes: list[dict[str, float]] = []
+    last_ts = 0
+    last_month: tuple[int, int] | None = None
 
-    # Placeholder angle computation for parity with simulation engine
-    angle = 0.0
-    evaluate_sell(0, 0.0, [], 0.0, angle=angle, slope_sale=slope_sale)
+    while True:
+        ohlcv = exchange.fetch_ohlcv(market, timeframe="1h", limit=720) or []
+        if not ohlcv:
+            time.sleep(60)
+            continue
+        df = pd.DataFrame(ohlcv, columns=["timestamp", "open", "high", "low", "close", "volume"])
+        df["timestamp"] = (
+            pd.to_datetime(df["timestamp"], unit="ms", utc=True).astype("int64") // 1_000_000_000
+        )
+        df = df.sort_values("timestamp").reset_index(drop=True)
+        df["candle_index"] = range(len(df))
+        df["returns"] = df["close"].pct_change()
+        df["volatility"] = df["returns"].rolling(VOL_LOOKBACK).std().fillna(0)
+        df["angle"] = 0.0
 
-    feed = None
-    if graph_feed:
-        feed = GraphFeed(
-            mode="live",
-            coin=coin,
-            account=account,
-            downsample=graph_downsample,
-            flush=True,
+        pts = {
+            "exhaustion_up": {"x": [], "y": [], "s": []},
+            "exhaustion_down": {"x": [], "y": [], "s": []},
+        }
+        for t in range(EXHAUSTION_LOOKBACK, len(df), WINDOW_STEP):
+            now_price = float(df["close"].iloc[t])
+            past_price = float(df["close"].iloc[t - EXHAUSTION_LOOKBACK])
+            end_idx = int(df["candle_index"].iloc[t])
+            if now_price < past_price:
+                delta_down = past_price - now_price
+                norm_down = delta_down / max(1e-9, past_price)
+                size = 1_000_000 * (norm_down ** 3)
+                pts["exhaustion_down"]["x"].append(end_idx)
+                pts["exhaustion_down"]["y"].append(now_price)
+                pts["exhaustion_down"]["s"].append(size)
+
+        for t in range(ANGLE_LOOKBACK, len(df)):
+            dy = df["close"].iloc[t] - df["close"].iloc[t - ANGLE_LOOKBACK]
+            dx = ANGLE_LOOKBACK
+            angle = np.arctan2(dy, dx)
+            df.at[t, "angle"] = max(-1.0, min(1.0, angle / (np.pi / 4)))
+
+        subset = df[df["timestamp"] > last_ts]
+        if subset.empty:
+            now = int(time.time())
+            time.sleep(max(0, 3600 - (now % 3600)))
+            continue
+
+        latest = subset.iloc[-1]
+        print(
+            f"[DEBUG] angle={float(latest['angle']):.3f}, volatility={float(latest['volatility']):.5f} "
+            f"(lookbacks: angle={ANGLE_LOOKBACK}, vol={VOL_LOOKBACK})"
         )
 
-    # Real trading logic would go here. This placeholder simply closes the feed.
-    if feed:
-        feed.close()
+        from pathlib import Path
+
+        def record_trade(trade, account, coin):
+            if not trade:
+                return
+            path = Path("data") / "ledgers" / f"{account}_{coin}.jsonl"
+            path.parent.mkdir(parents=True, exist_ok=True)
+            with path.open("a", encoding="utf-8") as f:
+                json.dump(trade, f)
+                f.write("\n")
+
+        def write_action(idx, row, sells, buys, notes, cap):
+            path = Path("data") / "actions" / f"{account}_{coin}.jsonl"
+            path.parent.mkdir(parents=True, exist_ok=True)
+            record = {
+                "idx": int(idx),
+                "timestamp": int(row.get("timestamp", 0)),
+                "sells": int(sells),
+                "buys": int(buys),
+                "open_notes": len(notes),
+                "capital": float(cap),
+            }
+            with path.open("a", encoding="utf-8") as f:
+                json.dump(record, f)
+                f.write("\n")
+
+        for idx, row in subset.iterrows():
+            ts = int(row.get("timestamp", 0))
+            dt = pd.to_datetime(ts, unit="s", utc=True)
+            current_month = (dt.year, dt.month)
+            if current_month != last_month:
+                capital += MONTHLY_TOPUP
+                print(
+                    f"[INFO] Monthly top-up: +{MONTHLY_TOPUP} USDT at {dt.date()} → Capital={capital:.2f}"
+                )
+                write_action(idx, row, 0, 0, open_notes, capital)
+                last_month = current_month
+
+            sells = 0
+            buys = 0
+
+            def buy_handler(i, r, notes, cap):
+                nonlocal buys
+                trade, cap, notes = buy_module.evaluate_buy(i, r, pts, cap, notes)
+                if trade:
+                    buys += 1
+                return trade, cap, notes
+
+            def sell_handler(i, r, notes, cap):
+                nonlocal sells
+                price = float(r["close"])
+                angle = float(r.get("angle", 0.0))
+                closed, cap, notes = evaluate_sell(i, price, notes, cap, angle=angle, slope_sale=slope_sale)
+                sells += len(closed)
+                return closed, cap, notes
+
+            handlers = {
+                "buy": buy_handler,
+                "sell": sell_handler,
+                "ledger": record_trade,
+                "action": lambda *args, **kwargs: None,
+                "capital": capital,
+                "open_notes": open_notes,
+            }
+
+            candle_df = subset.loc[[idx]]
+            capital, open_notes = run_candle_loop(candle_df, handlers, account, coin)
+            ts = int(row.get("timestamp", 0))
+            write_action(idx, row, sells, buys, open_notes, capital)
+            print(
+                f"[DEBUG] {account}/{coin} @ {ts}: sells={sells}, buys={buys}, "
+                f"open_notes={len(open_notes)}, capital={capital:.2f}"
+            )
+
+        last_ts = int(subset["timestamp"].iloc[-1])
+
+        now = int(time.time())
+        time.sleep(max(0, 3600 - (now % 3600)))

--- a/systems/scripts/candle_loop.py
+++ b/systems/scripts/candle_loop.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+"""Shared candle iteration logic for sim and live engines."""
+
+from typing import Any, Callable, Dict, Iterable, List, Tuple
+
+import pandas as pd
+
+HandlerFn = Callable[..., Any]
+HandlersDict = Dict[str, HandlerFn]
+
+
+def run_candle_loop(
+    candles: pd.DataFrame,
+    handlers: Dict[str, HandlerFn],
+    account: str,
+    coin: str,
+) -> Tuple[float, List[Dict[str, float]]]:
+    """Iterate over ``candles`` dispatching to strategy handlers.
+
+    Parameters
+    ----------
+    candles:
+        DataFrame of candles sorted in ascending order. Required columns:
+        ``close`` and ``timestamp``.
+    handlers:
+        Mapping containing at minimum ``buy``, ``sell``, ``ledger`` and
+        ``action`` callables. Optional ``on_candle`` callable receives
+        ``(idx, row)`` each step. ``capital`` and ``open_notes`` keys may be
+        provided to seed initial state.
+    account:
+        Account name, forwarded to ledger and action handlers.
+    coin:
+        Coin symbol, forwarded to ledger and action handlers.
+
+    Returns
+    -------
+    Tuple[float, List[Dict[str, float]]]
+        Final capital and list of open notes after processing all candles.
+    """
+
+    buy_fn: HandlerFn = handlers["buy"]
+    sell_fn: HandlerFn = handlers["sell"]
+    ledger_fn: HandlerFn = handlers["ledger"]
+    action_fn: HandlerFn = handlers["action"]
+    on_candle: HandlerFn | None = handlers.get("on_candle")
+
+    capital: float = float(handlers.get("capital", 0.0))
+    open_notes: List[Dict[str, float]] = list(handlers.get("open_notes", []))
+
+    for idx, row in candles.iterrows():
+        if on_candle:
+            on_candle(idx, row)
+
+        price = float(row.get("close", 0.0))
+
+        closed, capital, open_notes = sell_fn(idx, row, open_notes, capital)
+        for trade in closed:
+            ledger_fn(trade, account, coin)
+            action_fn(trade.get("side", "SELL"), idx, row, account, coin)
+
+        trade, capital, open_notes = buy_fn(idx, row, open_notes, capital)
+        if trade:
+            ledger_fn(trade, account, coin)
+            action_fn(trade.get("side", "BUY"), idx, row, account, coin)
+        elif not closed:
+            action_fn("HOLD", idx, row, account, coin)
+
+    return capital, open_notes
+
+
+__all__ = ["run_candle_loop"]


### PR DESCRIPTION
## Summary
- add reusable `run_candle_loop` to drive candle-by-candle processing
- refactor `sim_engine` to use the shared loop and dispatch handlers
- implement live engine loop that fetches Kraken candles and uses the shared loop
- compute rolling angle and volatility in live engine using coin settings for parity with simulation
- load live thresholds and multipliers from `coin_settings.json` instead of hardcoded constants
- process live candles with sell-first ordering, recording trades and per-candle summaries
- apply configurable monthly capital top-ups on both engines when a new month starts

## Testing
- `python -m py_compile systems/scripts/candle_loop.py systems/sim_engine.py systems/live_engine.py`


------
https://chatgpt.com/codex/tasks/task_e_68ac944f5a2083268803983d82d8ef12