### PR TITLE
Emit trades to graph feed in sim and live engines

### DIFF
--- a/systems/scripts/evaluate_buy.py
+++ b/systems/scripts/evaluate_buy.py
@@ -99,7 +99,14 @@ def evaluate_buy(
             updated_capital -= trade_usd
             sell_price = sell_target_from_bubble(price, bubble)
             updated_notes.append({"entry_price": price, "units": units, "sell_price": sell_price})
-            maybe_trade = {"idx": idx, "price": price, "side": "BUY", "usd": trade_usd}
+            maybe_trade = {
+                "idx": idx,
+                "price": price,
+                "side": "BUY",
+                "usd": trade_usd,
+                "units": units,
+                "target": sell_price,
+            }
             print(
                 f"BUY @ idx={idx}, price={price:.2f}, angle_mult={trend_mult:.2f}, vol_mult={vol_mult:.2f}, target={sell_price:.2f}"
             )

--- a/systems/scripts/evaluate_sell.py
+++ b/systems/scripts/evaluate_sell.py
@@ -29,7 +29,16 @@ def evaluate_sell(
         if price >= note["sell_price"]:
             sell_usd = note["units"] * price
             updated_capital += sell_usd
-            trades_closed.append({"idx": idx, "price": price, "side": "SELL", "usd": sell_usd})
+            trades_closed.append(
+                {
+                    "idx": idx,
+                    "price": price,
+                    "side": "SELL",
+                    "usd": sell_usd,
+                    "units": note["units"],
+                    "entry_price": note["entry_price"],
+                }
+            )
             print(
                 f"SELL @ idx={idx}, entry={note['entry_price']:.2f}, target={note['sell_price']:.2f}, price={price:.2f}"
             )

--- a/systems/sim_engine.py
+++ b/systems/sim_engine.py
@@ -247,6 +247,23 @@ def run_simulation(
     def ledger_handler(trade, account, coin):
         if not trade:
             return
+        if feed:
+            if trade.get("side") == "BUY":
+                feed.buy(
+                    int(trade.get("idx", 0)),
+                    float(trade.get("price", 0.0)),
+                    float(trade.get("units", 0.0)),
+                    float(trade.get("usd", 0.0)),
+                    float(trade.get("target", 0.0)),
+                )
+            else:
+                feed.sell(
+                    int(trade.get("idx", 0)),
+                    float(trade.get("price", 0.0)),
+                    float(trade.get("units", 0.0)),
+                    float(trade.get("usd", 0.0)),
+                    float(trade.get("entry_price", 0.0)),
+                )
         path = Path("data") / "ledgers" / f"{account}_{coin}.jsonl"
         path.parent.mkdir(parents=True, exist_ok=True)
         with path.open("a", encoding="utf-8") as f:


### PR DESCRIPTION
## Summary
- Include units and target data in buy trades and entry price on sells
- Emit buy and sell events to the graph feed during simulation and live trading
- Stream live candles and indicators to the graph feed for visualization

## Testing
- `python -m pytest` *(fails: No module named 'systems.scripts.fetch_candles')*
- `python -m pytest --ignore=legacy`
- `python -m systems.sim_engine --coin DOGEUSD --time 1m`

------
https://chatgpt.com/codex/tasks/task_e_68acaa1a8ac08326843907615daadadd