### PR TITLE
Enlarge trade markers

### DIFF
--- a/systems/graph_engine.py
+++ b/systems/graph_engine.py
@@ -88,11 +88,12 @@ class GraphEngine:
 
         self.buy_trades: List[Dict[str, Any]] = []
         self.sell_trades: List[Dict[str, Any]] = []
+        marker_size = 108  # triple default size for trade markers
         self.buy_art = self.ax_main.scatter(
-            [], [], marker="^", c="green", edgecolor="black", picker=True, pickradius=6
+            [], [], s=marker_size, marker="^", c="green", edgecolor="black", picker=True, pickradius=6
         )
         self.sell_art = self.ax_main.scatter(
-            [], [], marker="v", c="red", edgecolor="black", picker=True, pickradius=6
+            [], [], s=marker_size, marker="v", c="red", edgecolor="black", picker=True, pickradius=6
         )
         self.pb_art = self.ax_main.scatter(
             [], [], s=[], c="green", alpha=0.30, edgecolor="black"

--- a/systems/scripts/chart.py
+++ b/systems/scripts/chart.py
@@ -71,7 +71,7 @@ def plot_trades(
                 t["idx"],
                 t["price"],
                 marker="^",
-                s=150,
+                s=450,  # triple previous marker size
                 c="lime",
                 edgecolor="black",
                 zorder=10,
@@ -81,7 +81,7 @@ def plot_trades(
                 t["idx"],
                 t["price"],
                 marker="v",
-                s=150,
+                s=450,  # triple previous marker size
                 c="red",
                 edgecolor="black",
                 zorder=10,


### PR DESCRIPTION
## Summary
- triple default buy/sell marker size in graph engine
- enlarge trade markers in chart visualization

## Testing
- `python -m py_compile systems/graph_engine.py systems/scripts/chart.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'systems')*


------
https://chatgpt.com/codex/tasks/task_e_68acaedd73f48326b9f9c9dc18d3d211