### PR TITLE
feat: add test mode to live engine

### DIFF
--- a/live.py
+++ b/live.py
@@ -28,6 +28,11 @@ def main(argv: Optional[list[str]] = None) -> None:
         default=5,
         help="Feed candle stride",
     )
+    parser.add_argument(
+        "--test",
+        action="store_true",
+        help="Run a single test cycle without placing orders",
+    )
     args = parser.parse_args(argv)
     from systems.utils.load_config import load_config
 
@@ -64,6 +69,7 @@ def main(argv: Optional[list[str]] = None) -> None:
         market=market,
         graph_feed=args.graph_feed,
         graph_downsample=args.graph_downsample,
+        test_mode=args.test,
     )
 
     if args.graph:

--- a/systems/scripts/action_writer.py
+++ b/systems/scripts/action_writer.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+"""Helpers for recording per-candle decisions during live runs."""
+
+import json
+from pathlib import Path
+from typing import Any, List
+
+
+def write_action(
+    idx: int,
+    row: Any,
+    sells: int,
+    buys: int,
+    notes: List[dict],
+    cap: float,
+    account: str,
+    coin: str,
+) -> None:
+    """Append an action record for the given candle."""
+
+    path = Path("data") / "actions" / f"{account}_{coin}.jsonl"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    record = {
+        "idx": int(idx),
+        "timestamp": int(row.get("timestamp", 0)),
+        "sells": int(sells),
+        "buys": int(buys),
+        "open_notes": len(notes),
+        "capital": float(cap),
+    }
+    with path.open("a", encoding="utf-8") as f:
+        json.dump(record, f)
+        f.write("\n")
+
+
+__all__ = ["write_action"]
+

--- a/systems/scripts/ledger.py
+++ b/systems/scripts/ledger.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+"""Utilities for persisting trade records to disk."""
+
+import json
+from pathlib import Path
+from typing import Dict, Any
+
+
+def write_trade(trade: Dict[str, Any] | None, account: str, coin: str) -> None:
+    """Append ``trade`` to the ledger for ``account``/``coin``."""
+
+    if not trade:
+        return
+    path = Path("data") / "ledgers" / f"{account}_{coin}.jsonl"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as f:
+        json.dump(trade, f)
+        f.write("\n")
+
+
+__all__ = ["write_trade"]
+


### PR DESCRIPTION
## Summary
- add `--test` flag to CLI for single-cycle dry runs
- support test mode in live engine with conditional Kraken orders and validation summary
- extract ledger and action writers into reusable scripts

## Testing
- `pytest -q` *(fails: No module named 'systems' in legacy test)*
- `pytest systems -q`
- `python -m py_compile live.py systems/live_engine.py systems/scripts/ledger.py systems/scripts/action_writer.py`


------
https://chatgpt.com/codex/tasks/task_e_68aca888edb483268ae49c10117fc038